### PR TITLE
App 486 redirect on other networks

### DIFF
--- a/packages/web-app/src/context/apolloClient.tsx
+++ b/packages/web-app/src/context/apolloClient.tsx
@@ -1,7 +1,13 @@
-import {ApolloClient, HttpLink, InMemoryCache, makeVar} from '@apollo/client';
+import {
+  ApolloClient,
+  HttpLink,
+  InMemoryCache,
+  makeVar,
+  NormalizedCacheObject,
+} from '@apollo/client';
 import {RestLink} from 'apollo-link-rest';
 import {CachePersistor, LocalStorageWrapper} from 'apollo3-cache-persist';
-import {BASE_URL, SUBGRAPH_API_URL} from 'utils/constants';
+import {BASE_URL, SUBGRAPH_API_URL, SupportedNetworks} from 'utils/constants';
 import {PRIVACY_KEY} from './privacyContext';
 
 const restLink = new RestLink({
@@ -69,7 +75,7 @@ if (value && JSON.parse(value).functional) {
   restoreApolloCache();
 }
 
-const rinkebyClient = new ApolloClient({
+export const rinkebyClient = new ApolloClient({
   cache,
   link: restLink.concat(new HttpLink({uri: SUBGRAPH_API_URL['rinkeby']})),
 });
@@ -84,13 +90,17 @@ const arbitrumTestClient = new ApolloClient({
   link: restLink.concat(new HttpLink({uri: SUBGRAPH_API_URL['arbitrum-test']})),
 });
 
-const client = {
-  main: undefined,
+// TODO: remove undefined when all clients are defined
+const client: Record<
+  SupportedNetworks,
+  ApolloClient<NormalizedCacheObject> | undefined
+> = {
+  ethereum: undefined,
   rinkeby: rinkebyClient,
   polygon: undefined,
   mumbai: mumbaiClient,
   arbitrum: undefined,
-  arbitrumTest: arbitrumTestClient,
+  'arbitrum-test': arbitrumTestClient,
 };
 
 type favoriteDAO = {

--- a/packages/web-app/src/hooks/useDaoParam.tsx
+++ b/packages/web-app/src/hooks/useDaoParam.tsx
@@ -1,4 +1,6 @@
 import {useQuery} from '@apollo/client';
+import {client} from 'context/apolloClient';
+import {useNetwork} from 'context/network';
 import {DAO_BY_ADDRESS} from 'queries/dao';
 import {useEffect} from 'react';
 import {useNavigate, useParams} from 'react-router-dom';
@@ -14,9 +16,13 @@ import {NotFound} from 'utils/paths';
  */
 export function useDaoParam() {
   const {dao} = useParams();
+  const {network} = useNetwork();
+
   // NOTE At this point, daoParam will always be defined.
   const {data, error, loading} = useQuery(DAO_BY_ADDRESS, {
     variables: {id: dao ? dao : ''},
+    client: client[network],
+    fetchPolicy: 'no-cache',
   });
   const navigate = useNavigate();
 
@@ -26,7 +32,7 @@ export function useDaoParam() {
     } else if (error || !data?.dao?.id) {
       navigate(NotFound, {replace: true, state: {incorrectDao: dao}});
     }
-  }, [loading, dao]); // eslint-disable-line
+  }, [loading, dao, network]); // eslint-disable-line
 
   return {data: data?.dao?.id, error, loading};
 }

--- a/packages/web-app/src/index.tsx
+++ b/packages/web-app/src/index.tsx
@@ -13,7 +13,7 @@ import {NetworkProvider} from 'context/network';
 import {UseSignerProvider} from 'use-signer';
 import {IProviderOptions} from 'web3modal';
 import WalletConnectProvider from '@walletconnect/web3-provider/dist/umd/index.min.js';
-import {client} from 'context/apolloClient';
+import {client, rinkebyClient} from 'context/apolloClient';
 import 'tailwindcss/tailwind.css';
 import {UseCacheProvider} from 'hooks/useCache';
 import {UseClientProvider} from 'hooks/useClient';
@@ -44,7 +44,9 @@ ReactDOM.render(
                         <GlobalModalsProvider>
                           {/* By default, rinkeby client is chosen, each useQuery needs to pass the network client it needs as argument
                       For REST queries using apollo, there's no need to pass a different client to useQuery  */}
-                          <ApolloProvider client={client['rinkeby']}>
+                          <ApolloProvider
+                            client={client['rinkeby'] || rinkebyClient} //TODO remove fallback when all clients are defined
+                          >
                             <App />
                           </ApolloProvider>
                         </GlobalModalsProvider>


### PR DESCRIPTION
## Description

Fix DAO parameter validation on network change. When changing the network parameter, the query to check the DAO parameter would still be done w.r.t. to Rinkeby. Now the query happens w.r.t. the current network (parameter).
 
Task: [486](https://aragonassociation.atlassian.net/browse/APP-486?atlOrigin=eyJpIjoiNTEzODcwOWI4MjhhNDZmYTk5ZGM3OTc3MjQwYTljNTEiLCJwIjoiaiJ9)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have tested my code on the test network.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.