### PR TITLE
Chore / DAO-437 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 node_modules
 
 # testing
-/coverage
+coverage
 
 # production
 build

--- a/packages/web-app/i18n.config.ts
+++ b/packages/web-app/i18n.config.ts
@@ -1,20 +1,22 @@
-import i18n from 'i18next'
-import { initReactI18next } from 'react-i18next'
+import i18n from 'i18next';
+import {initReactI18next} from 'react-i18next';
 
-import commonEn from './src/locales/en/common.json'
+import commonEn from './src/locales/en/common.json';
 
 export const resources = {
   en: {
-    translation: commonEn
-  }
-} as const
+    translation: commonEn,
+  },
+} as const;
 
 i18n.use(initReactI18next).init({
   lng: 'en',
   resources,
   interpolation: {
-    escapeValue: false // react already safes from xss
+    escapeValue: false, // react already safes from xss
   },
   supportedLngs: ['en', 'pt', 'es'],
-  fallbackLng: 'en'
-})
+  fallbackLng: 'en',
+});
+
+export {i18n};

--- a/packages/web-app/jest.config.js
+++ b/packages/web-app/jest.config.js
@@ -4,5 +4,10 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.ts(x)'],
   setupFilesAfterEnv: ['<rootDir>/.jest/setup.ts'],
-  modulePaths: ['<rootDir>/src/', '<rootDir>/.jest']
-}
+  modulePaths: ['<rootDir>/src/', '<rootDir>/.jest'],
+  moduleDirectories: [
+    'node_modules', // add the directory with the test-utils.js file, for example:
+    'utils', // a utility folder
+    __dirname, // the root directory
+  ],
+};

--- a/packages/web-app/jest.config.js
+++ b/packages/web-app/jest.config.js
@@ -5,9 +5,7 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.ts(x)'],
   setupFilesAfterEnv: ['<rootDir>/.jest/setup.ts'],
   modulePaths: ['<rootDir>/src/', '<rootDir>/.jest'],
-  moduleDirectories: [
-    'node_modules', // add the directory with the test-utils.js file, for example:
-    'utils', // a utility folder
-    __dirname, // the root directory
-  ],
+  // moduleDirectories overrides default jest package lookup behavior
+  // using this to include utils folder so jest is aware of where the test-utils file resides
+  moduleDirectories: ['node_modules', 'utils', __dirname],
 };

--- a/packages/web-app/src/containers/navbar/__tests__/navbar.test.tsx
+++ b/packages/web-app/src/containers/navbar/__tests__/navbar.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, screen} from '@testing-library/react';
+import {render, screen} from 'test-utils';
 
 import Navbar from '..';
 

--- a/packages/web-app/src/utils/test-utils.tsx
+++ b/packages/web-app/src/utils/test-utils.tsx
@@ -1,0 +1,22 @@
+import {I18nextProvider} from 'react-i18next';
+import React, {ReactElement} from 'react';
+import {HashRouter as Router} from 'react-router-dom';
+import {render, RenderOptions} from '@testing-library/react';
+
+import {i18n} from '../../i18n.config';
+
+const AllProviders: React.FC = ({children}) => {
+  return (
+    <I18nextProvider i18n={i18n}>
+      <Router>{children}</Router>
+    </I18nextProvider>
+  );
+};
+
+const customRender = (
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+) => render(ui, {wrapper: AllProviders, ...options});
+
+export * from '@testing-library/react';
+export {customRender as render};

--- a/packages/web-app/tsconfig.json
+++ b/packages/web-app/tsconfig.json
@@ -15,6 +15,9 @@
     "noEmit": true,
     "jsx": "react",
     "baseUrl": "./src",
+    "paths": {
+      "test-utils": ["./utils/test-utils"]
+    }
   },
   "include": ["src", "typings/**/*.d.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
- Re-exported testing-library/react with custom `render` function that includes a Router and internalization provider
- Changed path to the test-utils in tsconfig so utilities can be referenced as follows: ```import {screen, render} from 'test-utils'```