### PR TITLE
Fix/app 699 mobile dialog

### DIFF
--- a/packages/ui-components/src/components/backdrop/backdrop.tsx
+++ b/packages/ui-components/src/components/backdrop/backdrop.tsx
@@ -57,6 +57,7 @@ const StyledBackdrop = styled.div.attrs(({visible}: StyledBackdropProps) => {
     transition: 'visibility 0.2s, opacity 0.2s linear',
     backdropFilter: 'blur(24px)',
     cursor: 'pointer',
+    marginTop: 0,
   };
 
   return {className, style};

--- a/packages/ui-components/src/components/link/link.tsx
+++ b/packages/ui-components/src/components/link/link.tsx
@@ -36,18 +36,16 @@ export const Link: React.FC<LinkProps> = ({
       {...props}
       data-testid="link"
     >
-      <Content>
-        {iconLeft && iconLeft}
-        <Label>{label || href}</Label>
-        {!iconLeft && iconRight && iconRight}
-      </Content>
+      {iconLeft && <div>{iconLeft}</div>}
+      <Label>{label || href}</Label>
+      {!iconLeft && iconRight && <div>{iconRight}</div>}
     </StyledLink>
   );
 };
 
 type StyledLinkProps = {disabled: boolean; active: boolean};
 const StyledLink = styled.a.attrs(({active, disabled}: StyledLinkProps) => {
-  let className = `inline-flex overflow-hidden hover:text-primary-700 rounded 
+  let className = `flex items-center space-x-1.5 max-w-full hover:text-primary-700 rounded
      focus:ring-2 focus:ring-primary-500 focus:outline-none cursor-pointer`;
 
   className += ` ${
@@ -57,10 +55,6 @@ const StyledLink = styled.a.attrs(({active, disabled}: StyledLinkProps) => {
   return {className};
 })<StyledLinkProps>``;
 
-const Content = styled.span.attrs({
-  className: 'flex items-center space-x-1.5',
-})``;
-
-const Label = styled.span.attrs({
-  className: 'font-bold',
+const Label = styled.div.attrs({
+  className: 'font-bold truncate',
 })``;

--- a/packages/web-app/index.html
+++ b/packages/web-app/index.html
@@ -10,11 +10,6 @@
     href="https://fonts.googleapis.com/css2?family=Manrope:wght@500;700&family=Syne:wght@700&display=swap"
     rel="stylesheet" />
 
-  <!-- TODO: remove once fonts have been downloaded and set in stone -->
-  <link
-    href="https://fonts.googleapis.com/css2?family=Manrope:wght@500;700&family=Syne:wght@700&display=swap"
-    rel="stylesheet" />
-
   <style>
     * {
       font-weight: 500;


### PR DESCRIPTION
## Description

Fix minor layout changes on the mobile dialogue:

- Backdrop sometimes not filling vertical viewport
- Bottom sheet being too wide because of a text overflow in `DaoHeader` 

Note: As commented in the ticket, two tasks/bugs still need to be tackled. One is preventing a buggy animation when scrolling through a page with an open bottom sheet (not an issue with desktop modals, only mobile bottom sheets). The other is preventing the background from scrolling when a modal/bottom sheet is open. The latter would probably solve the former. I will ask for a new bug ticket to be created focusing just on those issues.

Task: [699](https://aragonassociation.atlassian.net/browse/APP-699?atlOrigin=eyJpIjoiZDMxM2Q0NDczZGEyNGI5Mjg4NjA2YzY4OWMzZDEzMjUiLCJwIjoiaiJ9)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)