### PR TITLE
Feature: Transfer filter - DAO 481

### DIFF
--- a/packages/web-app/src/components/wrappers/sectionWrappers.tsx
+++ b/packages/web-app/src/components/wrappers/sectionWrappers.tsx
@@ -4,6 +4,7 @@ import {Link} from 'react-router-dom';
 import {ButtonText, IconChevronRight} from '@aragon/ui-components';
 
 import {AllTokens, AllTransfers} from 'utils/paths';
+import {useTranslation} from 'react-i18next';
 
 export type SectionWrapperProps = {
   title: string;
@@ -20,6 +21,8 @@ export type SectionWrapperProps = {
  * define this.
  */
 export const TokenSectionWrapper = ({title, children}: SectionWrapperProps) => {
+  const {t} = useTranslation();
+
   return (
     <>
       <HeaderContainer>
@@ -64,7 +67,9 @@ export const TransferSectionWrapper = ({
 type SeeAllButtonProps = {
   path: string;
 };
+
 const SeeAllButton = ({path}: SeeAllButtonProps) => {
+  const {t} = useTranslation();
   return (
     <div>
       <Link to={path}>

--- a/packages/web-app/src/hooks/useCategorizedTransfers.tsx
+++ b/packages/web-app/src/hooks/useCategorizedTransfers.tsx
@@ -24,7 +24,7 @@ export default function useCategorizedTransfers(): HookData<CategorizedTransfer>
   // Instead of using hard-coded data, this hook should eventually  get its data
   // from a graphQL client.
 
-  const init = {
+  const init: CategorizedTransfer = {
     week: [],
     month: [],
     year: [],
@@ -54,9 +54,9 @@ export default function useCategorizedTransfers(): HookData<CategorizedTransfer>
       }
     });
     setCategorizedTransfers({
-      week: week,
-      month: month,
-      year: year,
+      week,
+      month,
+      year,
     });
   }, []);
 

--- a/packages/web-app/src/hooks/useCategorizedTransfers.tsx
+++ b/packages/web-app/src/hooks/useCategorizedTransfers.tsx
@@ -1,27 +1,144 @@
 // import {getDateSections} from 'utils/date';
 
-export type TransferSectionsType = {
-  week: number[];
-  month: number[];
-  year: number[];
+import {useEffect, useState} from 'react';
+import {HookData, Transfers} from 'utils/types';
+
+export type CategorizedTransfer = {
+  week: Transfers[];
+  month: Transfers[];
+  year: Transfers[];
 };
 
-export default function useCategorizedTransfers(): TransferSectionsType {
-  // const sections = getDateSections(); // Sections will dynamically set based on today date
+/**
+ * Split transfer data into three categories based on their date attribute.
+ *
+ * @return An object containing three array of transfers. One containing all
+ * transfers before last month, one containing all transfer of the last month
+ * (excluding the last week), and one containing only this weeks transfers.
+ *
+ */
+export default function useCategorizedTransfers(): HookData<CategorizedTransfer> {
+  // const sections = getDateSections(); // Sections will dynamically set based
+  // on today date
 
-  /**
-   * Note: In this Hook we should split the transfer data
-   *
-   * @params is a list of transfers
-   *
-   * @return should be a object with params with list of transfers for each section. Also
-   * It's possible to save data directly on context api
-   *
-   */
+  // Instead of using hard-coded data, this hook should eventually  get its data
+  // from a graphQL client.
 
-  return {
-    week: [1, 2, 3],
-    month: [1, 2, 3],
-    year: [1, 2, 3],
+  const init = {
+    week: [],
+    month: [],
+    year: [],
   };
+  const [categorizedTransfers, setCategorizedTransfers] =
+    useState<CategorizedTransfer>(init);
+
+  useEffect(() => {
+    const week: Transfers[] = [];
+    const month: Transfers[] = [];
+    const year: Transfers[] = [];
+
+    transfers.forEach(t => {
+      switch (t.transferDate) {
+        case 'Yesterday':
+          week.push(t);
+          break;
+        case 'Last Week':
+          month.push(t);
+          break;
+        case 'Last Month':
+          year.push(t);
+          break;
+        default:
+          week.push(t);
+          break;
+      }
+    });
+    setCategorizedTransfers({
+      week: week,
+      month: month,
+      year: year,
+    });
+  }, []);
+
+  return {data: categorizedTransfers, isLoading: false};
 }
+
+const transfers: Array<Transfers> = [
+  //this week -> today
+  {
+    title: 'Deposit',
+    tokenAmount: 42,
+    transferDate: 'Pending...',
+    tokenSymbol: 'DAI',
+    transferType: 'Deposit',
+    usdValue: '$200.00',
+    isPending: true,
+  },
+  {
+    title: 'Deposit With some Reference',
+    tokenAmount: 300,
+    tokenSymbol: 'DAI',
+    transferDate: 'Yesterday',
+    transferType: 'Deposit',
+    usdValue: '$200.00',
+  },
+  {
+    title: 'Withdraw',
+    tokenAmount: 1337,
+    transferDate: 'Yesterday',
+    tokenSymbol: 'DAI',
+    transferType: 'Withdraw',
+    usdValue: '$200.00',
+    isPending: true,
+  },
+  //this month -> this week
+  {
+    title: 'Deposit',
+    tokenAmount: 1,
+    transferDate: 'Last Week',
+    tokenSymbol: 'DAI',
+    transferType: 'Deposit',
+    usdValue: '$200.00',
+  },
+  {
+    title: 'Deposit DAI so I can do whatever I want whenever I want',
+    tokenAmount: 2,
+    tokenSymbol: 'DAI',
+    transferDate: 'Last Week',
+    transferType: 'Deposit',
+    usdValue: '$200.00',
+  },
+  {
+    title: 'Withdraw',
+    tokenAmount: 3,
+    transferDate: 'Last Week',
+    tokenSymbol: 'DAI',
+    transferType: 'Withdraw',
+    usdValue: '$200.00',
+  },
+  //this year -> this month
+  {
+    title: 'Deposit',
+    tokenAmount: 1,
+    transferDate: 'Last Month',
+    tokenSymbol: 'DAI',
+    transferType: 'Deposit',
+    usdValue: '$200.00',
+  },
+  {
+    title: 'Deposit DAI so I can do whatever I want whenever I want',
+    tokenAmount: 2,
+    tokenSymbol: 'DAI',
+    transferDate: 'Last Month',
+    transferType: 'Deposit',
+    usdValue: '$200.00',
+  },
+  {
+    title: 'Withdraw',
+    tokenAmount: 3,
+    transferDate: 'Last Month',
+    tokenSymbol: 'DAI',
+    transferType: 'Withdraw',
+    usdValue: '$200.00',
+  },
+];

--- a/packages/web-app/src/pages/transfers.tsx
+++ b/packages/web-app/src/pages/transfers.tsx
@@ -1,51 +1,43 @@
-import {SearchInput} from '@aragon/ui-components';
-import React from 'react';
+import {Radio, RadioGroup, SearchInput} from '@aragon/ui-components';
+import React, {useState} from 'react';
 import styled from 'styled-components';
 import {useTranslation} from 'react-i18next';
 import {withTransaction} from '@elastic/apm-rum-react';
 
 import {TransferSectionWrapper} from 'components/wrappers';
-import useCategorizedTransfers, {
-  TransferSectionsType,
-} from 'hooks/useCategorizedTransfers';
+import useCategorizedTransfers from 'hooks/useCategorizedTransfers';
 import {useTransferModalContext} from 'context/transfersModal';
 import {PageWrapper} from 'components/wrappers';
 import TransferList from 'components/transferList';
 import {Transfers} from 'utils/types';
 
-const transfers: Array<Transfers> = [
-  {
-    title: 'Deposit',
-    tokenAmount: 300,
-    transferDate: 'Pending...',
-    tokenSymbol: 'DAI',
-    transferType: 'Deposit',
-    usdValue: '$200.00',
-    isPending: true,
-  },
-  {
-    title: 'Deposit DAI so I can do whatever I want whenever I want',
-    tokenAmount: 300,
-    tokenSymbol: 'DAI',
-    transferDate: 'Yesterday',
-    transferType: 'Deposit',
-    usdValue: '$200.00',
-  },
-  {
-    title: 'Withdraw',
-    tokenAmount: 300,
-    transferDate: 'Yesterday',
-    tokenSymbol: 'DAI',
-    transferType: 'Withdraw',
-    usdValue: '$200.00',
-  },
-];
-
 const Transfers: React.FC = () => {
   const {t} = useTranslation();
-  const transfersList: TransferSectionsType = useCategorizedTransfers();
   const {open} = useTransferModalContext();
+  const {data: categorizedTransfers} = useCategorizedTransfers();
+  const [filterValue, setFilterValue] = useState('');
 
+  const handleButtonGroupChange = (selected: string) => {
+    const val = selected === 'All' ? '' : selected;
+    setFilterValue(val);
+  };
+
+  var displayedTransfers = {
+    week: categorizedTransfers.week,
+    month: categorizedTransfers.month,
+    year: categorizedTransfers.year,
+  };
+  if (filterValue) {
+    displayedTransfers.week = categorizedTransfers.week.filter(
+      t => t.transferType === filterValue
+    );
+    displayedTransfers.month = categorizedTransfers.month.filter(
+      t => t.transferType === filterValue
+    );
+    displayedTransfers.year = categorizedTransfers.year.filter(
+      t => t.transferType === filterValue
+    );
+  }
   /**
    * Note: We can add a nested iterator for both sections and transfer cards
    */
@@ -59,30 +51,30 @@ const Transfers: React.FC = () => {
         onClick={open}
       >
         <SearchInput placeholder="Type to filter" />
+        <RadioGroup defaultValue="All" onChange={handleButtonGroupChange}>
+          <Radio value="All">All</Radio>
+          <Radio value="Deposit">Deposit</Radio>
+          <Radio value="Withdraw">Withdraw</Radio>
+          <Radio value="External Contract">External Contract</Radio>
+        </RadioGroup>
         <SectionContainer>
           <TransferSectionWrapper title={t('allTransfer.thisWeek') as string}>
             <div className="my-2 space-y-2 border-solid">
-              {transfersList.week.map((data, index) => (
-                <TransferList transfers={transfers} key={index} />
-              ))}
+              <TransferList transfers={displayedTransfers.week} />
             </div>
           </TransferSectionWrapper>
         </SectionContainer>
         <SectionContainer>
           <TransferSectionWrapper title={'December'}>
             <div className="my-2 space-y-2 border-solid">
-              {transfersList.month.map((data, index) => (
-                <TransferList transfers={transfers} key={index} />
-              ))}
+              <TransferList transfers={displayedTransfers.month} />
             </div>
           </TransferSectionWrapper>
         </SectionContainer>
         <SectionContainer>
           <TransferSectionWrapper title={'2021'}>
             <div className="my-2 space-y-2 border-solid">
-              {transfersList.year.map((data, index) => (
-                <TransferList transfers={transfers} key={index} />
-              ))}
+              <TransferList transfers={displayedTransfers.year} />
             </div>
           </TransferSectionWrapper>
         </SectionContainer>

--- a/packages/web-app/src/pages/transfers.tsx
+++ b/packages/web-app/src/pages/transfers.tsx
@@ -22,7 +22,7 @@ const Transfers: React.FC = () => {
     setFilterValue(val);
   };
 
-  var displayedTransfers = {
+  const displayedTransfers = {
     week: categorizedTransfers.week,
     month: categorizedTransfers.month,
     year: categorizedTransfers.year,
@@ -50,30 +50,32 @@ const Transfers: React.FC = () => {
         subtitle={'$1,002,200.00 Total Volume'}
         onClick={open}
       >
-        <SearchInput placeholder="Type to filter" />
-        <RadioGroup defaultValue="All" onChange={handleButtonGroupChange}>
-          <Radio value="All">All</Radio>
-          <Radio value="Deposit">Deposit</Radio>
-          <Radio value="Withdraw">Withdraw</Radio>
-          <Radio value="External Contract">External Contract</Radio>
-        </RadioGroup>
+        <div className="space-y-1.5">
+          <SearchInput placeholder="Type to filter" />
+          <RadioGroup defaultValue="All" onChange={handleButtonGroupChange}>
+            <Radio value="All">All</Radio>
+            <Radio value="Deposit">Deposit</Radio>
+            <Radio value="Withdraw">Withdraw</Radio>
+            <Radio value="External Contract">External Contract</Radio>
+          </RadioGroup>
+        </div>
         <SectionContainer>
           <TransferSectionWrapper title={t('allTransfer.thisWeek') as string}>
-            <div className="my-2 space-y-2 border-solid">
+            <div className="my-2 space-y-1.5 border-solid">
               <TransferList transfers={displayedTransfers.week} />
             </div>
           </TransferSectionWrapper>
         </SectionContainer>
         <SectionContainer>
           <TransferSectionWrapper title={'December'}>
-            <div className="my-2 space-y-2 border-solid">
+            <div className="my-2 space-y-1.5 border-solid">
               <TransferList transfers={displayedTransfers.month} />
             </div>
           </TransferSectionWrapper>
         </SectionContainer>
         <SectionContainer>
           <TransferSectionWrapper title={'2021'}>
-            <div className="my-2 space-y-2 border-solid">
+            <div className="my-2 space-y-1.5 border-solid">
               <TransferList transfers={displayedTransfers.year} />
             </div>
           </TransferSectionWrapper>

--- a/packages/web-app/src/utils/date.ts
+++ b/packages/web-app/src/utils/date.ts
@@ -1,3 +1,7 @@
+/**
+ * Note: This function will return a list of timestamp that we can use to categorize transfers
+ * @return a object with milliseconds params
+ */
 export function getDateSections(): {
   lastWeek: number;
   lastMonth: number;
@@ -13,11 +17,6 @@ export function getDateSections(): {
     1
   ).getTime();
   const lastYear: number = new Date(date.getFullYear(), 0, 1).getTime();
-
-  /**
-   * Note: This function will return a list of timestamp that we can use to categorize transfers
-   * @return a object with milliseconds params
-   */
 
   return {
     lastWeek,


### PR DESCRIPTION
This PR

- Adds additional mock transfer data
- Categorizes it by date using the corresponding hook
- Adds a button group to `/finance/transfers`
- Adds logic to filter transfer by type using the button group
- Fixes the current deployment issue