### PR TITLE
Feature: App-494 - Dao Page Routing

### DIFF
--- a/packages/web-app/src/app.tsx
+++ b/packages/web-app/src/app.tsx
@@ -84,6 +84,8 @@ function App() {
               <Route path="community" element={<CommunityPage />} />
               <Route path="settings" element={<SettingsPage />} />
               <Route path="settings/edit" element={<EditSettingsPage />} />
+              {/* Redirects the user to the dashboard page by default if no dao-specific page is specified. */}
+              <Route index element={<Navigate to={'dashboard'} replace />} />
             </Route>
           </Route>
           <Route path={NotFound} element={<NotFoundPage />} />

--- a/packages/web-app/src/pages/editSettings.tsx
+++ b/packages/web-app/src/pages/editSettings.tsx
@@ -18,6 +18,7 @@ import ConfigureCommunity from 'containers/configureCommunity';
 import {useMappedBreadcrumbs} from 'hooks/useMappedBreadcrumbs';
 import useScreen from 'hooks/useScreen';
 import {useDaoParam} from 'hooks/useDaoParam';
+import {Loading} from 'components/temporary';
 
 const defaultValues = {
   links: [{label: '', href: ''}],
@@ -33,12 +34,16 @@ const EditSettings: React.FC = () => {
   const {t} = useTranslation();
   const navigate = useNavigate();
   const {isMobile} = useScreen();
-  const {} = useDaoParam();
+  const {loading} = useDaoParam();
   const {breadcrumbs, icon} = useMappedBreadcrumbs();
   const formMethods = useForm({
     mode: 'onChange',
     defaultValues,
   });
+
+  if (loading) {
+    return <Loading />;
+  }
 
   return (
     <FormProvider {...formMethods}>

--- a/packages/web-app/src/pages/editSettings.tsx
+++ b/packages/web-app/src/pages/editSettings.tsx
@@ -17,6 +17,7 @@ import DefineMetadata from 'containers/defineMetadata';
 import ConfigureCommunity from 'containers/configureCommunity';
 import {useMappedBreadcrumbs} from 'hooks/useMappedBreadcrumbs';
 import useScreen from 'hooks/useScreen';
+import {useDaoParam} from 'hooks/useDaoParam';
 
 const defaultValues = {
   links: [{label: '', href: ''}],
@@ -32,6 +33,7 @@ const EditSettings: React.FC = () => {
   const {t} = useTranslation();
   const navigate = useNavigate();
   const {isMobile} = useScreen();
+  const {} = useDaoParam();
   const {breadcrumbs, icon} = useMappedBreadcrumbs();
   const formMethods = useForm({
     mode: 'onChange',

--- a/packages/web-app/src/pages/explore.tsx
+++ b/packages/web-app/src/pages/explore.tsx
@@ -13,8 +13,8 @@ import ActiveProposalsExplore from 'containers/activeProposalsExplore';
 import {GridLayout} from 'components/layout';
 
 const existingDaos = [
-  '0x07de9a02a1c7e09bae5b15b7270e5b1ba2029bfd',
-  '0xf1ce79a45615ce1d32af6422ed77b9b7ffc35c88',
+  '0x74db053cac4e803096e912251cf3e847ae92b8ba',
+  '0xa125220cce787500d3fc8bff83a959a3a84fe4f4',
 ];
 
 const Explore: React.FC = () => {


### PR DESCRIPTION
## Description

This PR introduces an automatic redirecting for users that enter URLs of type `/#/<network>/<daoId>/`. Since there is no page to these paths, users would be sent to `not-found`. Instead, users are sent to the DAO's dashboard, with the path `/#/<network>/<daoId>/dashboard`.

Task: [494](https://aragonassociation.atlassian.net/browse/APP-494?atlOrigin=eyJpIjoiYmJhYzg0MWI0ODAyNGI3ZTlhYTE3Yjc5YzhkOWJkM2EiLCJwIjoiaiJ9)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code on the test network.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.