### PR TITLE
resolve #225: use solidity custom errors

### DIFF
--- a/packages/contracts/contracts/core/DAO.sol
+++ b/packages/contracts/contracts/core/DAO.sol
@@ -30,14 +30,20 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
     bytes32 public constant SET_SIGNATURE_VALIDATOR_ROLE = keccak256("SET_SIGNATURE_VALIDATOR_ROLE");
 
     // Error msg's
-    string internal constant ERROR_ACTION_CALL_FAILED = "ACTION_CALL_FAILED";
-    string internal constant ERROR_WITHDRAW_RECIPIENT_ZERO = "WITHDRAW_RECIPIENT_ZERO";
-    string internal constant ERROR_DEPOSIT_AMOUNT_ZERO = "DEPOSIT_AMOUNT_ZERO";
-    string internal constant ERROR_WITHDRAW_AMOUNT_ZERO = "WITHDRAW_AMOUNT_ZERO";
-    string internal constant ERROR_DEPOSIT_ETH_VALUE_ZERO = "DEPOSIT_ETH_VALUE_ZERO";
-    string internal constant ERROR_ETH_DEPOSIT_AMOUNT_MISMATCH = "ETH_DEPOSIT_AMOUNT_MISMATCH";
-    string internal constant ERROR_ETH_WITHDRAW_FAILED = "ETH_WITHDRAW_FAILED";
-    
+    /// @notice Thrown if action execution has failed
+    error ActionFailed();
+
+    /// @notice Thrown if the deposit or withdraw amount is zero
+    error ZeroAmount();
+
+    /// @notice Thrown if the expected and actually deposited ETH amount mismatch
+    /// @param expected ETH amount
+    /// @param actual ETH amount
+    error ETHDepositAmountMismatch(uint256 expected, uint256 actual);
+
+    /// @notice Thrown if an ETH withdraw fails
+    error ETHWithdrawFailed();
+
     ERC1271 signatureValidator;
 
     /// @dev Used for UUPS upgradability pattern
@@ -89,7 +95,7 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         for (uint256 i = 0; i < _actions.length; i++) {
             (bool success, bytes memory response) = _actions[i].to.call{value: _actions[i].value}(_actions[i].data);
 
-            require(success, ERROR_ACTION_CALL_FAILED);
+            if(!success) revert ActionFailed();
 
             execResults[i] = response;
         }
