### PR TITLE
Updates the process events

### DIFF
--- a/packages/contracts/contracts/core/processes/Process.sol
+++ b/packages/contracts/contracts/core/processes/Process.sol
@@ -19,7 +19,7 @@ abstract contract Process is Component {
     address internal constant ANY_ADDR = address(type(uint160).max);
 
     /// @notice Emitted as soon as the process does get started
-    event ProcessStarted(Execution execution, bytes metadata, uint256 indexed executionId);
+    event ProcessStarted(Execution execution);
     /// @notice Emitted as soon as the process with his actions does get executed
     event ProcessExecuted(Execution execution, uint256 indexed executionId);
     /// @notice Emtted as soon as new allowed actions do get added
@@ -157,7 +157,7 @@ abstract contract Process is Component {
 
         _start(execution); // "Hook" to add logic in start of a concrete implementation.
 
-        emit ProcessStarted(execution, _proposal.metadata, executionsCounter);
+        emit ProcessStarted(execution);
 
         return executionsCounter;
     }

--- a/packages/contracts/contracts/core/processes/disputable/DisputableProcess.sol
+++ b/packages/contracts/contracts/core/processes/disputable/DisputableProcess.sol
@@ -15,9 +15,9 @@ abstract contract DisputableProcess is StoppableProcess {
     bytes4 internal constant DISPUTABLE_PROCESS_INTERFACE_ID = STOPPABLE_PROCESS_INTERFACE_ID ^ type(DisputableProcess).interfaceId;
 
     /// @notice Emitted as soon as the process got paused
-    event ProcessHalted(Execution execution, uint256 indexed executionId);
+    event ProcessHalted(Execution execution);
     /// @notice Emittes as soon as the process got started again
-    event ProcessForwarded(Execution execution, uint256 indexed executionId);
+    event ProcessForwarded(Execution execution);
 
     /// @notice The role identifier to halt a process
     bytes32 public constant PROCESS_HALT_ROLE = keccak256("PROCESS_HALT_ROLE");
@@ -44,7 +44,7 @@ abstract contract DisputableProcess is StoppableProcess {
 
         _halt(_data);
 
-        emit ProcessHalted(execution, _executionId);
+        emit ProcessHalted(execution);
     }
 
     /// @notice If called the execution does get forwarded.
@@ -60,7 +60,7 @@ abstract contract DisputableProcess is StoppableProcess {
 
         _forward(_data);
 
-        emit ProcessForwarded(execution, _executionId);
+        emit ProcessForwarded(execution);
     }
 
     /// @dev The concrete implementation of halt.

--- a/packages/contracts/contracts/core/processes/stoppable/StoppableProcess.sol
+++ b/packages/contracts/contracts/core/processes/stoppable/StoppableProcess.sol
@@ -15,7 +15,7 @@ abstract contract StoppableProcess is Process {
     bytes4 internal constant STOPPABLE_PROCESS_INTERFACE_ID = PROCESS_INTERFACE_ID ^ type(StoppableProcess).interfaceId;
 
     /// @notice Emitted as soon as the process does get stopped
-    event ProcessStopped(Execution indexed execution, uint256 indexed executionId);
+    event ProcessStopped(Execution execution);
 
     /// @notice The role identifier to stop a process
     bytes32 public constant PROCESS_STOP_ROLE = keccak256("PROCESS_STOP_ROLE");
@@ -40,7 +40,7 @@ abstract contract StoppableProcess is Process {
         
         _stop(_data);
 
-        emit ProcessStopped(execution, _executionId);
+        emit ProcessStopped(execution);
     }
 
     /// @dev The concrete implementation of stop.

--- a/packages/contracts/contracts/core/processes/voting/VotingProcess.sol
+++ b/packages/contracts/contracts/core/processes/voting/VotingProcess.sol
@@ -15,7 +15,7 @@ abstract contract VotingProcess is Process {
     bytes4 internal constant VOTING_PROCESS_INTERFACE_ID = PROCESS_INTERFACE_ID ^ type(VotingProcess).interfaceId;
 
     /// @notice Emitted as soon as new vote does get casted
-    event VotedOnProcess(Execution execution, bytes data, uint256 indexed executionId);
+    event VotedOnProcess(Execution execution, bytes data);
 
     /// @notice The role identifier to vote
     bytes32 public constant PROCESS_VOTE_ROLE = keccak256("PROCESS_VOTE_ROLE");
@@ -37,7 +37,7 @@ abstract contract VotingProcess is Process {
 
         _vote(_executionId, _data);
 
-        emit VotedOnProcess(execution, _data, _executionId);
+        emit VotedOnProcess(execution, _data);
     }
 
     /// @dev The concrete implementation of vote.


### PR DESCRIPTION
Because of the latest refactoring happened do we include the entire submitted proposal in the execution struct. This means we don't have to emit the other values from the proposal struct separately as before and also the ID doesn't have to be a parameter anymore of the events cause it is included in the execution struct.