### PR TITLE
Fix: Disconnect modal font-size

### DIFF
--- a/packages/web-app/src/containers/navbar/walletMenu.tsx
+++ b/packages/web-app/src/containers/navbar/walletMenu.tsx
@@ -41,8 +41,8 @@ export const WalletMenu = () => {
         <AvatarAddressContainer>
           <Avatar src={ensAvatarUrl || address || ''} size="small" />
           <AddressContainer>
-            {ensName && <Title>{ensName}</Title>}
-            <SubTitle>{shortenAddress(address)}</SubTitle>
+            <Title>{ensName ? ensName : shortenAddress(address)}</Title>
+            {ensName && <SubTitle>{shortenAddress(address)}</SubTitle>}
           </AddressContainer>
         </AvatarAddressContainer>
         <ButtonIcon
@@ -92,7 +92,7 @@ const Title = styled.div.attrs({
   className: 'flex-1 font-bold text-ui-800',
 })``;
 const SubTitle = styled.div.attrs({
-  className: 'flex-1 font-medium text-ui-500 text-xs',
+  className: 'flex-1 font-medium text-ui-500 text-sm',
 })``;
 const AvatarAddressContainer = styled.div.attrs({
   className: 'flex flex-1 gap-1.5 items-center',


### PR DESCRIPTION
## Description

The font size on the disconnect modal was not correct when the user had no ens name associated

Task: [APP-18](https://aragonassociation.atlassian.net/browse/APP-18)

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.