### PR TITLE
fix: allow vertical movement in mobile

### DIFF
--- a/packages/web-app/src/containers/carousel/index.tsx
+++ b/packages/web-app/src/containers/carousel/index.tsx
@@ -61,6 +61,8 @@ const Carousel: React.FC = () => {
           emulateTouch
           centerMode
           autoPlay
+          preventMovementUntilSwipeScrollTolerance
+          swipeScrollTolerance={100}
           interval={4000}
           showArrows={false}
           showStatus={false}


### PR DESCRIPTION
## Description

Our mobile carousel is hijacking the scroll behavior when user clicks to scroll the page. Although expected for horizontal movements, it shouldn’t be true for vertical ones

Note: There's a *very small* horizontal drag that doesn't make it perfectly smooth, that said, this only affects mobile and other solutions would mean changing the carousel, which is less than ideal

Task: [676](https://aragonassociation.atlassian.net/browse/APP-676?atlOrigin=eyJpIjoiNGIyMTA4OGRmNzZlNGQ3N2IwNWU0NjQ2MmFmMjEzMjEiLCJwIjoiaiJ9)

## Type of change

<!--- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
