### PR TITLE
Feature: App 305 Wrong wallet network Indicator

### DIFF
--- a/packages/web-app/src/components/addWallets/row.tsx
+++ b/packages/web-app/src/components/addWallets/row.tsx
@@ -32,7 +32,7 @@ export type WalletField = {
 const WalletRow: React.FC<WalletRowProps> = ({index, onDelete}) => {
   const {t} = useTranslation();
   const [isDuplicate, setIsDuplicate] = useState<boolean>(false);
-  const {account} = useWallet();
+  const {address} = useWallet();
   const {control, getValues, setValue, trigger} = useFormContext();
   const walletFieldArray = getValues('wallets');
 
@@ -95,20 +95,20 @@ const WalletRow: React.FC<WalletRowProps> = ({index, onDelete}) => {
               <ValueInput
                 mode={error ? 'critical' : 'default'}
                 name={name}
-                value={value === account ? 'My Wallet' : value}
+                value={value === address ? 'My Wallet' : value}
                 onBlur={onBlur}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   onChange(
-                    e.target.value === account ? 'My Wallet' : e.target.value
+                    e.target.value === address ? 'My Wallet' : e.target.value
                   );
                 }}
                 disabled={index === 0}
                 adornmentText={value ? t('labels.copy') : t('labels.paste')}
                 onAdornmentClick={() => {
                   handleClipboardActions(
-                    value === 'My Wallet' ? account : value,
+                    value === 'My Wallet' ? address : value,
                     (newValue: string) => {
-                      onChange(newValue === account ? 'My Wallet' : newValue);
+                      onChange(newValue === address ? 'My Wallet' : newValue);
                     }
                   );
                 }}

--- a/packages/web-app/src/components/whitelistWallets/index.tsx
+++ b/packages/web-app/src/components/whitelistWallets/index.tsx
@@ -14,7 +14,7 @@ import {useWallet} from 'hooks/useWallet';
 import {Row} from './row';
 
 export const WhitelistWallets = () => {
-  const {account} = useWallet();
+  const {address} = useWallet();
   const {control, watch} = useFormContext();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const {update, replace, append} = useFieldArray({
@@ -29,14 +29,14 @@ export const WhitelistWallets = () => {
   };
 
   useEffect(() => {
-    if (account) {
-      update(0, {address: account});
+    if (address) {
+      update(0, {address: address});
     }
   });
 
   // reset all
   const handleDeleteWallets = () => {
-    replace([{address: account}, {address: ''}]);
+    replace([{address: address}, {address: ''}]);
   };
   const handleResetWallets = () => {
     whitelistWallets.forEach((_, index) => {

--- a/packages/web-app/src/components/whitelistWallets/row.tsx
+++ b/packages/web-app/src/components/whitelistWallets/row.tsx
@@ -21,7 +21,7 @@ type WhitelistWalletsRowProps = {
 
 export const Row = ({index}: WhitelistWalletsRowProps) => {
   const {control, watch, trigger} = useFormContext();
-  const {account} = useWallet();
+  const {address} = useWallet();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const {remove, update, append} = useFieldArray({
     control,
@@ -55,16 +55,16 @@ export const Row = ({index}: WhitelistWalletsRowProps) => {
         <Container>
           <InputContainer>
             <ValueInput
-              value={value === account ? 'My Wallet' : value}
+              value={value === address ? 'My Wallet' : value}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 onChange(
-                  e.target.value === account ? 'My Wallet' : e.target.value
+                  e.target.value === address ? 'My Wallet' : e.target.value
                 );
               }}
               mode="default"
               placeholder="0x..."
               adornmentText={value ? 'Copy' : 'Paste'}
-              disabled={value === account}
+              disabled={value === address}
               onAdornmentClick={() => handleClipboardActions(value, onChange)}
             />
             {error?.message && (

--- a/packages/web-app/src/containers/configureWithdraw/index.tsx
+++ b/packages/web-app/src/containers/configureWithdraw/index.tsx
@@ -44,7 +44,7 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
   const {t} = useTranslation();
   const client = useApolloClient();
   const {open} = useGlobalModalContext();
-  const {account} = useWallet();
+  const {address} = useWallet();
   const {infura: provider} = useProviders();
 
   const {control, getValues, trigger, resetField, setFocus, setValue} =
@@ -70,11 +70,11 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
     if (from === '') {
       setValue(`actions.${index}.from`, TEST_DAO);
     }
-  }, [account, from, index, isCustomToken, setFocus, setValue]);
+  }, [address, from, index, isCustomToken, setFocus, setValue]);
 
   // Fetch custom token information
   useEffect(() => {
-    if (!account || !isCustomToken || !tokenAddress) return;
+    if (!address || !isCustomToken || !tokenAddress) return;
 
     const fetchTokenInfo = async () => {
       if (errors.tokenAddress !== undefined) {
@@ -121,7 +121,7 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
 
     fetchTokenInfo();
   }, [
-    account,
+    address,
     dirtyFields.amount,
     errors.tokenAddress,
     index,

--- a/packages/web-app/src/containers/defineProposal/index.tsx
+++ b/packages/web-app/src/containers/defineProposal/index.tsx
@@ -17,7 +17,7 @@ import {Controller, useFormContext} from 'react-hook-form';
 
 const DefineProposal: React.FC = () => {
   const {t} = useTranslation();
-  const {account, ensAvatarUrl} = useWallet();
+  const {address, ensAvatarUrl} = useWallet();
   const {control} = useFormContext();
 
   return (
@@ -27,7 +27,7 @@ const DefineProposal: React.FC = () => {
 
         <ButtonWallet
           label="You"
-          src={ensAvatarUrl || account}
+          src={ensAvatarUrl || address}
           isConnected
           disabled
         />

--- a/packages/web-app/src/containers/depositForm/index.tsx
+++ b/packages/web-app/src/containers/depositForm/index.tsx
@@ -30,7 +30,7 @@ const DepositForm: React.FC = () => {
   const client = useApolloClient();
   const {t} = useTranslation();
   const {open} = useGlobalModalContext();
-  const {account, balance: walletBalance} = useWallet();
+  const {address, balance: walletBalance} = useWallet();
   const {infura: provider} = useProviders();
   const {control, resetField, setValue, setFocus, trigger, getValues} =
     useFormContext();
@@ -47,7 +47,7 @@ const DepositForm: React.FC = () => {
   }, [isCustomToken, setFocus]);
 
   useEffect(() => {
-    if (!account || !isCustomToken || !tokenAddress) return;
+    if (!address || !isCustomToken || !tokenAddress) return;
 
     const fetchTokenInfo = async () => {
       if (errors.tokenAddress !== undefined) {
@@ -60,7 +60,7 @@ const DepositForm: React.FC = () => {
         const allTokenInfoPromise = Promise.all([
           isETH(tokenAddress)
             ? utils.formatEther(walletBalance || 0)
-            : fetchBalance(tokenAddress, account, provider),
+            : fetchBalance(tokenAddress, address, provider),
           fetchTokenData(tokenAddress, client),
         ]);
 
@@ -90,7 +90,7 @@ const DepositForm: React.FC = () => {
 
     fetchTokenInfo();
   }, [
-    account,
+    address,
     dirtyFields.amount,
     errors.tokenAddress,
     isCustomToken,

--- a/packages/web-app/src/containers/navbar/desktop.tsx
+++ b/packages/web-app/src/containers/navbar/desktop.tsx
@@ -9,7 +9,6 @@ import {useWallet} from 'hooks/useWallet';
 import NetworkIndicator from './networkIndicator';
 import {BreadcrumbDropdown} from './breadcrumbDropdown';
 import {useGlobalModalContext} from 'context/globalModals';
-import {NetworkIndicatorStatus} from 'utils/types';
 import {replaceNetworkParam} from 'utils/paths';
 import {selectedDAO} from 'context/apolloClient';
 import {useReactiveVar} from '@apollo/client';
@@ -19,7 +18,6 @@ import {useNetwork} from 'context/network';
 const MIN_ROUTE_DEPTH_FOR_BREADCRUMBS = 2;
 
 type DesktopNavProp = {
-  status?: NetworkIndicatorStatus;
   returnURL?: string;
   processLabel?: string;
   onWalletClick: () => void;
@@ -48,7 +46,7 @@ const DesktopNav: React.FC<DesktopNavProp> = props => {
   if (isProcess) {
     return (
       <Container data-testid="navbar">
-        <NetworkIndicator status={props.status} />
+        <NetworkIndicator />
         <Menu>
           <Breadcrumb
             crumbs={{label: props.processLabel!, path: props.returnURL!}}
@@ -70,7 +68,7 @@ const DesktopNav: React.FC<DesktopNavProp> = props => {
 
   return (
     <Container data-testid="navbar">
-      <NetworkIndicator status={props.status} />
+      <NetworkIndicator />
       <Menu>
         <Content>
           <CardDao

--- a/packages/web-app/src/containers/navbar/index.tsx
+++ b/packages/web-app/src/containers/navbar/index.tsx
@@ -15,11 +15,11 @@ import {i18n} from '../../../i18n.config';
 import MobileNav from './mobile';
 import useScreen from 'hooks/useScreen';
 import DesktopNav from './desktop';
-import {CHAIN_METADATA} from 'utils/constants';
-import {useNetwork} from 'context/network';
 import {useWallet} from 'hooks/useWallet';
 import {useGlobalModalContext} from 'context/globalModals';
 
+// TODO is this stuff really only used in the Desktop version of the Navbar? If
+// so, it should be moved there.
 type StringIndexed = {[key: string]: {processLabel: string; returnURL: string}};
 
 const processPaths = [
@@ -49,26 +49,12 @@ const Navbar: React.FC = () => {
   const {open} = useGlobalModalContext();
   const {pathname} = useLocation();
   const {isDesktop} = useScreen();
-  const {network} = useNetwork();
   const {methods, isConnected} = useWallet();
 
   const processName = useMemo(() => {
     const results = matchRoutes(processPaths, pathname);
     if (results) return results[0].route.path;
   }, [pathname]);
-
-  // NOTE: Since the wallet is no longer the determining factor for the app's
-  // network, this logic needs to be reconsidered. Currently, the app can no
-  // longer be on an "unsupported network" (the user would be redirected to a
-  // "not found" page instead). So the status currently really just shows
-  // whether the app operates on a testnet or on a mainnet ("default").
-  const status = useMemo(() => {
-    if (CHAIN_METADATA[network].testnet) {
-      return 'testnet';
-    } else {
-      return 'default';
-    }
-  }, [network]);
 
   const handleWalletButtonClick = () => {
     if (isConnected) {
@@ -82,15 +68,16 @@ const Navbar: React.FC = () => {
     });
   };
 
-  return isDesktop ? (
-    <DesktopNav
-      status={status}
-      {...(processName ? {...processes[processName]} : {})}
-      onWalletClick={handleWalletButtonClick}
-    />
-  ) : (
+  if (isDesktop) {
+    return (
+      <DesktopNav
+        {...(processName ? {...processes[processName]} : {})}
+        onWalletClick={handleWalletButtonClick}
+      />
+    );
+  }
+  return (
     <MobileNav
-      status={status}
       isProcess={processName !== undefined}
       onWalletClick={handleWalletButtonClick}
     />

--- a/packages/web-app/src/containers/navbar/mobile.tsx
+++ b/packages/web-app/src/containers/navbar/mobile.tsx
@@ -27,7 +27,7 @@ const MobileNav: React.FC<MobileNavProps> = props => {
   const {open} = useGlobalModalContext();
   const {isMobile} = useScreen();
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const {isConnected, account, ensName, ensAvatarUrl} = useWallet();
+  const {isConnected, address, ensName, ensAvatarUrl} = useWallet();
 
   if (props.isProcess)
     return (
@@ -66,11 +66,11 @@ const MobileNav: React.FC<MobileNavProps> = props => {
           </FlexOne>
           <FlexOne className="justify-end">
             <ButtonWallet
-              src={ensAvatarUrl || account}
+              src={ensAvatarUrl || address}
               onClick={props.onWalletClick}
               isConnected={isConnected}
               label={
-                isConnected ? ensName || account : t('navButtons.connectWallet')
+                isConnected ? ensName || address : t('navButtons.connectWallet')
               }
             />
           </FlexOne>

--- a/packages/web-app/src/containers/navbar/mobile.tsx
+++ b/packages/web-app/src/containers/navbar/mobile.tsx
@@ -14,10 +14,8 @@ import MobileMenu from './mobileMenu';
 import {useWallet} from 'hooks/useWallet';
 import NetworkIndicator from './networkIndicator';
 import {useGlobalModalContext} from 'context/globalModals';
-import {NetworkIndicatorStatus} from 'utils/types';
 
 type MobileNavProps = {
-  status?: NetworkIndicatorStatus;
   isProcess?: boolean;
   onWalletClick: () => void;
 };
@@ -32,7 +30,7 @@ const MobileNav: React.FC<MobileNavProps> = props => {
   if (props.isProcess)
     return (
       <Container>
-        <NetworkIndicator status={props.status} />
+        <NetworkIndicator />
       </Container>
     );
 
@@ -75,7 +73,7 @@ const MobileNav: React.FC<MobileNavProps> = props => {
             />
           </FlexOne>
         </Menu>
-        <NetworkIndicator status={props.status} />
+        <NetworkIndicator />
       </Container>
       <MobileMenu isOpen={isOpen} onClose={() => setIsOpen(false)} />
     </>

--- a/packages/web-app/src/containers/navbar/networkIndicator.tsx
+++ b/packages/web-app/src/containers/navbar/networkIndicator.tsx
@@ -1,24 +1,17 @@
 import React from 'react';
 import {AlertBanner} from '@aragon/ui-components';
 import {useTranslation} from 'react-i18next';
+import {useWallet} from 'hooks/useWallet';
 
-import {NetworkIndicatorStatus} from 'utils/types';
-
-type IndicatorProps = {
-  status?: NetworkIndicatorStatus;
-};
-
-const NetworkIndicator: React.FC<IndicatorProps> = ({status = 'default'}) => {
+const NetworkIndicator: React.FC = () => {
+  const {isOnWrongNetwork} = useWallet();
   const {t} = useTranslation();
 
-  switch (status) {
-    case 'testnet':
-      return <AlertBanner label={t('alert.testNet')} />;
-    case 'unsupported':
-      return <AlertBanner label={t('alert.unsupportedNet')} mode="critical" />;
-    default:
-      return null;
-  }
+  if (isOnWrongNetwork)
+    return (
+      <AlertBanner label={t('alert.wrongWalletNetwork')} mode={'warning'} />
+    );
+  return null;
 };
 
 export default NetworkIndicator;

--- a/packages/web-app/src/containers/setupCommunity/index.tsx
+++ b/packages/web-app/src/containers/setupCommunity/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import {useTranslation} from 'react-i18next';
-import {CheckboxListItem, Label, AlertCard} from '@aragon/ui-components';
+import {AlertCard, CheckboxListItem, Label} from '@aragon/ui-components/src';
 import {Controller, useFormContext, useWatch} from 'react-hook-form';
 import ExistingTokenPartialForm from './addExistingToken';
 import CreateNewToken from './createNewToken';

--- a/packages/web-app/src/containers/walletMenu/index.tsx
+++ b/packages/web-app/src/containers/walletMenu/index.tsx
@@ -8,7 +8,7 @@ import {useWalletMenuContext} from 'context/walletMenu';
 
 const WalletMenu: React.FC = () => {
   const {isOpen, close} = useWalletMenuContext();
-  const {methods, account, ensName, ensAvatarUrl} = useWallet();
+  const {methods, address, ensName, ensAvatarUrl} = useWallet();
 
   return (
     <ModalBottomSheetSwitcher
@@ -19,9 +19,9 @@ const WalletMenu: React.FC = () => {
       <Container>
         <CardWallet
           wide
-          src={ensAvatarUrl || account}
+          src={ensAvatarUrl || address}
           name={ensName}
-          address={account}
+          address={address}
         />
         <ActionContainer>
           <ActionListItem

--- a/packages/web-app/src/hooks/useWallet.tsx
+++ b/packages/web-app/src/hooks/useWallet.tsx
@@ -1,16 +1,12 @@
 import {useSigner, SignerValue} from 'use-signer';
 import {useEffect, useState} from 'react';
 import {BigNumber} from 'ethers';
-import {Network} from '@ethersproject/networks';
 
 export interface IUseWallet extends SignerValue {
   balance: BigNumber | null;
   ensAvatarUrl: string;
   ensName: string;
   isConnected: boolean;
-  networkName: string;
-  // equal value to address
-  account: string | null;
 }
 
 export const useWallet = (): IUseWallet => {
@@ -18,7 +14,6 @@ export const useWallet = (): IUseWallet => {
   const [balance, setBalance] = useState<BigNumber | null>(null);
   const [ensName, setEnsName] = useState<string>('');
   const [ensAvatarUrl, setEnsAvatarUrl] = useState<string>('');
-  const [networkName, setNetworkName] = useState<string>('');
   const [isConnected, setIsConnected] = useState<boolean>(false);
 
   // Update balance
@@ -47,27 +42,16 @@ export const useWallet = (): IUseWallet => {
     setIsConnected(status === 'connected');
   }, [status]);
 
-  // update networkName
-  useEffect(() => {
-    if (provider) {
-      provider?.getNetwork().then((network: Network) => {
-        setNetworkName(network.name);
-      });
-    }
-  }, [provider, chainId]);
-
   return {
     provider,
     signer,
     status,
     address,
-    account: address,
     chainId,
     balance,
     ensAvatarUrl,
     ensName,
     isConnected,
-    networkName,
     methods,
   };
 };

--- a/packages/web-app/src/hooks/useWallet.tsx
+++ b/packages/web-app/src/hooks/useWallet.tsx
@@ -1,15 +1,24 @@
 import {useSigner, SignerValue} from 'use-signer';
 import {useEffect, useState} from 'react';
 import {BigNumber} from 'ethers';
+import {useNetwork} from 'context/network';
+import {CHAIN_METADATA} from 'utils/constants';
 
 export interface IUseWallet extends SignerValue {
   balance: BigNumber | null;
   ensAvatarUrl: string;
   ensName: string;
   isConnected: boolean;
+  /**
+   * Returns true iff the wallet is connected and it is on the wrong network
+   * (i.e., the chainId returned by the useSigner context does not agree with
+   * the network name returned by the useNetwork context).
+   */
+  isOnWrongNetwork: boolean;
 }
 
 export const useWallet = (): IUseWallet => {
+  const {network} = useNetwork();
   const {chainId, methods, signer, provider, address, status} = useSigner();
   const [balance, setBalance] = useState<BigNumber | null>(null);
   const [ensName, setEnsName] = useState<string>('');
@@ -42,6 +51,9 @@ export const useWallet = (): IUseWallet => {
     setIsConnected(status === 'connected');
   }, [status]);
 
+  const isOnWrongNetwork =
+    isConnected && CHAIN_METADATA[network].id !== chainId;
+
   return {
     provider,
     signer,
@@ -52,6 +64,7 @@ export const useWallet = (): IUseWallet => {
     ensAvatarUrl,
     ensName,
     isConnected,
+    isOnWrongNetwork,
     methods,
   };
 };

--- a/packages/web-app/src/hooks/useWalletTokens.tsx
+++ b/packages/web-app/src/hooks/useWalletTokens.tsx
@@ -19,7 +19,7 @@ import {TokenBalance, HookData} from 'utils/types';
  * has balance.
  */
 export function useUserTokenAddresses(): HookData<string[]> {
-  const {account} = useWallet();
+  const {address} = useWallet();
   const {web3} = useProviders();
 
   const [tokenList, setTokenList] = useState<string[]>([]);
@@ -30,7 +30,7 @@ export function useUserTokenAddresses(): HookData<string[]> {
     async function fetchTokenList() {
       setIsLoading(true);
 
-      if (web3 && account) {
+      if (web3 && address) {
         try {
           const erc20Interface = new Interface(erc20TokenABI);
           const latestBlockNumber = await web3.getBlockNumber();
@@ -42,7 +42,7 @@ export function useUserTokenAddresses(): HookData<string[]> {
             topics: [
               erc20Interface.getEventTopic('Transfer'),
               null,
-              hexZeroPad(account as string, 32),
+              hexZeroPad(address as string, 32),
             ],
           });
           // Filter unique token contract addresses and convert all events to Contract instances
@@ -67,7 +67,7 @@ export function useUserTokenAddresses(): HookData<string[]> {
     }
 
     fetchTokenList();
-  }, [account, web3]);
+  }, [address, web3]);
 
   return {data: tokenList, isLoading, error};
 }
@@ -79,7 +79,7 @@ export function useUserTokenAddresses(): HookData<string[]> {
  * contract address it also returns the user's balance for each of the tokens.
  */
 export function useWalletTokens(): HookData<TokenBalance[]> {
-  const {account, balance} = useWallet();
+  const {address, balance} = useWallet();
   const {infura: provider} = useProviders();
   const {
     data: tokenList,
@@ -95,7 +95,7 @@ export function useWalletTokens(): HookData<TokenBalance[]> {
   useEffect(() => {
     async function fetchWalletTokens() {
       setIsLoading(true);
-      if (account === null || provider === null) {
+      if (address === null || provider === null) {
         setWalletTokens([]);
         return;
       }
@@ -125,7 +125,7 @@ export function useWalletTokens(): HookData<TokenBalance[]> {
           }
 
           return Promise.all([
-            fetchBalance(address, account, provider, false),
+            fetchBalance(address, address, provider, false),
             getTokenInfo(address, provider),
           ]);
         })
@@ -152,7 +152,7 @@ export function useWalletTokens(): HookData<TokenBalance[]> {
       return;
     }
     fetchWalletTokens();
-  }, [account, balance, tokenList, provider, tokenListLoading, tokenListError]);
+  }, [address, balance, tokenList, provider, tokenListLoading, tokenListError]);
 
   return {data: walletTokens, isLoading: tokenListLoading || isLoading, error};
 }

--- a/packages/web-app/src/locales/en/common.json
+++ b/packages/web-app/src/locales/en/common.json
@@ -217,8 +217,7 @@
   },
   "alert": {
     "durationAlert": "We recommend a minimum duration of 1 day if it does not have to be a quick financial decision.",
-    "testNet": "Testnet Active",
-    "unsupportedNet": "Network Not Supported"
+    "wrongWalletNetwork": "Wrong Wallet Network"
   },
   "warnings": {
     "amountGtDaoToken": "Withdraw amount is greater than the current token balance"

--- a/packages/web-app/src/pages/newDeposit.tsx
+++ b/packages/web-app/src/pages/newDeposit.tsx
@@ -37,7 +37,7 @@ const defaultValues = {
 
 const NewDeposit: React.FC = () => {
   const {t} = useTranslation();
-  const {account} = useWallet();
+  const {address} = useWallet();
   const formMethods = useForm<DepositFormData>({
     defaultValues,
     mode: 'onChange',
@@ -50,10 +50,10 @@ const NewDeposit: React.FC = () => {
 
   useEffect(() => {
     // add form metadata
-    if (account) {
-      formMethods.setValue('from', account);
+    if (address) {
+      formMethods.setValue('from', address);
     }
-  }, [account, formMethods]);
+  }, [address, formMethods]);
 
   /*************************************************
    *             Callbacks and Handlers            *

--- a/packages/web-app/src/pages/newProposal.tsx
+++ b/packages/web-app/src/pages/newProposal.tsx
@@ -29,17 +29,17 @@ const NewProposal: React.FC = () => {
   const {errors, dirtyFields} = useFormState({
     control: formMethods.control,
   });
-  const {account} = useWallet();
+  const {address} = useWallet();
   const [durationSwitch] = formMethods.getValues(['durationSwitch']);
 
   // TODO: Sepehr, is this still necessary?
   useEffect(() => {
-    if (account) {
+    if (address) {
       // TODO: Change from to proper address
       formMethods.setValue('from', constants.AddressZero);
       formMethods.setValue('type', TransferTypes.Withdraw);
     }
-  }, [account, formMethods]);
+  }, [address, formMethods]);
 
   /*************************************************
    *                    Render                     *

--- a/packages/web-app/src/utils/types.ts
+++ b/packages/web-app/src/utils/types.ts
@@ -201,8 +201,6 @@ export type TransactionItem = {
   };
 };
 
-export type NetworkIndicatorStatus = 'default' | 'testnet' | 'unsupported';
-
 export type StringIndexed = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;


### PR DESCRIPTION
## Description

Adds an indicator that warns the user if the wallet's network is different from the application network. This is necessary because the source of truth for the network is now the app, rather than the wallet. For example, if a user is on `/ethereum/finance/` but has their wallet connected to `Rinkeby`, an alert banner (warning) is displayed. The banner then vanishes if the user changes their wallet to the correct network.

Task: [305](https://aragonassociation.atlassian.net/jira/software/c/projects/APP/boards/41?modal=detail&selectedIssue=APP-305)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.