### PR TITLE
fix mainnet dao id validation

### DIFF
--- a/packages/web-app/src/hooks/useDaoParam.tsx
+++ b/packages/web-app/src/hooks/useDaoParam.tsx
@@ -27,6 +27,13 @@ export function useDaoParam() {
   const navigate = useNavigate();
 
   useEffect(() => {
+    // undefined mainnet clients cause problem here. This bypasses the dao param
+    // validation on mainnets and immediately redirects to notfound (which makes
+    // sense since there can not yet be daos on mainnets). Remove this if
+    // statement once those clients are implemented.
+    if (!client[network])
+      navigate(NotFound, {replace: true, state: {incorrectDao: dao}});
+
     if (loading) {
       return;
     } else if (error || !data?.dao?.id) {


### PR DESCRIPTION
## Description

Makes app react to changes in the URL's network parameter (i.e., it revalidates the dao parameter with respect to the new network if the network is changed in the URL). To test that this works:
- select an existing DAO
- visit any of its pages
- change the network in the URL
- This should redirect you to not-found, as the dao with the same id does most likely not exist on another testnet and certainly doesn't exist on mainnet.

Task: [494](https://aragonassociation.atlassian.net/browse/APP-494)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
