### PR TITLE
Fix: Show newly completed transfer

### DIFF
--- a/packages/web-app/src/context/deposit.tsx
+++ b/packages/web-app/src/context/deposit.tsx
@@ -66,7 +66,9 @@ const DepositProvider = ({children}: {children: ReactNode}) => {
       case TransactionState.LOADING:
         break;
       case TransactionState.SUCCESS:
-        navigate(generatePath(Finance, {network, dao}));
+        navigate(generatePath(Finance, {network, dao}), {
+          state: {refetch: true},
+        });
         break;
       default:
         setShowModal(false);

--- a/packages/web-app/src/hooks/useDaoBalances.tsx
+++ b/packages/web-app/src/hooks/useDaoBalances.tsx
@@ -7,6 +7,7 @@ import {DAO_BALANCE_LIST} from 'queries/finances';
 export const useDaoBalances = (daoAddress: Address) => {
   const {data, error, loading, refetch} = useQuery(DAO_BALANCE_LIST, {
     variables: {dao: daoAddress},
+    fetchPolicy: 'no-cache',
   });
 
   return {

--- a/packages/web-app/src/hooks/useDaoProposals.tsx
+++ b/packages/web-app/src/hooks/useDaoProposals.tsx
@@ -65,7 +65,6 @@ const MOCK_PROPOSALS: MockProposal[] = [
     tokenAmount: '3.5M',
     tokenSymbol: 'DNT',
     publishLabel: 'Published by',
-    daoName: 'Lorex DAO',
     publisherAddress: '0x374d444487A4602750CA00EFdaC5d22B21F130E1',
     alertMessage: '5 days left',
     stateLabel: [

--- a/packages/web-app/src/hooks/useDaoTransfers.tsx
+++ b/packages/web-app/src/hooks/useDaoTransfers.tsx
@@ -8,6 +8,7 @@ import {DAO_TRANSFER_LIST} from 'queries/finances';
 export const useDaoTransfers = (daoAddress: Address) => {
   const {data, error, loading, refetch} = useQuery(DAO_TRANSFER_LIST, {
     variables: {dao: daoAddress},
+    fetchPolicy: 'no-cache',
   });
 
   const sortedData = useMemo(() => {

--- a/packages/web-app/src/hooks/useDaoVault.tsx
+++ b/packages/web-app/src/hooks/useDaoVault.tsx
@@ -16,7 +16,11 @@ import {PollTokenOptions, VaultToken} from 'utils/types';
  * @returns A list of tokens in the DAO treasury, current USD sum value of all assets,
  * and the price change in USD based on the filter. An option to manually refetch assets is included.
  */
-export const useDaoVault = (daoAddress: string, options?: PollTokenOptions) => {
+export const useDaoVault = (
+  daoAddress: string,
+  showTransfers?: boolean,
+  options?: PollTokenOptions
+) => {
   const {data: balances, refetch: refetchBalances} = useDaoBalances(daoAddress);
   const {data: transfers, refetch: refetchTransfers} =
     useDaoTransfers(daoAddress);
@@ -45,7 +49,7 @@ export const useDaoVault = (daoAddress: string, options?: PollTokenOptions) => {
     tokens,
     totalAssetValue: data.totalAssetValue,
     totalAssetChange: data.totalAssetChange,
-    transfers: transfersData,
+    transfers: showTransfers ? transfersData : [],
     refetch: useCallback(async () => {
       await refetchBalances();
       await refetchTransfers();

--- a/packages/web-app/src/hooks/useDaoVault.tsx
+++ b/packages/web-app/src/hooks/useDaoVault.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 
 import {useDaoBalances} from './useDaoBalances';
 import {useDaoTransfers} from './useDaoTransfers';
@@ -14,15 +14,12 @@ import {PollTokenOptions, VaultToken} from 'utils/types';
  * @param options.filter TimeFilter for market data
  * @param options.interval Delay in milliseconds
  * @returns A list of tokens in the DAO treasury, current USD sum value of all assets,
- * and the price change in USD based on the filter
+ * and the price change in USD based on the filter. An option to manually refetch assets is included.
  */
-export const useDaoVault = (
-  daoAddress: string,
-  showTransfers?: boolean,
-  options?: PollTokenOptions
-) => {
-  const {data: balances} = useDaoBalances(daoAddress);
-  const {data: transfers} = useDaoTransfers(daoAddress);
+export const useDaoVault = (daoAddress: string, options?: PollTokenOptions) => {
+  const {data: balances, refetch: refetchBalances} = useDaoBalances(daoAddress);
+  const {data: transfers, refetch: refetchTransfers} =
+    useDaoTransfers(daoAddress);
   const {data: tokensWithMetadata} = useTokenMetadata(balances);
   const {data} = usePollTokenPrices(tokensWithMetadata, options);
   const {data: transfersData} = usePollTransfersPrices(transfers);
@@ -48,6 +45,10 @@ export const useDaoVault = (
     tokens,
     totalAssetValue: data.totalAssetValue,
     totalAssetChange: data.totalAssetChange,
-    transfers: showTransfers ? transfersData : [],
+    transfers: transfersData,
+    refetch: useCallback(async () => {
+      await refetchBalances();
+      await refetchTransfers();
+    }, [refetchBalances, refetchTransfers]),
   };
 };

--- a/packages/web-app/src/pages/finance.tsx
+++ b/packages/web-app/src/pages/finance.tsx
@@ -34,7 +34,7 @@ const Finance: React.FC = () => {
     if (state?.refetch) {
       setTimeout(() => {
         refetch();
-      }, 5000);
+      }, 10000);
     }
   }, [refetch, state?.refetch]);
 

--- a/packages/web-app/src/pages/finance.tsx
+++ b/packages/web-app/src/pages/finance.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import styled from 'styled-components';
 import {useTranslation} from 'react-i18next';
 import {withTransaction} from '@elastic/apm-rum-react';
@@ -16,14 +16,27 @@ import {useDaoVault} from 'hooks/useDaoVault';
 import {useDaoParam} from 'hooks/useDaoParam';
 import {useGlobalModalContext} from 'context/globalModals';
 import {useTransactionDetailContext} from 'context/transactionDetail';
+import {useLocation} from 'react-router-dom';
 
 const Finance: React.FC = () => {
   const {t} = useTranslation();
   const {open} = useGlobalModalContext();
+  const {state} = useLocation();
   const {data: daoId, loading} = useDaoParam();
   const {handleTransferClicked} = useTransactionDetailContext();
-  const {tokens, totalAssetChange, totalAssetValue, transfers} =
+  const {tokens, totalAssetChange, totalAssetValue, transfers, refetch} =
     useDaoVault(daoId);
+
+  // delaying a second refresh for five seconds
+  // because subgraph doesn't immediately pick up
+  // transfer sometimes
+  useEffect(() => {
+    if (state?.refetch) {
+      setTimeout(() => {
+        refetch();
+      }, 5000);
+    }
+  }, [refetch, state?.refetch]);
 
   sortTokens(tokens, 'treasurySharePercentage');
 

--- a/packages/web-app/src/pages/finance.tsx
+++ b/packages/web-app/src/pages/finance.tsx
@@ -14,7 +14,6 @@ import {sortTokens} from 'utils/tokens';
 import TransferList from 'components/transferList';
 import {useDaoVault} from 'hooks/useDaoVault';
 import {useDaoParam} from 'hooks/useDaoParam';
-import {TemporarySection} from 'components/temporary';
 import {useGlobalModalContext} from 'context/globalModals';
 import {useTransactionDetailContext} from 'context/transactionDetail';
 
@@ -67,13 +66,6 @@ const Finance: React.FC = () => {
             />
           </ListContainer>
         </TransferSectionWrapper>
-        <TemporarySection purpose="It whether the dao parameter was properly parsed and validated.">
-          {daoId ? (
-            <p>{`DAO address: ${daoId.slice(0, 15) + '...'}`}</p>
-          ) : (
-            <p>{"Something's not right"}</p>
-          )}
-        </TemporarySection>
       </PageWrapper>
     </>
   );


### PR DESCRIPTION
## Description

- Bypasses cache when getting balances and transfers
- manually refetch after a 5 second delay to give subgraph enough time to pick up on transaction

Note: Time between successful deposit and transfer available on subgraph is variable sometimes the refetch does happen without the data available yet. Ideally, we should keep polling until the latest transfer matches up with the transaction ID we get when we successfully execute a deposit. Currently, we don't have the transaction hash yet.

Task: [APP-565](https://aragonassociation.atlassian.net/browse/APP-565)

## Type of change
<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the test network.