### PR TITLE
Fix: Token card size DAO-529

### DIFF
--- a/packages/ui-components/src/components/badge/badge.tsx
+++ b/packages/ui-components/src/components/badge/badge.tsx
@@ -14,7 +14,7 @@ export const Badge: React.FC<BadgeProps> = ({
 }) => {
   return (
     <StyledBadge data-testid="badge" colorScheme={colorScheme}>
-      {label}
+      <p>{label}</p>
     </StyledBadge>
   );
 };
@@ -23,7 +23,7 @@ type StyledBadgeProps = {
   colorScheme: BadgeProps['colorScheme'];
 };
 
-const StyledBadge = styled.span.attrs(({colorScheme}: StyledBadgeProps) => {
+const StyledBadge = styled.div.attrs(({colorScheme}: StyledBadgeProps) => {
   let colorCode;
   if (colorScheme === 'success') {
     colorCode = 'bg-success-200 text-success-800';

--- a/packages/ui-components/src/components/tokenCard/token.tsx
+++ b/packages/ui-components/src/components/tokenCard/token.tsx
@@ -61,7 +61,8 @@ export const TokenCard: React.FC<TokenCardProps> = props => {
 };
 
 const Card = styled.div.attrs({
-  className: 'bg-ui-0 rounded-xl flex justify-between items-center py-2.5 px-3',
+  className:
+    'flex justify-between items-center py-2.5 px-3 bg-ui-0 rounded-xl font-normal',
 })``;
 
 const CoinDetailsWithImage = styled.div.attrs({
@@ -78,11 +79,11 @@ const CoinDetails = styled.div.attrs({
 })``;
 
 const CoinNameAndAllocation = styled.div.attrs({
-  className: 'flex items-center space-x-1',
+  className: 'flex items-start space-x-1',
 })``;
 
 const CoinName = styled.h1.attrs({
-  className: 'text-xl font-semibold text-ui-800 truncate',
+  className: 'font-bold text-ui-800 truncate',
 })``;
 
 const SecondaryCoinDetails = styled.div.attrs({
@@ -94,7 +95,7 @@ const MarketProperties = styled.div.attrs({
 })``;
 
 const FiatValue = styled.h1.attrs({
-  className: 'text-xl font-semibold text-ui-800 truncate',
+  className: 'font-bold text-ui-800 truncate',
 })``;
 
 const SecondaryFiatDetails = styled.div.attrs({

--- a/packages/ui-components/tailwind.config.js
+++ b/packages/ui-components/tailwind.config.js
@@ -81,6 +81,10 @@ module.exports = {
         25: '200px',
       },
     },
+    fontWeight: {
+      normal: 500,
+      bold: 700,
+    },
     // overwirtes screen breakpoints according to design system
     screens: {
       tablet: '768px',


### PR DESCRIPTION
This ticket:

- adapts the token card's text sizes to the ones in the design. 
- changes the badge from being a span to being a div, since this leads to it not being displayed correctly
-  removes all font weight except for normal and bold, which are the only font weights defined for this project.

General note: Font-weight of normal is currently wort 500 (i.e., is effectively medium), instead of the usual 400. This should probably be changed in the design. Otherwise we have to specify `font-normal` in every component.