### PR TITLE
FIX: `ui-components` library dependencies

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -40,8 +40,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",
-    "@radix-ui/react-dialog": "^0.1.2",
-    "@radix-ui/react-popover": "^0.1.1",
     "@rollup/plugin-image": "^2.1.1",
     "@size-limit/preset-small-lib": "^6.0.4",
     "@storybook/addon-essentials": "^6.3.12",
@@ -55,7 +53,6 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.1.2",
     "@types/react": "^17.0.33",
-    "@types/react-blockies": "^1.4.1",
     "@types/react-dom": "^17.0.10",
     "@types/styled-components": "^5.1.15",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
@@ -74,9 +71,7 @@
     "jest-svg-transformer": "^1.0.0",
     "postcss": "^8",
     "react": "^17.0.2",
-    "react-blockies": "^1.4.1",
     "react-dom": "^17.0.2",
-    "react-dropzone": "^11.5.1",
     "react-is": "^17.0.2",
     "rollup-plugin-postcss": "^4.0.0",
     "size-limit": "^6.0.4",
@@ -92,6 +87,11 @@
     "@tiptap/extension-placeholder": "^2.0.0-beta.46",
     "@tiptap/react": "^2.0.0-beta.104",
     "@tiptap/starter-kit": "^2.0.0-beta.168",
-    "tailwindcss-fluid-type": "^1.3.1"
+    "tailwindcss-fluid-type": "^1.3.1",
+    "react-blockies": "^1.4.1",
+    "@radix-ui/react-dialog": "^0.1.2",
+    "react-dropzone": "^11.5.1",
+    "@types/react-blockies": "^1.4.1",
+    "@radix-ui/react-popover": "^0.1.1"
   }
 }

--- a/packages/ui-components/src/index.tsx
+++ b/packages/ui-components/src/index.tsx
@@ -29,3 +29,4 @@ export * from './components/widgets';
 export * from './components/checkbox';
 export * from './components/headers';
 export * from './components/stateEmpty';
+export * from './components/illustrations';


### PR DESCRIPTION
## Description

The `ui-components` didn't work properly when imported as a package from npm, this was caused mostly because some dependencies were in the `devDependencies` instead of the `depencencies`  object inside the `package.json` file

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the test network.