### PR TITLE
Chore/Apollo client DAO-682

### DIFF
--- a/packages/web-app/package.json
+++ b/packages/web-app/package.json
@@ -24,6 +24,7 @@
     "ethers": "^5.5.1",
     "framer-motion": "^5.2.1",
     "graphql": "^16.3.0",
+    "graphql-anywhere": "^4.2.7",
     "i18next": "^21.3.3",
     "qs": "^6.10.3",
     "react": "^17.0.2",

--- a/packages/web-app/package.json
+++ b/packages/web-app/package.json
@@ -14,13 +14,18 @@
     "check-types": "tsc --noemit"
   },
   "dependencies": {
+    "@apollo/client": "^3.5.8",
     "@aragon/ui-components": "0.1.0",
     "@elastic/apm-rum-react": "^1.3.1",
     "@rollup/plugin-typescript": "^8.3.0",
     "@types/react-router-dom": "^5.3.2",
+    "apollo-link-rest": "^0.9.0-rc.1",
+    "apollo3-cache-persist": "^0.14.0",
     "ethers": "^5.5.1",
     "framer-motion": "^5.2.1",
+    "graphql": "^16.3.0",
     "i18next": "^21.3.3",
+    "qs": "^6.10.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.22.2",

--- a/packages/web-app/src/context/apolloClient.tsx
+++ b/packages/web-app/src/context/apolloClient.tsx
@@ -1,0 +1,23 @@
+import {ApolloClient, InMemoryCache} from '@apollo/client';
+import {RestLink} from 'apollo-link-rest';
+import {CachePersistor, LocalStorageWrapper} from 'apollo3-cache-persist';
+
+const restLink = new RestLink({
+  uri: 'https://api.coingecko.com/api/v3',
+});
+
+const cache = new InMemoryCache();
+
+const persistor = new CachePersistor({
+  cache,
+  maxSize: 5242880, // 5 MiB
+  storage: new LocalStorageWrapper(window.localStorage),
+  debug: process.env.NODE_ENV === 'development',
+});
+
+await persistor.restore();
+
+export const client = new ApolloClient({
+  cache,
+  link: restLink,
+});

--- a/packages/web-app/src/context/apolloClient.tsx
+++ b/packages/web-app/src/context/apolloClient.tsx
@@ -14,6 +14,7 @@ const entitiesToPersist = ['tokenData'];
 
 const persistor = new CachePersistor({
   cache,
+  // TODO: Check and update the size needed for the cache
   maxSize: 5242880, // 5 MiB
   storage: new LocalStorageWrapper(window.localStorage),
   debug: process.env.NODE_ENV === 'development',

--- a/packages/web-app/src/context/apolloClient.tsx
+++ b/packages/web-app/src/context/apolloClient.tsx
@@ -1,18 +1,57 @@
 import {ApolloClient, InMemoryCache} from '@apollo/client';
 import {RestLink} from 'apollo-link-rest';
 import {CachePersistor, LocalStorageWrapper} from 'apollo3-cache-persist';
+import {BASE_URL} from 'utils/constants';
 
 const restLink = new RestLink({
-  uri: 'https://api.coingecko.com/api/v3',
+  uri: BASE_URL,
 });
 
 const cache = new InMemoryCache();
+
+// add the REST API's typename you want to persist here
+const entitiesToPersist = ['tokenData'];
 
 const persistor = new CachePersistor({
   cache,
   maxSize: 5242880, // 5 MiB
   storage: new LocalStorageWrapper(window.localStorage),
   debug: process.env.NODE_ENV === 'development',
+  persistenceMapper: async (data: any) => {
+    const parsed = JSON.parse(data);
+
+    const mapped: any = {};
+    const persistEntities: any[] = [];
+    const rootQuery = parsed['ROOT_QUERY'];
+
+    mapped['ROOT_QUERY'] = Object.keys(rootQuery).reduce(
+      (obj: any, key: string) => {
+        if (key === '__typename') return obj;
+
+        if (entitiesToPersist.includes(key)) {
+          obj[key] = rootQuery[key];
+
+          if (Array.isArray(rootQuery[key])) {
+            const entities = rootQuery[key].map((item: any) => item.__ref);
+            persistEntities.push(...entities);
+          } else {
+            const entity = rootQuery[key].__ref;
+            persistEntities.push(entity);
+          }
+        }
+
+        return obj;
+      },
+      {__typename: 'Query'}
+    );
+
+    persistEntities.reduce((obj, key) => {
+      obj[key] = parsed[key];
+      return obj;
+    }, mapped);
+
+    return JSON.stringify(mapped);
+  },
 });
 
 await persistor.restore();

--- a/packages/web-app/src/context/apolloClient.tsx
+++ b/packages/web-app/src/context/apolloClient.tsx
@@ -17,22 +17,25 @@ const persistor = new CachePersistor({
   maxSize: 5242880, // 5 MiB
   storage: new LocalStorageWrapper(window.localStorage),
   debug: process.env.NODE_ENV === 'development',
-  persistenceMapper: async (data: any) => {
+  persistenceMapper: async (data: string) => {
     const parsed = JSON.parse(data);
 
-    const mapped: any = {};
-    const persistEntities: any[] = [];
+    const mapped: Record<string, unknown> = {};
+    const persistEntities: string[] = [];
     const rootQuery = parsed['ROOT_QUERY'];
 
     mapped['ROOT_QUERY'] = Object.keys(rootQuery).reduce(
-      (obj: any, key: string) => {
+      (obj: Record<string, unknown>, key: string) => {
         if (key === '__typename') return obj;
 
-        if (entitiesToPersist.includes(key)) {
+        const keyWithoutArgs = key.substring(0, key.indexOf('('));
+        if (entitiesToPersist.includes(keyWithoutArgs)) {
           obj[key] = rootQuery[key];
 
           if (Array.isArray(rootQuery[key])) {
-            const entities = rootQuery[key].map((item: any) => item.__ref);
+            const entities = rootQuery[key].map(
+              (item: Record<string, unknown>) => item.__ref
+            );
             persistEntities.push(...entities);
           } else {
             const entity = rootQuery[key].__ref;

--- a/packages/web-app/src/hooks/useDaoTokens.tsx
+++ b/packages/web-app/src/hooks/useDaoTokens.tsx
@@ -40,10 +40,6 @@ export const useDaoTokens = (daoAddress: Address) => {
 // TEMPORARY, should eventually be obtained from a subgraph
 // count should NOT be formatted with decimals yet
 const TEMP_TOKEN_ADDR: TokenBalance[] = [
-  {
-    address: '0x35d36f7d2a376143fb8eab3c41bf389eba82e17c',
-    count: BigInt('6650000000000000000000'),
-  },
   {address: constants.AddressZero, count: BigInt('6224533680000000001')},
   {
     address: '0xa117000000f279d81a1d3cc75430faa017fa5a2e',

--- a/packages/web-app/src/index.tsx
+++ b/packages/web-app/src/index.tsx
@@ -7,6 +7,8 @@ import {WalletProvider} from 'context/augmentedWallet';
 import {APMProvider} from 'context/elasticAPM';
 import {WalletMenuProvider} from 'context/walletMenu';
 import {GlobalModalsProvider} from 'context/globalModals';
+import {ApolloProvider} from '@apollo/client';
+import {client} from 'context/apolloClient';
 import 'tailwindcss/tailwind.css';
 
 ReactDOM.render(
@@ -16,7 +18,9 @@ ReactDOM.render(
         <WalletMenuProvider>
           <GlobalModalsProvider>
             <Router>
-              <App />
+              <ApolloProvider client={client}>
+                <App />
+              </ApolloProvider>
             </Router>
           </GlobalModalsProvider>
         </WalletMenuProvider>

--- a/packages/web-app/src/services/prices.ts
+++ b/packages/web-app/src/services/prices.ts
@@ -3,6 +3,8 @@ import {constants} from 'ethers';
 
 import {TokenPricePercentages} from 'utils/types';
 import {BASE_URL, DEFAULT_CURRENCY} from 'utils/constants';
+import {client} from 'context/apolloClient';
+import {gql} from '@apollo/client';
 
 type TokenPrices = {
   [key: string]: {
@@ -76,24 +78,41 @@ type FetchedTokenData = Promise<TokenData | undefined>;
  */
 async function fetchTokenData(address: Address): FetchedTokenData {
   const endPoint = '/coins/ethereum';
-  let url = `${BASE_URL}${endPoint}`;
+  const arg =
+    address !== constants.AddressZero
+      ? `${endPoint}/contract/${address}`
+      : `${endPoint}`;
 
-  if (address !== constants.AddressZero) url += `/contract/${address}`;
+  const TOKEN_DATA_QUERY = gql`
+    query TokenData {
+      tokenData(address: ${JSON.stringify(arg)})
+        @rest(
+          type: "TokenData"
+          path: "{args.address}"
+          method: "GET"
+        ) {
+        id
+        name
+        symbol
+        image {
+          large
+        }
+        address
+      }
+    }
+  `;
 
-  try {
-    const res = await fetch(url);
-    const data = await res.json();
-    if (data.id)
-      return {
-        id: data.id,
-        name: data.name,
-        symbol: (data.symbol as string).toUpperCase(),
-        imgUrl: data.image.large,
-        address: address,
-      };
-  } catch (error) {
-    console.error('Error fetching token data', error);
+  const {data, error} = await client.query({query: TOKEN_DATA_QUERY});
+  if (!error && data.tokenData) {
+    return {
+      id: data.tokenData.id,
+      name: data.tokenData.name,
+      symbol: (data.tokenData.symbol as string).toUpperCase(),
+      imgUrl: data.tokenData.image.large,
+      address: address,
+    };
   }
+  console.error('Error fetching token price', error);
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -7270,6 +7270,13 @@
   dependencies:
     tslib "^2.3.0"
 
+"@wry/equality@^0.1.2":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.11.tgz#35cb156e4a96695aa81a9ecc4d03787bc17f1790"
+  integrity sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==
+  dependencies:
+    tslib "^1.9.3"
+
 "@wry/equality@^0.5.0":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.2.tgz#72c8a7a7d884dff30b612f4f8464eba26c080e73"
@@ -7745,6 +7752,16 @@ apollo-link-rest@^0.9.0-rc.1:
   version "0.9.0-rc.1"
   resolved "https://registry.yarnpkg.com/apollo-link-rest/-/apollo-link-rest-0.9.0-rc.1.tgz#bc462ecf20c5e6fa041a3a6fd818fbb9aae4016c"
   integrity sha512-v4iztbE1uDAbs5jXCCIZzOs+muLfRHpzj1Ej5Ajo+LnKD+n4Yfh0W1X41NyPSvmHeVkBjcFza+ma9JRrU7nVCg==
+
+apollo-utilities@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.3.4.tgz#6129e438e8be201b6c55b0f13ce49d2c7175c9cf"
+  integrity sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==
+  dependencies:
+    "@wry/equality" "^0.1.2"
+    fast-json-stable-stringify "^2.0.0"
+    ts-invariant "^0.4.0"
+    tslib "^1.10.0"
 
 apollo3-cache-persist@^0.14.0:
   version "0.14.0"
@@ -14818,6 +14835,15 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+
+graphql-anywhere@^4.2.7:
+  version "4.2.7"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.2.7.tgz#c06fb40b1d62b39470c80e3731478dbbef060067"
+  integrity sha512-fJHvVywWVWjiHuPIMs16Nfjf4zdQUwSO1LKycwBJCWIPeoeQ8LqXK2BgYoZAHkhKEFktZZeYyzS4o/uIUG0z5A==
+  dependencies:
+    apollo-utilities "^1.3.4"
+    ts-invariant "^0.3.2"
+    tslib "^1.10.0"
 
 graphql-tag@^2.12.3:
   version "2.12.6"
@@ -25603,6 +25629,20 @@ ts-generator@^0.1.1:
     resolve "^1.8.1"
     ts-essentials "^1.0.0"
 
+ts-invariant@^0.3.2:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.3.3.tgz#b5742b1885ecf9e29c31a750307480f045ec0b16"
+  integrity sha512-UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==
+  dependencies:
+    tslib "^1.9.3"
+
+ts-invariant@^0.4.0:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
+  integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
+  dependencies:
+    tslib "^1.9.3"
+
 ts-invariant@^0.9.4:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.4.tgz#42ac6c791aade267dd9dc65276549df5c5d71cac"
@@ -25726,7 +25766,7 @@ tslib@2.0.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
-tslib@^1.0.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.0.0, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,6 +104,24 @@
     ethers "~4.0.4"
     lodash "^4.17.11"
 
+"@apollo/client@^3.5.8":
+  version "3.5.8"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.8.tgz#7215b974c5988b6157530eb69369209210349fe0"
+  integrity sha512-MAm05+I1ullr64VLpZwon/ISnkMuNLf6vDqgo9wiMhHYBGT4yOAbAIseRdjCHZwfSx/7AUuBgaTNOssZPIr6FQ==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.0.0"
+    "@wry/context" "^0.6.0"
+    "@wry/equality" "^0.5.0"
+    "@wry/trie" "^0.3.0"
+    graphql-tag "^2.12.3"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.16.1"
+    prop-types "^15.7.2"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.9.4"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.0"
+
 "@aragon/provided-connector@^6.0.8":
   version "6.0.8"
   resolved "https://registry.yarnpkg.com/@aragon/provided-connector/-/provided-connector-6.0.8.tgz#5d22ccb2a0ff599fbe6c23fdf96cb06d59ff2716"
@@ -2115,6 +2133,11 @@
   integrity sha512-2vU4m5ZPQIqMlMce/z5vmOtGHRlRmcRhMfemS3NIwxCSxSBGVnX2zb7QBTzzdQKGwsAZdbz6V0okkOtvohELfQ==
   dependencies:
     assemblyscript "0.19.10"
+
+"@graphql-typed-document-node/core@^3.0.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
+  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -7240,6 +7263,27 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@wry/context@^0.6.0":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
+  integrity sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/equality@^0.5.0":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.2.tgz#72c8a7a7d884dff30b612f4f8464eba26c080e73"
+  integrity sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/trie@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.1.tgz#2279b790f15032f8bcea7fc944d27988e5b3b139"
+  integrity sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==
+  dependencies:
+    tslib "^2.3.0"
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -7696,6 +7740,16 @@ apisauce@^1.0.1:
   dependencies:
     axios "^0.21.2"
     ramda "^0.25.0"
+
+apollo-link-rest@^0.9.0-rc.1:
+  version "0.9.0-rc.1"
+  resolved "https://registry.yarnpkg.com/apollo-link-rest/-/apollo-link-rest-0.9.0-rc.1.tgz#bc462ecf20c5e6fa041a3a6fd818fbb9aae4016c"
+  integrity sha512-v4iztbE1uDAbs5jXCCIZzOs+muLfRHpzj1Ej5Ajo+LnKD+n4Yfh0W1X41NyPSvmHeVkBjcFza+ma9JRrU7nVCg==
+
+apollo3-cache-persist@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/apollo3-cache-persist/-/apollo3-cache-persist-0.14.0.tgz#457519f548698fb1e70f99d81e59652fc289ab19"
+  integrity sha512-jT3wkB3IJGNyK1XTtS2WbaAyD/Z9Z4HuFEsU0kIpYceqdtT8gV1kNSX+4YMBt0XgS954zMKY6cs8Q4zt7NNPeQ==
 
 app-module-path@^2.2.0:
   version "2.2.0"
@@ -14765,10 +14819,22 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
+graphql-tag@^2.12.3:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
+  dependencies:
+    tslib "^2.1.0"
+
 graphql@^15.5.0:
   version "15.8.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
   integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
+
+graphql@^16.3.0:
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.3.0.tgz#a91e24d10babf9e60c706919bb182b53ccdffc05"
+  integrity sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==
 
 growl@1.10.5:
   version "1.10.5"
@@ -15199,7 +15265,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -20252,6 +20318,14 @@ opentracing@^0.14.3:
   resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.5.tgz#891fa92cd90a24e64f99bc964370227310926c85"
   integrity sha512-XLKtEfHxqrWyF1fzxznsv78w3csW41ucHnjiKnfzZLD5FN8UBDZZL1i4q0FR29zjxXhm+2Hop+5Vr/b8tKIvEg==
 
+optimism@^0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.16.1.tgz#7c8efc1f3179f18307b887e18c15c5b7133f6e7d"
+  integrity sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==
+  dependencies:
+    "@wry/context" "^0.6.0"
+    "@wry/trie" "^0.3.0"
+
 optimist@~0.3.5:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.3.7.tgz#c90941ad59e4273328923074d2cf2e7cbc6ec0d9"
@@ -22030,7 +22104,7 @@ qs@^6.10.0, qs@^6.4.0, qs@^6.6.0, qs@^6.7.0, qs@^6.9.4:
   dependencies:
     side-channel "^1.0.4"
 
-qs@^6.5.2:
+qs@^6.10.3, qs@^6.5.2:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
@@ -24829,6 +24903,11 @@ swarm-js@^0.1.40:
     tar "^4.0.2"
     xhr-request "^1.0.1"
 
+symbol-observable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
+  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
+
 symbol-tree@^3.2.2, symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -25523,6 +25602,13 @@ ts-generator@^0.1.1:
     prettier "^2.1.2"
     resolve "^1.8.1"
     ts-essentials "^1.0.0"
+
+ts-invariant@^0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.4.tgz#42ac6c791aade267dd9dc65276549df5c5d71cac"
+  integrity sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==
+  dependencies:
+    tslib "^2.1.0"
 
 ts-jest@^25.3.1:
   version "25.5.1"
@@ -27940,6 +28026,18 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zen-observable-ts@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz#c2f5ccebe812faf0cfcde547e6004f65b1a6d769"
+  integrity sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==
+  dependencies:
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Only the fetchTokenData is changed to use Apollo Client REST Link, because that data seems to be constant for a chain and can be persisted. To persist a query, you need to add the typename to entitiesToPersist in apolloClient.tsx 

The token data loading in finance page is wee bit faster from the subsequent loads