@@ -119,12 +125,13 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         uint256 _amount,
         string calldata _reference
     ) external payable override {
-        require(_amount > 0, ERROR_DEPOSIT_AMOUNT_ZERO);
+        if(_amount == 0) revert ZeroAmount();
 
         if (_token == address(0)) {
-            require(msg.value == _amount, ERROR_ETH_DEPOSIT_AMOUNT_MISMATCH);
+            if(msg.value != _amount) revert ETHDepositAmountMismatch({expected: _amount, actual: msg.value});
         } else {
-            require(msg.value == 0, ERROR_DEPOSIT_ETH_VALUE_ZERO);
+            if(msg.value != 0) revert ETHDepositAmountMismatch({expected: 0, actual: msg.value});
+
             ERC20(_token).safeTransferFrom(msg.sender, address(this), _amount);
         }
 
@@ -142,11 +149,11 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         uint256 _amount,
         string memory _reference
     ) external override auth(address(this), WITHDRAW_ROLE) {
-        require(_amount > 0, ERROR_WITHDRAW_AMOUNT_ZERO);
+        if(_amount == 0) revert ZeroAmount();
 
         if (_token == address(0)) {
             (bool ok, ) = _to.call{value: _amount}("");
-            require(ok, ERROR_ETH_WITHDRAW_FAILED);
+            if(!ok) revert ETHWithdrawFailed();
         } else {
             ERC20(_token).safeTransfer(_to, _amount);
         }

--- a/packages/contracts/contracts/core/component/Permissions.sol
+++ b/packages/contracts/contracts/core/component/Permissions.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@opengsn/contracts/src/BaseRelayRecipient.sol";
 
 import "./../IDAO.sol";
+import "./../acl/ACL.sol";
 
 /// @title Abstract implementation of the DAO permissions
 /// @author Samuel Furter - Aragon Association - 2022
@@ -17,11 +18,16 @@ abstract contract Permissions is Initializable, BaseRelayRecipient {
     
     /// @dev Every component needs DAO at least for the permission management. See 'auth' modifier.
     IDAO internal dao;
+
+    // Errors
+    error Permission(bytes32 magicNumber);
     
     /// @dev Auth modifier used in all components of a DAO to check the permissions.
     /// @param _role The hash of the role identifier
     modifier auth(bytes32 _role)  {
-        require(dao.hasPermission(address(this), _msgSender(), _role, _msgData()), "component: auth");
+        if(!dao.hasPermission(address(this), _msgSender(), _role, _msgData()))
+            revert ACLData.ACLAuth({here: address(this), where: address(this), who: _msgSender(), role: _role});
+
         _;
     }
 

--- a/packages/contracts/contracts/core/erc165/AdaptiveERC165.sol
+++ b/packages/contracts/contracts/core/erc165/AdaptiveERC165.sol
@@ -17,6 +17,10 @@ contract AdaptiveERC165 is ERC165 {
 
     bytes32 internal constant UNREGISTERED_CALLBACK = bytes32(0);
 
+    // Errors
+    error AdapERC165UnkownCallback(bytes32 magicNumber);
+
+    // Events
     event RegisteredStandard(bytes4 interfaceId);
     event RegisteredCallback(bytes4 sig, bytes4 magicNumber);
     event ReceivedCallback(bytes4 indexed sig, bytes data);
@@ -32,7 +36,7 @@ contract AdaptiveERC165 is ERC165 {
     /// @param _data The data resp. arguments passed to the method
     function _handleCallback(bytes4 _sig, bytes memory _data) internal {
         bytes32 magicNumber = callbackMagicNumbers[_sig];
-        require(magicNumber != UNREGISTERED_CALLBACK, "adap-erc165: unknown callback");
+        if (magicNumber == UNREGISTERED_CALLBACK) revert AdapERC165UnkownCallback({magicNumber: magicNumber});
 
         emit ReceivedCallback(_sig, _data);
 

--- a/packages/contracts/contracts/factories/DAOFactory.sol
+++ b/packages/contracts/contracts/factories/DAOFactory.sol
@@ -23,7 +23,7 @@ contract DAOFactory {
     using Address for address;
     using Clones for address;
 
-    string private constant ERROR_MISMATCH = "FACTORY: MISMATCH";
+    error MintArrayLengthMismatch(uint256 receiversArrayLength, uint256 amountsArrayLength);
 
     address public votingBase;
     address public daoBase;
@@ -72,7 +72,11 @@ contract DAOFactory {
             MerkleMinter minter
         )
     {
-        require(_mintConfig.receivers.length == _mintConfig.amounts.length, ERROR_MISMATCH);
+        if(_mintConfig.receivers.length != _mintConfig.amounts.length)
+            revert MintArrayLengthMismatch({
+                receiversArrayLength: _mintConfig.receivers.length,
+                amountsArrayLength: _mintConfig.amounts.length
+            });
 
         // create dao
         dao = DAO(createProxy(daoBase, bytes("")));

--- a/packages/contracts/contracts/registry/Registry.sol
+++ b/packages/contracts/contracts/registry/Registry.sol
@@ -10,6 +10,15 @@ import "../core/DAO.sol";
 /// @author Samuel Furter - Aragon Association - 2021
 /// @notice This contract provides the possiblity to register a DAO by a unique name.
 contract Registry {
+
+    /// @notice Thrown if the DAO name is already registered
+    /// @param name The DAO name requested for registration
+    error RegistryNameAlreadyUsed(string name);
+
+    /// @notice Emitted if a new DAO is registered
+    /// @param dao The address of the DAO contract
+    /// @param creator The address of the creator
+    /// @param name The name of the DAO
     event NewDAORegistered(DAO indexed dao, address indexed creator, address indexed token, string name);
 
     mapping(string => bool) public daos;
@@ -19,7 +28,7 @@ contract Registry {
     /// @param name The name of the DAO
     /// @param dao The address of the DAO contract
     function register(string calldata name, DAO dao, address creator, address token) external {
-        require(daos[name] == false, "name already in use");
+        if(daos[name] != false) revert RegistryNameAlreadyUsed({name: name});
 
         daos[name] = true;
         

--- a/packages/contracts/contracts/utils/Uint256Helpers.sol
+++ b/packages/contracts/contracts/utils/Uint256Helpers.sol
@@ -7,10 +7,10 @@ pragma solidity 0.8.10;
 library Uint256Helpers {
     uint256 private constant MAX_UINT64 = type(uint64).max;
 
-    string private constant ERROR_NUMBER_TOO_BIG = "UINT64_NUMBER_TOO_BIG";
+    error OutOfBounds(uint256 maxValue, uint256 value);
 
     function toUint64(uint256 a) internal pure returns (uint64) {
-        require(a <= MAX_UINT64, ERROR_NUMBER_TOO_BIG);
+        if(a > MAX_UINT64) revert OutOfBounds({maxValue: MAX_UINT64, value: a});
         return uint64(a);
     }
 }

--- a/packages/contracts/contracts/votings/ERC20Voting/ERC20Voting.sol
+++ b/packages/contracts/contracts/votings/ERC20Voting/ERC20Voting.sol
@@ -46,14 +46,13 @@ contract ERC20Voting is Component, TimeHelpers {
 
     ERC20VotesUpgradeable public token;
 
-    string private constant ERROR_VOTE_DATES_WRONG = "VOTING_DURATION_TIME_WRONG";
-    string private constant ERROR_MIN_DURATION_NO_ZERO = "VOTING_MIN_DURATION_NO_ZERO";
-    string private constant ERROR_SUPPORT_TOO_BIG = "VOTING_SUPPORT_TOO_BIG";
-    string private constant ERROR_PARTICIPATION_TOO_BIG = "VOTING_PARTICIPATION_TOO_BIG";
-    string private constant ERROR_CAN_NOT_VOTE = "VOTING_CAN_NOT_VOTE";
-    string private constant ERROR_CAN_NOT_EXECUTE = "VOTING_CAN_NOT_EXECUTE";
-    string private constant ERROR_CAN_NOT_FORWARD = "VOTING_CAN_NOT_FORWARD";
-    string private constant ERROR_NO_VOTING_POWER = "VOTING_NO_VOTING_POWER";
+    error VoteSupportExceeded(uint64 limit, uint64 actual);
+    error VoteParticipationExceeded(uint64 limit, uint64 actual);
+    error VoteTimesForbidden(uint64 current, uint64 start, uint64 end, uint64 minDuration);
+    error VoteDurationZero();
+    error VoteCastForbidden(uint256 voteId, address sender);
+    error VoteExecutionForbidden(uint256 voteId);
+    error VotePowerZero();
 
     event StartVote(uint256 indexed voteId, address indexed creator, bytes metadata);
     event CastVote(uint256 indexed voteId, address indexed voter, uint8 voterState, uint256 stake);
@@ -75,9 +74,12 @@ contract ERC20Voting is Component, TimeHelpers {
         uint64 _supportRequiredPct,
         uint64 _minDuration
     ) public initializer {
-        require(_supportRequiredPct <= PCT_BASE, ERROR_SUPPORT_TOO_BIG);
-        require(_participationRequiredPct <= PCT_BASE, ERROR_PARTICIPATION_TOO_BIG);
-        require(_minDuration > 0, ERROR_MIN_DURATION_NO_ZERO);
+        if(_supportRequiredPct > PCT_BASE)
+            revert VoteSupportExceeded({limit: PCT_BASE, actual: _supportRequiredPct});
+        if(_participationRequiredPct > PCT_BASE)
+            revert VoteParticipationExceeded({limit: PCT_BASE, actual: _participationRequiredPct});
+        if(_minDuration == 0)
+            revert VoteDurationZero();
 
         __Component_init(_dao, _gsnForwarder);
         
@@ -100,9 +102,12 @@ contract ERC20Voting is Component, TimeHelpers {
         uint64 _supportRequiredPct,
         uint64 _minDuration
     ) external auth(MODIFY_CONFIG) {
-        require(_supportRequiredPct <= PCT_BASE, ERROR_SUPPORT_TOO_BIG);
-        require(_participationRequiredPct <= PCT_BASE, ERROR_PARTICIPATION_TOO_BIG);
-        require(_minDuration > 0, ERROR_MIN_DURATION_NO_ZERO);
+        if(_supportRequiredPct > PCT_BASE)
+            revert VoteSupportExceeded({limit: PCT_BASE, actual: _supportRequiredPct});
+        if(_participationRequiredPct > PCT_BASE)
+            revert VoteParticipationExceeded({limit: PCT_BASE, actual: _participationRequiredPct});
+        if(_minDuration == 0)
+            revert VoteDurationZero();
 
         participationRequiredPct = _participationRequiredPct;
         supportRequiredPct = _supportRequiredPct;
@@ -131,7 +136,8 @@ contract ERC20Voting is Component, TimeHelpers {
         uint64 snapshotBlock = getBlockNumber64() - 1;
 
         uint256 votingPower = token.getPastTotalSupply(snapshotBlock);
-        require(votingPower > 0, ERROR_NO_VOTING_POWER);
+        if (votingPower == 0) revert VotePowerZero();
+
 
         voteId = votesLength++;
 
@@ -141,7 +147,13 @@ contract ERC20Voting is Component, TimeHelpers {
         if (_startDate == 0) _startDate = currentTimestamp;
         if (_endDate == 0) _endDate = _startDate + minDuration;
 
-        require(_endDate - _startDate >= minDuration || _startDate >= currentTimestamp, ERROR_VOTE_DATES_WRONG);
+        if(_endDate - _startDate <  minDuration || _startDate < currentTimestamp)
+            revert VoteTimesForbidden({
+                current: currentTimestamp,
+                start: _startDate,
+                end: _endDate,
+                minDuration: minDuration
+            });
 
         // create a vote.
         Vote storage vote_ = votes[voteId];
@@ -174,7 +186,7 @@ contract ERC20Voting is Component, TimeHelpers {
         VoterState _outcome,
         bool _executesIfDecided
     ) external {
-        require(_canVote(_voteId, _msgSender()), ERROR_CAN_NOT_VOTE);
+        if(!_canVote(_voteId, msg.sender)) revert VoteCastForbidden(_voteId, msg.sender);
         _vote(_voteId, _outcome, _msgSender(), _executesIfDecided);
     }
 
@@ -228,7 +240,7 @@ contract ERC20Voting is Component, TimeHelpers {
      * @param _voteId The ID of the vote to execute
      */
     function execute(uint256 _voteId) public {
-        require(_canExecute(_voteId), ERROR_CAN_NOT_EXECUTE);
+        if(!_canExecute(_voteId)) revert VoteExecutionForbidden(_voteId);
         _execute(_voteId);
     }
 

--- a/packages/contracts/contracts/votings/whitelist/WhitelistVoting.sol
+++ b/packages/contracts/contracts/votings/whitelist/WhitelistVoting.sol
@@ -48,13 +48,13 @@ contract WhitelistVoting is Component, TimeHelpers {
 
     mapping(address => bool) public whitelisted;
 
-    string private constant ERROR_SUPPORT_TOO_BIG = "VOTING_SUPPORT_TOO_BIG";
-    string private constant ERROR_PARTICIPATION_TOO_BIG = "VOTING_PARTICIPATION_TOO_BIG";
-    string private constant ERROR_VOTE_DATES_WRONG = "VOTING_DURATION_TIME_WRONG";
-    string private constant ERROR_MIN_DURATION_NO_ZERO = "VOTING_MIN_DURATION_NO_ZERO";
-    string private constant ERROR_CAN_NOT_VOTE = "VOTING_CAN_NOT_VOTE";
-    string private constant ERROR_CAN_NOT_EXECUTE = "VOTING_CAN_NOT_EXECUTE";
-    string private constant ERROR_CAN_NOT_CREATE_VOTE = "VOTING_CAN_NOT_CREATE_VOTE";
+    error VoteSupportExceeded(uint64 limit, uint64 actual);
+    error VoteParticipationExceeded(uint64 limit, uint64 actual);
+    error VoteTimesForbidden(uint64 current, uint64 start, uint64 end, uint64 minDuration);
+    error VoteDurationZero();
+    error VoteCastForbidden(uint256 voteId, address sender);
+    error VoteExecutionForbidden(uint256 voteId);
+    error VoteCreationForbidden(address sender);
 
     event StartVote(uint256 indexed voteId, address indexed creator, bytes metadata);
     event CastVote(uint256 indexed voteId, address indexed voter, uint8 voterState);
@@ -78,9 +78,11 @@ contract WhitelistVoting is Component, TimeHelpers {
         uint64 _supportRequiredPct,
         uint64 _minDuration
     ) public initializer {
-        require(_supportRequiredPct <= PCT_BASE, ERROR_SUPPORT_TOO_BIG);
-        require(_participationRequiredPct <= PCT_BASE, ERROR_PARTICIPATION_TOO_BIG);
-        require(_minDuration > 0, ERROR_MIN_DURATION_NO_ZERO);
+        if(_supportRequiredPct > PCT_BASE)
+            revert VoteSupportExceeded({limit: PCT_BASE, actual: _supportRequiredPct});
+        if(_participationRequiredPct > PCT_BASE)
+            revert VoteParticipationExceeded({limit: PCT_BASE, actual: _participationRequiredPct});
+        if(_minDuration == 0) revert VoteDurationZero();
 
         __Component_init(_dao, _gsnForwarder);
         
@@ -141,9 +143,12 @@ contract WhitelistVoting is Component, TimeHelpers {
         uint64 _supportRequiredPct,
         uint64 _minDuration
     ) external auth(MODIFY_CONFIG) {
-        require(_supportRequiredPct <= PCT_BASE, ERROR_SUPPORT_TOO_BIG);
-        require(_participationRequiredPct <= PCT_BASE, ERROR_PARTICIPATION_TOO_BIG);
-        require(_minDuration > 0, ERROR_MIN_DURATION_NO_ZERO);
+        if(_supportRequiredPct > PCT_BASE)
+            revert VoteSupportExceeded({limit: PCT_BASE, actual: _supportRequiredPct});
+        if(_participationRequiredPct > PCT_BASE)
+            revert VoteParticipationExceeded({limit: PCT_BASE, actual: _participationRequiredPct});
+        if(_minDuration == 0)
+            revert VoteDurationZero();
 
         participationRequiredPct = _participationRequiredPct;
         supportRequiredPct = _supportRequiredPct;
@@ -169,7 +174,7 @@ contract WhitelistVoting is Component, TimeHelpers {
         bool _executeIfDecided,
         bool _castVote
     ) external returns (uint256 voteId) {
-        require(whitelisted[msg.sender], ERROR_CAN_NOT_CREATE_VOTE);
+        if(!whitelisted[msg.sender]) revert VoteCreationForbidden(msg.sender);
 
         // calculate start and end time for the vote
         uint64 currentTimestamp = getTimestamp64();
@@ -177,7 +182,13 @@ contract WhitelistVoting is Component, TimeHelpers {
         if (_startDate == 0) _startDate = currentTimestamp;
         if (_endDate == 0) _endDate = _startDate + minDuration;
 
-        require(_endDate - _startDate >= minDuration || _startDate >= currentTimestamp, ERROR_VOTE_DATES_WRONG);
+        if(_endDate - _startDate <  minDuration || _startDate < currentTimestamp)
+            revert VoteTimesForbidden({
+                current: currentTimestamp,
+                start: _startDate,
+                end: _endDate,
+                minDuration: minDuration
+            });
 
         voteId = votesLength++;
 
@@ -211,7 +222,7 @@ contract WhitelistVoting is Component, TimeHelpers {
         VoterState _outcome,
         bool _executesIfDecided
     ) external {
-        require(_canVote(_voteId, msg.sender), ERROR_CAN_NOT_VOTE);
+        if(!_canVote(_voteId, msg.sender)) revert VoteCastForbidden(_voteId, msg.sender);
         _vote(_voteId, _outcome, msg.sender, _executesIfDecided);
     }
 
@@ -263,7 +274,7 @@ contract WhitelistVoting is Component, TimeHelpers {
      * @param _voteId The ID of the vote to execute
      */
     function execute(uint256 _voteId) public {
-        require(_canExecute(_voteId), ERROR_CAN_NOT_EXECUTE);
+        if(!_canExecute(_voteId)) revert VoteExecutionForbidden(_voteId);
         _execute(_voteId);
     }
 

--- a/packages/contracts/test/adaptive-erc165.ts
+++ b/packages/contracts/test/adaptive-erc165.ts
@@ -8,10 +8,7 @@ import {
   AdaptiveERC165Mock__factory,
   AdaptiveERC165MockHelper__factory,
 } from '../typechain'
-
-const ERRORS = {
-  UNKNOWN_CALLBACK: 'adap-erc165: unknown callback',
-}
+import {customError} from './test-utils/custom-error-helper';
 
 const EVENTS = {
   REGISTERED_CALLBACK: 'RegisteredCallback',
@@ -23,6 +20,7 @@ const beefInterfaceId = '0xbeefbeef'
 const callbackSig = hexDataSlice(id('callbackFunc()'), 0, 4) // 0x1eb2075a
 const magicNumber = '0x10000000'
 const magicNumberReturn = magicNumber + '0'.repeat(56)
+const unregisteredNumberReturn = '0x' + '0'.repeat(64)
 
 describe('AdaptiveErc165', function () {
   let adaptive: AdaptiveERC165Mock, signers: Signer[]
@@ -62,7 +60,7 @@ describe('AdaptiveErc165', function () {
       )
     })
 
-    it('ensures the right callback was call with the right memory value', async () => {
+    it('ensures the right callback was called with the right memory value', async () => {
       await expect(
         signers[0].sendTransaction({
           to: adaptive.address,
@@ -79,7 +77,7 @@ describe('AdaptiveErc165', function () {
           to: adaptive.address,
           data: hexDataSlice(id('unknown()'), 0, 4),
         })
-      ).to.be.revertedWith(ERRORS.UNKNOWN_CALLBACK)
+      ).to.be.revertedWith(customError('AdapERC165UnkownCallback', unregisteredNumberReturn))
     })
 
     it('returns the correct value from handleCallback assembly', async () => {

--- a/packages/contracts/test/core/acl.ts
+++ b/packages/contracts/test/core/acl.ts
@@ -2,6 +2,7 @@ import {expect} from 'chai';
 import {ethers} from 'hardhat';
 import {ACLTest, ACLOracleMock} from '../../typechain';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
+import {customError} from '../test-utils/custom-error-helper';
 
 const ROOT_ROLE = ethers.utils.id('ROOT_ROLE');
 const ADMIN_ROLE = ethers.utils.id('ADMIN_ROLE');
@@ -43,9 +44,9 @@ describe('Core: ACL', function () {
 
   describe('init', () => {
     it('should allow init call only once', async () => {
-      await expect(acl.init(ownerSigner.address)).to.be.revertedWith(
-        'Initializable: contract is already initialized'
-      );
+      await expect(
+          acl.init(ownerSigner.address)
+      ).to.be.revertedWith('Initializable: contract is already initialized');
     });
 
     it('should emit Granted', async () => {
@@ -85,14 +86,14 @@ describe('Core: ACL', function () {
       await acl.grant(acl.address, otherSigner.address, ADMIN_ROLE);
       await expect(
         acl.grant(acl.address, otherSigner.address, ADMIN_ROLE)
-      ).to.be.revertedWith('acl: role already granted');
+      ).to.be.revertedWith(customError('ACLRoleAlreadyGranted', acl.address, otherSigner.address, ADMIN_ROLE));
     });
 
     it('should revert if frozen', async () => {
       await acl.freeze(acl.address, ADMIN_ROLE);
       await expect(
         acl.grant(acl.address, otherSigner.address, ADMIN_ROLE)
-      ).to.be.revertedWith('acl: frozen');
+      ).to.be.revertedWith(customError('ACLRoleFrozen', acl.address, ADMIN_ROLE));
     });
 
     it('should not allow grant', async () => {
@@ -100,7 +101,7 @@ describe('Core: ACL', function () {
         acl
           .connect(otherSigner)
           .grant(acl.address, otherSigner.address, ADMIN_ROLE)
-      ).to.be.revertedWith('acl: auth');
+      ).to.be.revertedWith(customError('ACLAuth', acl.address, acl.address, otherSigner.address, ROOT_ROLE));
     });
 
     it('should not allow for non ROOT', async () => {
@@ -109,7 +110,7 @@ describe('Core: ACL', function () {
         acl
           .connect(otherSigner)
           .grant(acl.address, otherSigner.address, ROOT_ROLE)
-      ).to.be.revertedWith('acl: auth');
+      ).to.be.revertedWith(customError('ACLAuth', acl.address, acl.address, otherSigner.address, ROOT_ROLE));
     });
   });
 
@@ -154,7 +155,7 @@ describe('Core: ACL', function () {
           ADMIN_ROLE,
           ALLOW_FLAG
         )
-      ).to.be.revertedWith('acl: role already granted');
+      ).to.be.revertedWith(customError('ACLRoleAlreadyGranted', acl.address, otherSigner.address, ADMIN_ROLE));
     });
 
     it('should revert if frozen', async () => {
@@ -166,7 +167,7 @@ describe('Core: ACL', function () {
           ADMIN_ROLE,
           ALLOW_FLAG
         )
-      ).to.be.revertedWith('acl: frozen');
+      ).to.be.revertedWith(customError('ACLRoleFrozen', acl.address, ADMIN_ROLE));
     });
 
     it('should set ACLOracle', async () => {
@@ -196,7 +197,7 @@ describe('Core: ACL', function () {
             ADMIN_ROLE,
             ALLOW_FLAG
           )
-      ).to.be.revertedWith('acl: auth');
+      ).to.be.revertedWith(customError('ACLAuth', acl.address, acl.address, otherSigner.address, ROOT_ROLE));
     });
 
     it('should not allow for non ROOT', async () => {
@@ -215,7 +216,7 @@ describe('Core: ACL', function () {
             ROOT_ROLE,
             ALLOW_FLAG
           )
-      ).to.be.revertedWith('acl: auth');
+      ).to.be.revertedWith(customError('ACLAuth', acl.address, acl.address, otherSigner.address, ROOT_ROLE));
     });
   });
 
@@ -244,7 +245,7 @@ describe('Core: ACL', function () {
         acl
           .connect(otherSigner)
           .revoke(acl.address, otherSigner.address, ADMIN_ROLE)
-      ).to.be.revertedWith('acl: auth');
+      ).to.be.revertedWith(customError('ACLAuth', acl.address, acl.address, otherSigner.address, ROOT_ROLE));
     });
 
     it('should revert if frozen', async () => {
@@ -252,7 +253,7 @@ describe('Core: ACL', function () {
       await acl.freeze(acl.address, ADMIN_ROLE);
       await expect(
         acl.revoke(acl.address, otherSigner.address, ADMIN_ROLE)
-      ).to.be.revertedWith('acl: frozen');
+      ).to.be.revertedWith(customError('ACLRoleFrozen', acl.address, ADMIN_ROLE));
     });
 
     it('should revert if already revoked', async () => {
@@ -260,7 +261,7 @@ describe('Core: ACL', function () {
       await acl.revoke(acl.address, otherSigner.address, ADMIN_ROLE);
       await expect(
         acl.revoke(acl.address, otherSigner.address, ADMIN_ROLE)
-      ).to.be.revertedWith('acl: role already revoked');
+      ).to.be.revertedWith(customError('ACLRoleAlreadyRevoked', acl.address, otherSigner.address, ADMIN_ROLE));
     });
 
     it('should not allow', async () => {
@@ -268,7 +269,7 @@ describe('Core: ACL', function () {
         acl
           .connect(otherSigner)
           .revoke(acl.address, otherSigner.address, ADMIN_ROLE)
-      ).to.be.revertedWith('acl: auth');
+      ).to.be.revertedWith(customError('ACLAuth', acl.address, acl.address, otherSigner.address, ROOT_ROLE));
     });
 
     it('should not allow for non ROOT', async () => {
@@ -277,7 +278,7 @@ describe('Core: ACL', function () {
         acl
           .connect(otherSigner)
           .revoke(acl.address, otherSigner.address, ADMIN_ROLE)
-      ).to.be.revertedWith('acl: auth');
+      ).to.be.revertedWith(customError('ACLAuth', acl.address, acl.address, otherSigner.address, ROOT_ROLE));
     });
   });
 
@@ -294,22 +295,22 @@ describe('Core: ACL', function () {
 
     it('should revert if already frozen', async () => {
       await acl.freeze(acl.address, ADMIN_ROLE);
-      await expect(acl.freeze(acl.address, ADMIN_ROLE)).to.be.revertedWith(
-        'acl: role already freeze'
-      );
+      await expect(
+          acl.freeze(acl.address, ADMIN_ROLE)
+      ).to.be.revertedWith(customError('ACLRoleFrozen', acl.address, ADMIN_ROLE));
     });
 
     it('should not allow', async () => {
       await expect(
         acl.connect(otherSigner).freeze(acl.address, ADMIN_ROLE)
-      ).to.be.revertedWith('acl: auth');
+      ).to.be.revertedWith(customError('ACLAuth', acl.address, acl.address, otherSigner.address, ROOT_ROLE));
     });
 
     it('should not allow for non ROOT', async () => {
       await acl.grant(acl.address, otherSigner.address, ADMIN_ROLE);
       await expect(
         acl.connect(otherSigner).freeze(acl.address, ADMIN_ROLE)
-      ).to.be.revertedWith('acl: auth');
+      ).to.be.revertedWith(customError('ACLAuth', acl.address, acl.address, otherSigner.address, ROOT_ROLE));
     });
   });
 
@@ -465,9 +466,9 @@ describe('Core: ACL', function () {
         },
       ];
 
-      await expect(acl.bulk(acl.address, bulkItems)).to.be.revertedWith(
-        'acl: role already freeze'
-      );
+      await expect(
+          acl.bulk(acl.address, bulkItems)
+      ).to.be.revertedWith(customError('ACLRoleFrozen', acl.address, ADMIN_ROLE));
       expect(
         await acl.getAuthPermission(acl.address, signers[1].address, ADMIN_ROLE)
       ).to.be.equal(ALLOW_FLAG);
@@ -489,7 +490,7 @@ describe('Core: ACL', function () {
       ];
       await expect(
         acl.connect(otherSigner).bulk(acl.address, bulkItems)
-      ).to.be.revertedWith('acl: auth');
+      ).to.be.revertedWith(customError('ACLAuth', acl.address, acl.address, otherSigner.address, ROOT_ROLE));
     });
 
     it('should not allow for non ROOT', async () => {
@@ -503,7 +504,7 @@ describe('Core: ACL', function () {
       ];
       await expect(
         acl.connect(otherSigner).bulk(acl.address, bulkItems)
-      ).to.be.revertedWith('acl: auth');
+      ).to.be.revertedWith(customError('ACLAuth', acl.address, acl.address, otherSigner.address, ROOT_ROLE));
     });
   });
 

--- a/packages/contracts/test/dao-factory.ts
+++ b/packages/contracts/test/dao-factory.ts
@@ -1,6 +1,8 @@
 import {expect} from 'chai';
 import {ethers} from 'hardhat';
 import {VoterState} from './test-utils/voting';
+import {customError} from './test-utils/custom-error-helper';
+
 
 const EVENTS = {
   NewDAORegistered: 'NewDAORegistered',
@@ -12,11 +14,8 @@ const EVENTS = {
   EXECUTED: 'Executed',
 };
 
-const ERRORS = {
-  NameAlreadyInUse: 'name already in use',
-  ComponentAuth: 'component: auth',
-  ACLAuth: 'acl: auth',
-};
+const EXEC_ROLE = ethers.utils.id('EXEC_ROLE');
+const MODIFY_VOTE_CONFIG = ethers.utils.id('MODIFY_VOTE_CONFIG');
 
 const zeroAddress = ethers.constants.AddressZero;
 const ACLAnyAddress = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF';
@@ -215,11 +214,13 @@ describe('DAOFactory: ', function () {
     // ===== Test if user can create a vote and execute it ======
 
     // should be only callable by ERC20Voting
-    await expect(dao.execute(0, [])).to.be.revertedWith(ERRORS.ACLAuth);
+    await expect(
+        dao.execute(0, [])
+    ).to.be.revertedWith(customError('ACLAuth', dao.address, dao.address, ownerAddress, EXEC_ROLE));
 
-    await expect(ERC20Voting.changeVoteConfig(1, 2, 3)).to.be.revertedWith(
-      ERRORS.ComponentAuth
-    );
+    await expect(
+        ERC20Voting.changeVoteConfig(1, 2, 3)
+    ).to.be.revertedWith(customError('ACLAuth', ERC20Voting.address, ERC20Voting.address, ownerAddress, MODIFY_VOTE_CONFIG));
 
     const actions = [
       {

--- a/packages/contracts/test/registry.ts
+++ b/packages/contracts/test/registry.ts
@@ -1,12 +1,9 @@
 import {expect} from 'chai';
 import {ethers} from 'hardhat';
+import {customError} from './test-utils/custom-error-helper';
 
 const EVENTS = {
   NewDAORegistered: 'NewDAORegistered'
-}
-
-const ERRORS = {
-  NameAlreadyInUse: 'name already in use'
 }
 
 describe('Registry', function () {
@@ -45,7 +42,7 @@ describe('Registry', function () {
 
     await expect(
       registry.register(daoName, daoAddress, ownerAddress, ownerAddress)
-    ).to.be.revertedWith(ERRORS.NameAlreadyInUse)
+    ).to.be.revertedWith(customError('RegistryNameAlreadyUsed', daoName))
   });
 
 });

--- a/packages/contracts/test/test-utils/custom-error-helper.ts
+++ b/packages/contracts/test/test-utils/custom-error-helper.ts
@@ -1,0 +1,22 @@
+export function customError (errorName: string, ...args: any[]){
+
+  let argumentString = '';
+
+  if(Array.isArray(args) && args.length) {
+
+    // add quotation marks to first argument if it is of string type
+    if (typeof args[0] === 'string') {
+      args[0] = `"${args[0]}"`
+    }
+
+    // add joining comma and quotation marks to all subsequent arguments, if they are of string type
+    argumentString = args.reduce(function (acc: string, cur: any) {
+      if (typeof cur === 'string')
+        return `${acc}, "${cur}"`
+      else
+        return `${acc}, ${cur.toString()}`;
+    })
+  }
+
+  return `'${errorName}(${argumentString})'`
+}

--- a/packages/web-app/src/abis/DAOFactory.json
+++ b/packages/web-app/src/abis/DAOFactory.json
@@ -16,6 +16,22 @@
     "type": "constructor"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "receiversArrayLength",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountsArrayLength",
+        "type": "uint256"
+      }
+    ],
+    "name": "MintArrayLengthMismatch",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {


### PR DESCRIPTION
This feature replaces errors strings by custom errors, as described in #225 in our code.

E.g.,
`string private constant ERROR_CAN_NOT_EXECUTE = "VOTING_CAN_NOT_EXECUTE";`
is replaced by
`error VoteExecutionForbidden(uint256 voteId);`.

Then,
`require(_canExecute(_voteId), ERROR_CAN_NOT_EXECUTE);`
becomes
`if(!_canExecute(_voteId)) revert VoteExecutionForbidden(_voteId);`.