### PR TITLE
Feature: Fetch existing token on erc20 Voting DAO creation

### DIFF
--- a/packages/web-app/src/containers/setupCommunity/addExistingToken.tsx
+++ b/packages/web-app/src/containers/setupCommunity/addExistingToken.tsx
@@ -12,7 +12,7 @@ import styled from 'styled-components';
 import {chains} from 'use-wallet';
 import {ChainInformation} from 'use-wallet/dist/cjs/types';
 
-import {useProviders} from 'context/providers';
+import {useSpecificProvider} from 'context/providers';
 import {formatUnits} from 'utils/library';
 import {getTokenInfo} from 'utils/tokens';
 import {validateTokenAddress} from 'utils/validators';
@@ -21,7 +21,6 @@ const DEFAULT_BLOCK_EXPLORER = 'https://etherscan.io/';
 
 const AddExistingToken: React.FC = () => {
   const {t} = useTranslation();
-  const {getCustomProvider} = useProviders();
   const {control, setValue, trigger} = useFormContext();
 
   const [tokenAddress, blockchain, tokenName, tokenSymbol, tokenTotalSupply] =
@@ -35,11 +34,7 @@ const AddExistingToken: React.FC = () => {
       ],
     });
 
-  const provider = useMemo(
-    () => getCustomProvider(blockchain.id),
-    [blockchain.id, getCustomProvider]
-  );
-
+  const provider = useSpecificProvider(blockchain.id);
   const explorer = useMemo(() => {
     if (blockchain.id) {
       // TODO move necessary information from useWallet's ChainInformation into
@@ -134,7 +129,6 @@ const AddExistingToken: React.FC = () => {
         />
         {tokenName && tokenAddress && (
           <TokenInfoContainer>
-            {console.log(tokenName)}
             <InfoContainer>
               <Label label={t('labels.tokenName')} />
               <TextInput disabled value={tokenName || ''} />
@@ -147,11 +141,10 @@ const AddExistingToken: React.FC = () => {
               <Label label={t('labels.supply')} />
               <TextInput
                 disabled
-                value={
-                  new Intl.NumberFormat('en-US', {
-                    maximumFractionDigits: 4,
-                  }).format(tokenTotalSupply) || ''
-                }
+                defaultValue=""
+                value={new Intl.NumberFormat('en-US', {
+                  maximumFractionDigits: 4,
+                }).format(tokenTotalSupply)}
               />
             </InfoContainer>
           </TokenInfoContainer>

--- a/packages/web-app/src/containers/setupCommunity/addExistingToken.tsx
+++ b/packages/web-app/src/containers/setupCommunity/addExistingToken.tsx
@@ -13,18 +13,15 @@ import {chains} from 'use-wallet';
 import {ChainInformation} from 'use-wallet/dist/cjs/types';
 
 import {useProviders} from 'context/providers';
-import {useNetwork} from 'context/network';
 import {formatUnits} from 'utils/library';
 import {getTokenInfo} from 'utils/tokens';
 import {validateTokenAddress} from 'utils/validators';
-import {CHAIN_METADATA} from 'utils/constants';
 
 const DEFAULT_BLOCK_EXPLORER = 'https://etherscan.io/';
 
 const AddExistingToken: React.FC = () => {
   const {t} = useTranslation();
-  const {network} = useNetwork();
-  const {infura: provider} = useProviders();
+  const {getCustomProvider} = useProviders();
   const {control, setValue, trigger} = useFormContext();
 
   const [tokenAddress, blockchain, tokenName, tokenSymbol, tokenTotalSupply] =
@@ -38,7 +35,11 @@ const AddExistingToken: React.FC = () => {
       ],
     });
 
-  const chainId = CHAIN_METADATA[network].id;
+  const provider = useMemo(
+    () => getCustomProvider(blockchain.id),
+    [blockchain.id, getCustomProvider]
+  );
+
   const explorer = useMemo(() => {
     if (blockchain.id) {
       // TODO move necessary information from useWallet's ChainInformation into
@@ -54,10 +55,10 @@ const AddExistingToken: React.FC = () => {
 
   // Trigger address validation on network change
   useEffect(() => {
-    if (blockchain.id && tokenAddress !== '' && !tokenSymbol) {
+    if (blockchain.id && tokenAddress !== '') {
       trigger('tokenAddress');
     }
-  }, [blockchain.id, chainId, tokenAddress, tokenSymbol, trigger]);
+  }, [blockchain.id, tokenAddress, trigger]);
 
   /*************************************************
    *            Functions and Callbacks            *
@@ -131,23 +132,26 @@ const AddExistingToken: React.FC = () => {
             </>
           )}
         />
-        {tokenName && (
+        {tokenName && tokenAddress && (
           <TokenInfoContainer>
+            {console.log(tokenName)}
             <InfoContainer>
               <Label label={t('labels.tokenName')} />
-              <TextInput disabled value={tokenName} />
+              <TextInput disabled value={tokenName || ''} />
             </InfoContainer>
             <InfoContainer>
               <Label label={t('labels.tokenSymbol')} />
-              <TextInput disabled value={tokenSymbol} />
+              <TextInput disabled value={tokenSymbol || ''} />
             </InfoContainer>
             <InfoContainer>
               <Label label={t('labels.supply')} />
               <TextInput
                 disabled
-                value={new Intl.NumberFormat('en-US', {
-                  maximumFractionDigits: 4,
-                }).format(tokenTotalSupply)}
+                value={
+                  new Intl.NumberFormat('en-US', {
+                    maximumFractionDigits: 4,
+                  }).format(tokenTotalSupply) || ''
+                }
               />
             </InfoContainer>
           </TokenInfoContainer>


### PR DESCRIPTION
## Description

- Adds the ability to fetch existing token from all supported networks when creating an ERC20 voting DAO
- Fixes uncontrolled component warnings

Task: [APP-380](https://aragonassociation.atlassian.net/browse/APP-380)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have tested my code on the test network.