### PR TITLE
Feat: Keep wallet connected on page load

### DIFF
--- a/packages/web-app/package.json
+++ b/packages/web-app/package.json
@@ -46,7 +46,7 @@
     "styled-components": "^5.3.1",
     "tailwindcss-fluid-type": "^1.3.1",
     "use-react-router-breadcrumbs": "^3.0.1",
-    "use-signer": "^0.2.0",
+    "use-signer": "^0.3.0",
     "use-wallet": "^0.13.4"
   },
   "devDependencies": {

--- a/packages/web-app/src/app.tsx
+++ b/packages/web-app/src/app.tsx
@@ -49,9 +49,12 @@ function App() {
   const {methods} = useWallet();
 
   useEffect(() => {
+    // This check would prevent the wallet selection modal from opening up if the user hasn't logged in previously.
+    // But if the injected wallet like Metamask is locked and the user has logged in before using that wallet, there will be a prompt for password.
     if (localStorage.getItem('WEB3_CONNECT_CACHED_PROVIDER')) {
       methods.selectWallet();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/packages/web-app/src/app.tsx
+++ b/packages/web-app/src/app.tsx
@@ -21,6 +21,7 @@ import ExploreNav from 'containers/navbar/exploreNav';
 import Footer from 'containers/exploreFooter';
 import NetworkErrorMenu from 'containers/networkErrorMenu';
 import TransferMenu from 'containers/transferMenu';
+import {useWallet} from 'hooks/useWallet';
 
 const ExplorePage = lazy(() => import('pages/explore'));
 const NotFoundPage = lazy(() => import('pages/notFound'));
@@ -45,6 +46,13 @@ function App() {
   // TODO this needs to be inside a Routes component. Will be moved there with
   // further refactoring of layout (see further below).
   const {pathname} = useLocation();
+  const {methods} = useWallet();
+
+  useEffect(() => {
+    if (localStorage.getItem('WEB3_CONNECT_CACHED_PROVIDER')) {
+      methods.selectWallet();
+    }
+  }, []);
 
   useEffect(() => {
     trackPage(pathname);

--- a/packages/web-app/src/containers/walletMenu/index.tsx
+++ b/packages/web-app/src/containers/walletMenu/index.tsx
@@ -31,6 +31,7 @@ export const WalletMenu = () => {
     methods
       .disconnect()
       .then(() => {
+        localStorage.removeItem('WEB3_CONNECT_CACHED_PROVIDER');
         close('wallet');
       })
       .catch((e: Error) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23274,10 +23274,10 @@ use-sidecar@^1.0.1, use-sidecar@^1.0.5:
     detect-node-es "^1.1.0"
     tslib "^1.9.3"
 
-use-signer@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/use-signer/-/use-signer-0.2.0.tgz#62a3cda5815a40d28115c819cd7963aad1cec0d4"
-  integrity sha512-g1fsdOtsG6MKfQJfOwJAyQTRgheIPFAZXs84sMasB0lyB79io29vBtUgVe0XMQcSdXAJUSW4gVMCeKq/4GBO8Q==
+use-signer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/use-signer/-/use-signer-0.3.0.tgz#a87399975178456d48fef67ab1eab0de9b5f2b33"
+  integrity sha512-mdxG+LjCxHbqT+t+RoLWRw3zbPDL28ONfA72JYzGwHBurSHLOD7j0YGQe+Y1mw2whodnswhBu+gM08gsvV0L9Q==
   dependencies:
     "@ethersproject/providers" "^5.5.3"
     "@walletconnect/web3-provider" "^1.7.4"


### PR DESCRIPTION
## Description

The wallet selector popup appears only after you click logout from the app and try to login again. Otherwise, it will always try to automatically connect to the last connected wallet(asks for password if you are locked out of the wallet, if the wallet is unlocked, then it's connected silently)

Task: [APP-487](https://aragonassociation.atlassian.net/browse/APP-487)

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.