### PR TITLE
Chore/Disabled options in ButtonGroup, Link url fixes DAO-701 DAO-592

### DIFF
--- a/packages/ui-components/src/components/button/buttonGroup/button.tsx
+++ b/packages/ui-components/src/components/button/buttonGroup/button.tsx
@@ -5,9 +5,14 @@ import {useButtonGroupContext} from './buttonGroup';
 export type OptionProps = {
   value: string;
   label: string;
+  disabled?: boolean;
 };
 
-export const Option: React.FC<OptionProps> = ({value, label}) => {
+export const Option: React.FC<OptionProps> = ({
+  value,
+  label,
+  disabled = false,
+}) => {
   const {bgWhite, selectedValue, onChange} = useButtonGroupContext();
 
   return (
@@ -18,6 +23,7 @@ export const Option: React.FC<OptionProps> = ({value, label}) => {
       mode="ghost"
       size="small"
       className="flex-1 justify-center whitespace-nowrap"
+      disabled={disabled}
       onClick={() => {
         if (onChange) {
           onChange(value);

--- a/packages/web-app/src/components/addLinks/row.tsx
+++ b/packages/web-app/src/components/addLinks/row.tsx
@@ -149,7 +149,7 @@ const LinkRow: React.FC<LinkRowProps> = ({index, onDelete}) => {
                 value={field.value}
                 onBlur={() => {
                   addProtocolToLinks(field.name);
-                  field.onBlur;
+                  field.onBlur();
                 }}
                 onChange={field.onChange}
                 placeholder="https://"

--- a/packages/web-app/src/components/addLinks/row.tsx
+++ b/packages/web-app/src/components/addLinks/row.tsx
@@ -23,6 +23,10 @@ type LinkRowProps = {
   onDelete?: (index: number) => void;
 };
 
+const UrlRegex = new RegExp(URL_PATTERN);
+const EmailRegex = new RegExp(EMAIL_PATTERN);
+const UrlWithProtocolRegex = new RegExp(URL_WITH_PROTOCOL_PATTERN);
+
 const LinkRow: React.FC<LinkRowProps> = ({index, onDelete}) => {
   const {t} = useTranslation();
   const {control, clearErrors, getValues, trigger, setValue} = useFormContext();
@@ -65,14 +69,8 @@ const LinkRow: React.FC<LinkRowProps> = ({index, onDelete}) => {
     (name: string) => {
       const url = getValues(name);
 
-      if (
-        new RegExp(URL_PATTERN).test(url) ||
-        new RegExp(EMAIL_PATTERN).test(url)
-      ) {
-        if (
-          new RegExp(URL_PATTERN).test(url) &&
-          !new RegExp(URL_WITH_PROTOCOL_PATTERN).test(url)
-        ) {
+      if (UrlRegex.test(url) || EmailRegex.test(url)) {
+        if (UrlRegex.test(url) && !UrlWithProtocolRegex.test(url)) {
           setValue(name, `http://${url}`);
         }
         return true;
@@ -89,8 +87,7 @@ const LinkRow: React.FC<LinkRowProps> = ({index, onDelete}) => {
 
       if (url === '') return t('errors.required.link');
 
-      return new RegExp(URL_PATTERN).test(url) ||
-        new RegExp(EMAIL_PATTERN).test(url)
+      return UrlRegex.test(url) || EmailRegex.test(url)
         ? true
         : t('errors.invalidURL');
     },

--- a/packages/web-app/src/containers/reviewWithdraw/index.tsx
+++ b/packages/web-app/src/containers/reviewWithdraw/index.tsx
@@ -90,7 +90,11 @@ const ReviewWithdraw: React.FC = () => {
             </>
           )}
 
-          <VotingTerminal />
+          {/*
+            TODO: All the values inside the voting terminal is hardcoded.
+            The info tab needs to display data from the form context & graph query
+          */}
+          <VotingTerminal breakdownTabDisabled votersTabDisabled />
 
           <CardExecution
             title={t('governance.executionCard.title')}

--- a/packages/web-app/src/containers/votingTerminal/index.tsx
+++ b/packages/web-app/src/containers/votingTerminal/index.tsx
@@ -36,7 +36,15 @@ const voters: Array<VoterType> = [
   },
 ];
 
-export const VotingTerminal: React.FC = () => {
+type VotingTerminalProps = {
+  breakdownTabDisabled?: boolean;
+  votersTabDisabled?: boolean;
+};
+
+export const VotingTerminal: React.FC<VotingTerminalProps> = ({
+  breakdownTabDisabled = false,
+  votersTabDisabled = false,
+}) => {
   const [buttonGroupState, setButtonGroupState] = useState('info');
   const [votingInProcess, setVotingInProcess] = useState(false);
   const {t} = useTranslation();
@@ -50,8 +58,16 @@ export const VotingTerminal: React.FC = () => {
           defaultValue={buttonGroupState}
           onChange={setButtonGroupState}
         >
-          <Option value="breakdown" label={t('votingTerminal.breakdown')} />
-          <Option value="voters" label={t('votingTerminal.voters')} />
+          <Option
+            value="breakdown"
+            label={t('votingTerminal.breakdown')}
+            disabled={breakdownTabDisabled}
+          />
+          <Option
+            value="voters"
+            label={t('votingTerminal.voters')}
+            disabled={votersTabDisabled}
+          />
           <Option value="info" label={t('votingTerminal.info')} />
         </ButtonGroup>
       </Header>

--- a/packages/web-app/src/utils/constants.ts
+++ b/packages/web-app/src/utils/constants.ts
@@ -28,6 +28,9 @@ export const enum TransferTypes {
 export const URL_PATTERN =
   /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/g;
 
+export const URL_WITH_PROTOCOL_PATTERN =
+  /^(http:\/\/|https:\/\/)[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/g;
+
 export const EMAIL_PATTERN =
   /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
 

--- a/packages/web-app/src/utils/constants.ts
+++ b/packages/web-app/src/utils/constants.ts
@@ -26,10 +26,10 @@ export const enum TransferTypes {
 }
 
 export const URL_PATTERN =
-  /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/g;
+  /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/i;
 
 export const URL_WITH_PROTOCOL_PATTERN =
-  /^(http:\/\/|https:\/\/)[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/g;
+  /^(http:\/\/|https:\/\/)[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/i;
 
 export const EMAIL_PATTERN =
   /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;


### PR DESCRIPTION
- Makes few tabs in VotingTerminal disabled
- Adds protocol(`http://` - this is the default behaviour in almost every app and also tiptap editor) to links to prevent opening them as relative paths