### PR TITLE
Fix/Staging bug - DAO-689

### DIFF
--- a/packages/ui-components/src/components/input/index.ts
+++ b/packages/ui-components/src/components/input/index.ts
@@ -1,8 +1,25 @@
-export {TextInputProps, TextInput} from './textInput';
-export {SearchInput, SearchInputProps} from './searchInput';
-export {NumberInput, NumberInputProps} from './numberInput';
-export {DropdownInput, DropDownInputProps} from './dropdownInput';
-export {TimeInput, TimeInputProps} from './timeInput';
-export {DateInput, DateInputProps} from './dateInput';
+/**
+ * Types have to be explicitly re - exported(export type { abc } from 'component')
+ * or exported with export * from 'component'; in TS 3.7 or older when the
+ * --isolatedModules flag is provided
+ */
+export {TextInput} from './textInput';
+export type {TextInputProps} from './textInput';
+
+export {SearchInput} from './searchInput';
+export type {SearchInputProps} from './searchInput';
+
+export {NumberInput} from './numberInput';
+export type {NumberInputProps} from './numberInput';
+
+export {DropdownInput} from './dropdownInput';
+export type {DropDownInputProps} from './dropdownInput';
+
+export {TimeInput} from './timeInput';
+export type {TimeInputProps} from './timeInput';
+
+export {DateInput} from './dateInput';
+export type {DateInputProps} from './dateInput';
+
 export * from './inputImageSingle';
 export * from './valueInput';

--- a/packages/ui-components/src/components/input/index.ts
+++ b/packages/ui-components/src/components/input/index.ts
@@ -6,4 +6,3 @@ export {TimeInput, TimeInputProps} from './timeInput';
 export {DateInput, DateInputProps} from './dateInput';
 export * from './inputImageSingle';
 export * from './valueInput';
-export * from './dateInput';


### PR DESCRIPTION
- removes duplicated export for dateInput
- fixes type re-export for other inputs

Apparently, types have to be explicitly re-exported `export type { abc } from 'component'` or exported with `export * from 'component'` in TS 3.7 or older when the --isolatedModules flag is provided