### PR TITLE
App 722 - Limiting Proposal Actions

### DIFF
--- a/packages/web-app/src/containers/actionBuilder/addAddresses/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/addAddresses/index.tsx
@@ -1,27 +1,26 @@
 import {
-  ButtonText,
   ButtonIcon,
+  ButtonText,
   Dropdown,
   IconMenuVertical,
   Label,
   ListItemAction,
   StateEmpty,
 } from '@aragon/ui-components';
-import styled from 'styled-components';
-import {useTranslation} from 'react-i18next';
 import React, {useEffect} from 'react';
 import {useFieldArray, useFormContext, useWatch} from 'react-hook-form';
+import {useTranslation} from 'react-i18next';
+import styled from 'styled-components';
 
-import {AddressRow} from './addressRow';
-import AccordionSummary from './accordionSummary';
 import {AccordionMethod} from 'components/accordionMethod';
 import {useActionsContext} from 'context/actions';
+import {ActionIndex} from 'utils/types';
+import AccordionSummary from './accordionSummary';
+import {AddressRow} from './addressRow';
 
-type Props = {
-  index: number;
-};
+type AddAddressesProps = ActionIndex;
 
-const AddAddresses: React.FC<Props> = ({index: actionIndex}) => {
+const AddAddresses: React.FC<AddAddressesProps> = ({actionIndex}) => {
   const {t} = useTranslation();
   const {removeAction} = useActionsContext();
 

--- a/packages/web-app/src/containers/actionBuilder/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/index.tsx
@@ -9,7 +9,12 @@ import {useDaoBalances} from 'hooks/useDaoBalances';
 import {useDaoParam} from 'hooks/useDaoParam';
 import {fetchTokenPrice} from 'services/prices';
 import {formatUnits} from 'utils/library';
-import {ActionItem, ActionsTypes, BaseTokenInfo} from 'utils/types';
+import {
+  ActionIndex,
+  ActionItem,
+  ActionsTypes,
+  BaseTokenInfo,
+} from 'utils/types';
 import AddAddresses from './addAddresses';
 import MintTokens from './mintTokens';
 import RemoveAddresses from './removeAddresses';
@@ -24,15 +29,14 @@ import WithdrawAction from './withdraw/withdrawAction';
 
 type ActionsComponentProps = {
   name: ActionsTypes;
-  index: number;
-};
+} & ActionIndex;
 
-const Action: React.FC<ActionsComponentProps> = ({name, index}) => {
+const Action: React.FC<ActionsComponentProps> = ({name, actionIndex}) => {
   switch (name) {
     case 'withdraw_assets':
-      return <WithdrawAction {...{index}} />;
+      return <WithdrawAction {...{actionIndex}} />;
     case 'mint_token':
-      return <MintTokens {...{index}} />;
+      return <MintTokens {...{actionIndex}} />;
     case 'external_contract':
       return (
         <TemporarySection purpose="It serves as a placeholder for not yet implemented external contract interaction component" />
@@ -42,9 +46,9 @@ const Action: React.FC<ActionsComponentProps> = ({name, index}) => {
         <TemporarySection purpose="It serves as a placeholder for not yet implemented external contract interaction component" />
       );
     case 'add_address':
-      return <AddAddresses {...{index}} />;
+      return <AddAddresses {...{actionIndex}} />;
     case 'remove_address':
-      return <RemoveAddresses {...{index}} />;
+      return <RemoveAddresses {...{actionIndex}} />;
     default:
       throw Error('Action not found');
   }
@@ -57,6 +61,8 @@ const ActionBuilder: React.FC = () => {
   const {data: tokens} = useDaoBalances(daoAddress);
   const {setValue, resetField, clearErrors, formState, trigger} =
     useFormContext();
+
+  console.log('[LOGGING] index ' + index);
 
   /*************************************************
    *             Callbacks and Handlers            *

--- a/packages/web-app/src/containers/actionBuilder/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/index.tsx
@@ -57,7 +57,7 @@ const Action: React.FC<ActionsComponentProps> = ({name, actionIndex}) => {
 const ActionBuilder: React.FC = () => {
   const {data: daoAddress} = useDaoParam();
   const {network} = useNetwork();
-  const {actionsCounter: index, actions} = useActionsContext();
+  const {selectedActionIndex: index, actions} = useActionsContext();
   const {data: tokens} = useDaoBalances(daoAddress);
   const {setValue, resetField, clearErrors, formState, trigger} =
     useFormContext();

--- a/packages/web-app/src/containers/actionBuilder/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/index.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
+import {useFormContext} from 'react-hook-form';
 
-import {useActionsContext} from 'context/actions';
-import WithdrawAction from './withdraw/withdrawAction';
-import {ActionsTypes} from 'utils/types';
+import {TemporarySection} from 'components/temporary';
 import TokenMenu from 'containers/tokenMenu';
-import {BaseTokenInfo, ActionItem} from 'utils/types';
+import {useActionsContext} from 'context/actions';
+import {useNetwork} from 'context/network';
+import {useDaoBalances} from 'hooks/useDaoBalances';
+import {useDaoParam} from 'hooks/useDaoParam';
 import {fetchTokenPrice} from 'services/prices';
 import {formatUnits} from 'utils/library';
-import {useFormContext} from 'react-hook-form';
-import {useDaoBalances} from 'hooks/useDaoBalances';
-import {useNetwork} from 'context/network';
-import {useDaoParam} from 'hooks/useDaoParam';
-import MintTokens from './mintTokens';
+import {ActionItem, ActionsTypes, BaseTokenInfo} from 'utils/types';
 import AddAddresses from './addAddresses';
+import MintTokens from './mintTokens';
 import RemoveAddresses from './removeAddresses';
+import WithdrawAction from './withdraw/withdrawAction';
 
 /**
  * This Component is responsible for generating all actions that append to pipeline context (actions)
@@ -34,9 +34,13 @@ const Action: React.FC<ActionsComponentProps> = ({name, index}) => {
     case 'mint_token':
       return <MintTokens {...{index}} />;
     case 'external_contract':
-      return null;
+      return (
+        <TemporarySection purpose="It serves as a placeholder for not yet implemented external contract interaction component" />
+      );
     case 'modify_settings':
-      return null;
+      return (
+        <TemporarySection purpose="It serves as a placeholder for not yet implemented external contract interaction component" />
+      );
     case 'add_address':
       return <AddAddresses {...{index}} />;
     case 'remove_address':
@@ -98,6 +102,10 @@ const ActionBuilder: React.FC = () => {
       {actions?.map((action: ActionItem, index: number) => (
         <Action key={index} name={action?.name} {...{index}} />
       ))}
+
+      {/* TODO Fabrice(?), could the TokenMenu and the corresponding callback be
+          moved further down to the respective child(ren)? I assume there was a
+          reason for putting it here. Is it still valid? [VR 10-08-2022] */}
       <TokenMenu
         isWallet={false}
         onTokenSelect={handleTokenSelect}

--- a/packages/web-app/src/containers/actionBuilder/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/index.tsx
@@ -103,9 +103,6 @@ const ActionBuilder: React.FC = () => {
         <Action key={index} name={action?.name} {...{index}} />
       ))}
 
-      {/* TODO Fabrice(?), could the TokenMenu and the corresponding callback be
-          moved further down to the respective child(ren)? I assume there was a
-          reason for putting it here. Is it still valid? [VR 10-08-2022] */}
       <TokenMenu
         isWallet={false}
         onTokenSelect={handleTokenSelect}

--- a/packages/web-app/src/containers/actionBuilder/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/index.tsx
@@ -62,8 +62,6 @@ const ActionBuilder: React.FC = () => {
   const {setValue, resetField, clearErrors, formState, trigger} =
     useFormContext();
 
-  console.log('[LOGGING] index ' + index);
-
   /*************************************************
    *             Callbacks and Handlers            *
    *************************************************/

--- a/packages/web-app/src/containers/actionBuilder/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/index.tsx
@@ -104,7 +104,7 @@ const ActionBuilder: React.FC = () => {
   return (
     <>
       {actions?.map((action: ActionItem, index: number) => (
-        <Action key={index} name={action?.name} {...{index}} />
+        <Action key={index} name={action?.name} actionIndex={index} />
       ))}
 
       <TokenMenu

--- a/packages/web-app/src/containers/actionBuilder/mintTokens/addressTokenRow.tsx
+++ b/packages/web-app/src/containers/actionBuilder/mintTokens/addressTokenRow.tsx
@@ -16,9 +16,9 @@ import styled from 'styled-components';
 
 import useScreen from 'hooks/useScreen';
 import {handleClipboardActions} from 'utils/library';
+import {ActionIndex} from 'utils/types';
 
-type IndexProps = {
-  actionIndex: number;
+type IndexProps = ActionIndex & {
   fieldIndex: number;
 };
 
@@ -94,9 +94,9 @@ const TokenField: React.FC<IndexProps> = ({actionIndex, fieldIndex}) => {
   );
 };
 
-const DropdownMenu: React.FC<
-  Omit<AddressAndTokenRowProps, 'newTokenSupply'>
-> = ({fieldIndex, onDelete}) => {
+type DropdownProps = Omit<AddressAndTokenRowProps, 'newTokenSupply'>;
+
+const DropdownMenu: React.FC<DropdownProps> = ({fieldIndex, onDelete}) => {
   const {t} = useTranslation();
 
   return (

--- a/packages/web-app/src/containers/actionBuilder/mintTokens/addressTokenRow.tsx
+++ b/packages/web-app/src/containers/actionBuilder/mintTokens/addressTokenRow.tsx
@@ -94,30 +94,31 @@ const TokenField: React.FC<IndexProps> = ({actionIndex, fieldIndex}) => {
   );
 };
 
-const DropdownMenu: React.FC<Omit<AddressAndTokenRowProps, 'newTokenSupply'>> =
-  ({fieldIndex, onDelete}) => {
-    const {t} = useTranslation();
+const DropdownMenu: React.FC<
+  Omit<AddressAndTokenRowProps, 'newTokenSupply'>
+> = ({fieldIndex, onDelete}) => {
+  const {t} = useTranslation();
 
-    return (
-      <Dropdown
-        align="start"
-        trigger={
-          <ButtonIcon mode="ghost" size="large" icon={<IconMenuVertical />} />
-        }
-        sideOffset={8}
-        listItems={[
-          {
-            component: (
-              <ListItemAction title={t('labels.removeWallet')} bgWhite />
-            ),
-            callback: () => {
-              onDelete(fieldIndex);
-            },
+  return (
+    <Dropdown
+      align="start"
+      trigger={
+        <ButtonIcon mode="ghost" size="large" icon={<IconMenuVertical />} />
+      }
+      sideOffset={8}
+      listItems={[
+        {
+          component: (
+            <ListItemAction title={t('labels.removeWallet')} bgWhite />
+          ),
+          callback: () => {
+            onDelete(fieldIndex);
           },
-        ]}
-      />
-    );
-  };
+        },
+      ]}
+    />
+  );
+};
 const PercentageDistribution: React.FC<
   Omit<AddressAndTokenRowProps, 'onDelete'>
 > = ({actionIndex, fieldIndex, newTokenSupply}) => {

--- a/packages/web-app/src/containers/actionBuilder/mintTokens/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/mintTokens/index.tsx
@@ -35,7 +35,7 @@ type AddressBalance = {
 const MintTokens: React.FC<Props> = ({index}) => {
   const {t} = useTranslation();
 
-  const {removeAction, duplicateAction} = useActionsContext();
+  const {removeAction} = useActionsContext();
   const {setValue} = useFormContext();
 
   const handleReset = () => {
@@ -43,10 +43,6 @@ const MintTokens: React.FC<Props> = ({index}) => {
   };
 
   const methodActions = [
-    {
-      component: <ListItemAction title={t('labels.duplicateAction')} bgWhite />,
-      callback: () => duplicateAction(index),
-    },
     {
       component: <ListItemAction title={t('labels.resetAction')} bgWhite />,
       callback: handleReset,

--- a/packages/web-app/src/containers/actionBuilder/mintTokens/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/mintTokens/index.tsx
@@ -16,11 +16,10 @@ import useScreen from 'hooks/useScreen';
 import {CHAIN_METADATA} from 'utils/constants';
 import {formatUnits} from 'utils/library';
 import {fetchBalance, getTokenInfo} from 'utils/tokens';
+import {ActionIndex} from 'utils/types';
 import {AddressAndTokenRow} from './addressTokenRow';
 
-type Props = {
-  index: number;
-};
+type MintTokensProps = ActionIndex;
 
 type MintInfo = {
   address: string;
@@ -32,14 +31,14 @@ type AddressBalance = {
   balance: BigNumber;
 };
 
-const MintTokens: React.FC<Props> = ({index}) => {
+const MintTokens: React.FC<MintTokensProps> = ({actionIndex}) => {
   const {t} = useTranslation();
 
   const {removeAction} = useActionsContext();
   const {setValue} = useFormContext();
 
   const handleReset = () => {
-    setValue(`actions.${index}.inputs.mintTokensToWallets`, []);
+    setValue(`actions.${actionIndex}.inputs.mintTokensToWallets`, []);
   };
 
   const methodActions = [
@@ -52,7 +51,7 @@ const MintTokens: React.FC<Props> = ({index}) => {
         <ListItemAction title={t('labels.removeEntireAction')} bgWhite />
       ),
       callback: () => {
-        removeAction(index);
+        removeAction(actionIndex);
       },
     },
   ];
@@ -67,17 +66,21 @@ const MintTokens: React.FC<Props> = ({index}) => {
       additionalInfo={t('newProposal.mintTokens.additionalInfo')}
       dropdownItems={methodActions}
     >
-      <MintTokenForm actionIndex={index} />
+      <MintTokenForm actionIndex={actionIndex} />
     </AccordionMethod>
   );
 };
 
 export default MintTokens;
 
-export const MintTokenForm: React.FC<{
-  actionIndex: number;
+type MintTokenFormProps = {
   standAlone?: boolean;
-}> = ({actionIndex, standAlone = false}) => {
+} & ActionIndex;
+
+export const MintTokenForm: React.FC<MintTokenFormProps> = ({
+  actionIndex,
+  standAlone = false,
+}) => {
   const {t} = useTranslation();
   const {isDesktop} = useScreen();
   const {data: daoId} = useDaoParam();

--- a/packages/web-app/src/containers/actionBuilder/removeAddresses/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/removeAddresses/index.tsx
@@ -8,26 +8,25 @@ import {
   StateEmpty,
 } from '@aragon/ui-components';
 import React from 'react';
+import {useFieldArray, useFormContext, useWatch} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
-import {useFormContext, useWatch, useFieldArray} from 'react-hook-form';
 
-import {FormItem} from '../addAddresses';
-import {AddressRow} from '../addAddresses/addressRow';
-import {useDaoParam} from 'hooks/useDaoParam';
-import AccordionSummary from '../addAddresses/accordionSummary';
-import {DaoWhitelist, useDaoMembers} from 'hooks/useDaoMembers';
 import {AccordionMethod} from 'components/accordionMethod';
 import ManageWalletsModal from 'containers/manageWalletsModal';
 import {useActionsContext} from 'context/actions';
 import {useGlobalModalContext} from 'context/globalModals';
+import {DaoWhitelist, useDaoMembers} from 'hooks/useDaoMembers';
+import {useDaoParam} from 'hooks/useDaoParam';
+import {ActionIndex} from 'utils/types';
+import {FormItem} from '../addAddresses';
+import AccordionSummary from '../addAddresses/accordionSummary';
+import {AddressRow} from '../addAddresses/addressRow';
 
-type Props = {
-  index: number;
-};
+type RemoveAddressesProps = ActionIndex;
 
 // README: when uploading CSV be sure to check for duplicates
 
-const RemoveAddresses: React.FC<Props> = ({index: actionIndex}) => {
+const RemoveAddresses: React.FC<RemoveAddressesProps> = ({actionIndex}) => {
   const {t} = useTranslation();
   const {open} = useGlobalModalContext();
   const {removeAction} = useActionsContext();

--- a/packages/web-app/src/containers/actionBuilder/withdraw/withdrawAction.tsx
+++ b/packages/web-app/src/containers/actionBuilder/withdraw/withdrawAction.tsx
@@ -1,22 +1,20 @@
-import React from 'react';
 import {ListItemAction} from '@aragon/ui-components';
-import {useTranslation} from 'react-i18next';
+import React from 'react';
 import {useFormContext} from 'react-hook-form';
+import {useTranslation} from 'react-i18next';
 
-import {FormItem} from '../addAddresses';
 import {AccordionMethod} from 'components/accordionMethod';
-import {useActionsContext} from 'context/actions';
 import ConfigureWithdrawForm from 'containers/configureWithdraw';
+import {useActionsContext} from 'context/actions';
+import {ActionIndex} from 'utils/types';
+import {FormItem} from '../addAddresses';
 
-type Props = {
-  index: number;
-};
+type WithdrawActionProps = ActionIndex;
 
-const WithdrawAction: React.FC<Props> = ({index: actionIndex}) => {
+const WithdrawAction: React.FC<WithdrawActionProps> = ({actionIndex}) => {
   const {t} = useTranslation();
   const {setValue, clearErrors} = useFormContext();
-  const {removeAction, duplicateAction, setActionsCounter} =
-    useActionsContext();
+  const {removeAction, duplicateAction} = useActionsContext();
 
   const resetWithdrawFields = () => {
     clearErrors(`actions.${actionIndex}`);
@@ -55,10 +53,7 @@ const WithdrawAction: React.FC<Props> = ({index: actionIndex}) => {
       methodDescription={t('AddActionModal.withdrawAssetsActionSubtitle')}
     >
       <FormItem className="py-3 space-y-3 rounded-b-xl">
-        <ConfigureWithdrawForm
-          index={actionIndex}
-          setActionsCounter={setActionsCounter}
-        />
+        <ConfigureWithdrawForm actionIndex={actionIndex} />
       </FormItem>
     </AccordionMethod>
   );

--- a/packages/web-app/src/containers/addActionMenu/index.tsx
+++ b/packages/web-app/src/containers/addActionMenu/index.tsx
@@ -14,7 +14,7 @@ type AddActionMenuProps = {
 
 const AddActionMenu: React.FC<AddActionMenuProps> = ({actions}) => {
   const {isAddActionOpen, close} = useGlobalModalContext();
-  const {addAction} = useActionsContext();
+  const {actions: usedActions, addAction} = useActionsContext();
   const {t} = useTranslation();
 
   return (
@@ -29,6 +29,11 @@ const AddActionMenu: React.FC<AddActionMenuProps> = ({actions}) => {
             key={a.type}
             title={a.title}
             subtitle={a.subtitle}
+            mode={
+              !a.isReuseable && usedActions.some(ua => ua.name === a.type)
+                ? 'disabled'
+                : 'default'
+            }
             iconRight={<IconChevronRight />}
             onClick={() => {
               addAction({

--- a/packages/web-app/src/containers/configureActions/index.tsx
+++ b/packages/web-app/src/containers/configureActions/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   AlertInline,
   ButtonText,
@@ -6,63 +5,66 @@ import {
   Label,
   StateEmpty,
 } from '@aragon/ui-components';
+import React from 'react';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
 
-import {StringIndexed} from 'utils/types';
-import {useGlobalModalContext} from 'context/globalModals';
-import {useActionsContext} from 'context/actions';
 import ActionBuilder from 'containers/actionBuilder';
+import {useActionsContext} from 'context/actions';
+import {useGlobalModalContext} from 'context/globalModals';
+import {useDaoActions} from 'hooks/useDaoActions';
+import {useDaoParam} from 'hooks/useDaoParam';
+import {StringIndexed} from 'utils/types';
+import AddActionMenu from 'containers/addActionMenu';
 
 const ConfigureActions: React.FC = () => {
+  const {data: daoId} = useDaoParam();
   const {t} = useTranslation();
   const {open} = useGlobalModalContext();
   const {actions} = useActionsContext();
+  const {data: availableActions} = useDaoActions(daoId);
 
   return (
-    <>
-      <FormItem>
-        <Label
-          label={t('newProposal.configureActions.yesOption')}
-          helpText={t('newProposal.configureActions.yesOptionSubtitle')}
-          isOptional
-        />
-        {actions.length !== 0 ? (
-          <ActionsWrapper>
-            <ActionBuilder />
-            <ButtonText
-              mode="ghost"
-              size="large"
-              bgWhite
-              label={t('newProposal.configureActions.addAction')}
-              iconLeft={<IconAdd />}
-              onClick={() => open('addAction')}
-              className="mt-2 w-full tablet:w-max"
-            />
-          </ActionsWrapper>
-        ) : (
-          <>
-            <StateEmpty
-              type="Object"
-              mode="card"
-              object="smart_contract"
-              title={t('newProposal.configureActions.addFirstAction')}
-              description={t(
-                'newProposal.configureActions.addFirstActionSubtitle'
-              )}
-              secondaryButton={{
-                label: t('newProposal.configureActions.addAction'),
-                onClick: () => open('addAction'),
-                iconLeft: <IconAdd />,
-              }}
-            />
-            <AlertInline
-              label={t('newProposal.configureActions.actionsInfo')}
-            />
-          </>
-        )}
-      </FormItem>
-    </>
+    <FormWrapper>
+      <Label
+        label={t('newProposal.configureActions.yesOption')}
+        helpText={t('newProposal.configureActions.yesOptionSubtitle')}
+        isOptional
+      />
+      {actions.length ? (
+        <ActionsWrapper>
+          <ActionBuilder />
+          <ButtonText
+            mode="ghost"
+            size="large"
+            bgWhite
+            label={t('newProposal.configureActions.addAction')}
+            iconLeft={<IconAdd />}
+            onClick={() => open('addAction')}
+            className="mt-2 w-full tablet:w-max"
+          />
+        </ActionsWrapper>
+      ) : (
+        <>
+          <StateEmpty
+            type="Object"
+            mode="card"
+            object="smart_contract"
+            title={t('newProposal.configureActions.addFirstAction')}
+            description={t(
+              'newProposal.configureActions.addFirstActionSubtitle'
+            )}
+            secondaryButton={{
+              label: t('newProposal.configureActions.addAction'),
+              onClick: () => open('addAction'),
+              iconLeft: <IconAdd />,
+            }}
+          />
+          <AlertInline label={t('newProposal.configureActions.actionsInfo')} />
+        </>
+      )}
+      <AddActionMenu actions={availableActions} />
+    </FormWrapper>
   );
 };
 
@@ -77,7 +79,7 @@ export function isValid(errors: StringIndexed) {
   return !errors.actions;
 }
 
-const FormItem = styled.div.attrs({
+const FormWrapper = styled.div.attrs({
   className: 'space-y-1.5',
 })``;
 

--- a/packages/web-app/src/containers/configureWithdraw/index.tsx
+++ b/packages/web-app/src/containers/configureWithdraw/index.tsx
@@ -48,7 +48,7 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
   const {address} = useWallet();
   const {infura: provider} = useProviders();
   const {data: daoAddress} = useDaoParam();
-  const {setActionsCounter} = useActionsContext();
+  const {setSelectedActionIndex} = useActionsContext();
 
   const {control, getValues, trigger, resetField, setFocus, setValue} =
     useFormContext();
@@ -332,7 +332,7 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
                 mode={error ? 'critical' : 'default'}
                 value={value}
                 onClick={() => {
-                  setActionsCounter(actionIndex);
+                  setSelectedActionIndex(actionIndex);
                   open('token');
                 }}
                 placeholder={t('placeHolders.selectToken')}

--- a/packages/web-app/src/containers/configureWithdraw/index.tsx
+++ b/packages/web-app/src/containers/configureWithdraw/index.tsx
@@ -5,6 +5,8 @@ import {
   ValueInput,
 } from '@aragon/ui-components';
 
+import {useApolloClient} from '@apollo/client';
+import React, {useCallback, useEffect} from 'react';
 import {
   Controller,
   FormState,
@@ -12,36 +14,32 @@ import {
   useFormState,
   useWatch,
 } from 'react-hook-form';
-import styled from 'styled-components';
 import {useTranslation} from 'react-i18next';
-import React, {useCallback, useEffect} from 'react';
-import {useApolloClient} from '@apollo/client';
+import styled from 'styled-components';
 
+import {useActionsContext} from 'context/actions';
+import {useGlobalModalContext} from 'context/globalModals';
+import {useNetwork} from 'context/network';
+import {useProviders} from 'context/providers';
+import {isAddress} from 'ethers/lib/utils';
+import {useDaoParam} from 'hooks/useDaoParam';
+import {useWallet} from 'hooks/useWallet';
+import {WithdrawAction} from 'pages/newWithdraw';
+import {fetchTokenData} from 'services/prices';
+import {CHAIN_METADATA} from 'utils/constants';
+import {handleClipboardActions} from 'utils/library';
+import {fetchBalance, getTokenInfo, isNativeToken} from 'utils/tokens';
+import {ActionIndex} from 'utils/types';
 import {
   validateAddress,
   validateTokenAddress,
   validateTokenAmount,
 } from 'utils/validators';
-import {useWallet} from 'hooks/useWallet';
-import {useProviders} from 'context/providers';
-import {fetchTokenData} from 'services/prices';
-import {useGlobalModalContext} from 'context/globalModals';
-import {handleClipboardActions} from 'utils/library';
-import {fetchBalance, getTokenInfo, isNativeToken} from 'utils/tokens';
-import {WithdrawAction} from 'pages/newWithdraw';
-import {isAddress} from 'ethers/lib/utils';
-import {useNetwork} from 'context/network';
-import {useDaoParam} from 'hooks/useDaoParam';
-import {CHAIN_METADATA} from 'utils/constants';
 
-type ConfigureWithdrawFormProps = {
-  index?: number;
-  setActionsCounter?: (index: number) => void;
-};
+type ConfigureWithdrawFormProps = ActionIndex; //extend if necessary
 
 const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
-  index = 0,
-  setActionsCounter,
+  actionIndex,
 }) => {
   const {t} = useTranslation();
   const client = useApolloClient();
@@ -50,6 +48,7 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
   const {address} = useWallet();
   const {infura: provider} = useProviders();
   const {data: daoAddress} = useDaoParam();
+  const {setActionsCounter} = useActionsContext();
 
   const {control, getValues, trigger, resetField, setFocus, setValue} =
     useFormContext();
@@ -58,12 +57,12 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
   const [name, from, tokenAddress, isCustomToken, tokenBalance, symbol] =
     useWatch({
       name: [
-        `actions.${index}.name`,
-        `actions.${index}.from`,
-        `actions.${index}.tokenAddress`,
-        `actions.${index}.isCustomToken`,
-        `actions.${index}.tokenBalance`,
-        `actions.${index}.tokenSymbol`,
+        `actions.${actionIndex}.name`,
+        `actions.${actionIndex}.from`,
+        `actions.${actionIndex}.tokenAddress`,
+        `actions.${actionIndex}.isCustomToken`,
+        `actions.${actionIndex}.tokenBalance`,
+        `actions.${actionIndex}.tokenSymbol`,
       ],
     });
   const nativeCurrency = CHAIN_METADATA[network].nativeCurrency;
@@ -72,16 +71,16 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
    *                    Hooks                      *
    *************************************************/
   useEffect(() => {
-    if (isCustomToken) setFocus(`actions.${index}.tokenAddress`);
+    if (isCustomToken) setFocus(`actions.${actionIndex}.tokenAddress`);
 
     if (from === '') {
-      setValue(`actions.${index}.from`, daoAddress);
+      setValue(`actions.${actionIndex}.from`, daoAddress);
     }
   }, [
     address,
     daoAddress,
     from,
-    index,
+    actionIndex,
     isCustomToken,
     setFocus,
     setValue,
@@ -90,9 +89,9 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
 
   useEffect(() => {
     if (!name) {
-      setValue(`actions.${index}.name`, 'withdraw_assets');
+      setValue(`actions.${actionIndex}.name`, 'withdraw_assets');
     }
-  }, [index, name, setValue]);
+  }, [actionIndex, name, setValue]);
 
   // Fetch custom token information
   useEffect(() => {
@@ -101,7 +100,10 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
     const fetchTokenInfo = async () => {
       if (errors.tokenAddress !== undefined) {
         if (dirtyFields.amount)
-          trigger([`actions.${index}.amount`, `actions.${index}.tokenSymbol`]);
+          trigger([
+            `actions.${actionIndex}.amount`,
+            `actions.${actionIndex}.tokenSymbol`,
+          ]);
         return;
       }
 
@@ -117,20 +119,20 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
         // use blockchain if api data unavailable
         const [balance, data] = await allTokenInfoPromise;
         if (data) {
-          setValue(`actions.${index}.tokenName`, data.name);
-          setValue(`actions.${index}.tokenSymbol`, data.symbol);
-          setValue(`actions.${index}.tokenImgUrl`, data.imgUrl);
-          setValue(`actions.${index}.tokenPrice`, data.price);
+          setValue(`actions.${actionIndex}.tokenName`, data.name);
+          setValue(`actions.${actionIndex}.tokenSymbol`, data.symbol);
+          setValue(`actions.${actionIndex}.tokenImgUrl`, data.imgUrl);
+          setValue(`actions.${actionIndex}.tokenPrice`, data.price);
         } else {
           const {name, symbol} = await getTokenInfo(
             tokenAddress,
             provider,
             nativeCurrency
           );
-          setValue(`actions.${index}.tokenName`, name);
-          setValue(`actions.${index}.tokenSymbol`, symbol);
+          setValue(`actions.${actionIndex}.tokenName`, name);
+          setValue(`actions.${actionIndex}.tokenSymbol`, symbol);
         }
-        setValue(`actions.${index}.tokenBalance`, balance);
+        setValue(`actions.${actionIndex}.tokenBalance`, balance);
       } catch (error) {
         /**
          * Error is intentionally swallowed. Passing invalid address will
@@ -141,7 +143,10 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
         console.error(error);
       }
       if (dirtyFields.amount)
-        trigger([`actions.${index}.amount`, `actions.${index}.tokenSymbol`]);
+        trigger([
+          `actions.${actionIndex}.amount`,
+          `actions.${actionIndex}.tokenSymbol`,
+        ]);
     };
 
     fetchTokenInfo();
@@ -149,7 +154,7 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
     address,
     dirtyFields.amount,
     errors.tokenAddress,
-    index,
+    actionIndex,
     isCustomToken,
     provider,
     setValue,
@@ -208,20 +213,20 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
 
       // address invalid, reset token fields
       if (validationResult !== true) {
-        resetField(`actions.${index}.tokenName`);
-        resetField(`actions.${index}.tokenImgUrl`);
-        resetField(`actions.${index}.tokenSymbol`);
-        resetField(`actions.${index}.tokenBalance`);
+        resetField(`actions.${actionIndex}.tokenName`);
+        resetField(`actions.${actionIndex}.tokenImgUrl`);
+        resetField(`actions.${actionIndex}.tokenSymbol`);
+        resetField(`actions.${actionIndex}.tokenBalance`);
       }
 
       return validationResult;
     },
-    [index, provider, resetField]
+    [actionIndex, provider, resetField]
   );
 
   const amountValidator = useCallback(
     async (amount: string) => {
-      const tokenAddress = getValues(`actions.${index}.tokenAddress`);
+      const tokenAddress = getValues(`actions.${actionIndex}.tokenAddress`);
 
       // check if a token is selected using its address
       if (tokenAddress === '') return t('errors.noTokenSelected');
@@ -244,7 +249,7 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
         return t('errors.defaultAmountValidationError');
       }
     },
-    [errors.tokenAddress, getValues, index, provider, t, nativeCurrency]
+    [errors.tokenAddress, getValues, actionIndex, provider, t, nativeCurrency]
   );
 
   const recipientValidator = useCallback(
@@ -279,7 +284,7 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
           helpText={t('newWithdraw.configureWithdraw.toSubtitle')}
         />
         <Controller
-          name={`actions.${index}.to`}
+          name={`actions.${actionIndex}.to`}
           control={control}
           defaultValue=""
           rules={{
@@ -316,7 +321,7 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
           helpText={t('newWithdraw.configureWithdraw.tokenSubtitle')}
         />
         <Controller
-          name={`actions.${index}.tokenSymbol`}
+          name={`actions.${actionIndex}.tokenSymbol`}
           control={control}
           defaultValue=""
           rules={{required: t('errors.required.token')}}
@@ -327,7 +332,7 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
                 mode={error ? 'critical' : 'default'}
                 value={value}
                 onClick={() => {
-                  setActionsCounter?.(index);
+                  setActionsCounter(actionIndex);
                   open('token');
                 }}
                 placeholder={t('placeHolders.selectToken')}
@@ -348,7 +353,7 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
             helpText={t('newDeposit.contractAddressSubtitle')}
           />
           <Controller
-            name={`actions.${index}.tokenAddress`}
+            name={`actions.${actionIndex}.tokenAddress`}
             control={control}
             defaultValue=""
             rules={{
@@ -386,7 +391,7 @@ const ConfigureWithdrawForm: React.FC<ConfigureWithdrawFormProps> = ({
           helpText={t('newWithdraw.configureWithdraw.amountSubtitle')}
         />
         <Controller
-          name={`actions.${index}.amount`}
+          name={`actions.${actionIndex}.amount`}
           control={control}
           defaultValue=""
           rules={{

--- a/packages/web-app/src/context/actions.tsx
+++ b/packages/web-app/src/context/actions.tsx
@@ -1,13 +1,12 @@
+import {Address} from '@aragon/ui-components/dist/utils/addresses';
 import React, {
   createContext,
-  useContext,
-  useState,
-  useMemo,
-  ReactNode,
   useCallback,
+  useContext,
+  useMemo,
+  useState,
 } from 'react';
 import {useFieldArray, useFormContext} from 'react-hook-form';
-import {Address} from '@aragon/ui-components/dist/utils/addresses';
 
 import {ActionItem} from 'utils/types';
 
@@ -21,18 +20,13 @@ type ActionsContextType = {
   addAction: (value: ActionItem) => void;
   duplicateAction: (index: number) => void;
   removeAction: (index: number) => void;
-  setDaoAddress: (value: string) => void;
 };
 
-type Props = Record<'children', ReactNode>;
+type ActionsProviderProps = {
+  daoId: Address;
+};
 
-/**
- * This Context must refactor later and add more attributes to cover whole transactions process
- */
-
-const ActionsProvider: React.FC<Props> = ({children}) => {
-  const [daoAddress, setDaoAddress] =
-    useState<ActionsContextType['daoAddress']>('');
+const ActionsProvider: React.FC<ActionsProviderProps> = ({daoId, children}) => {
   const [actions, setActions] = useState<ActionsContextType['actions']>([]);
   const [actionsCounter, setActionsCounter] =
     useState<ActionsContextType['actionsCounter']>(0);
@@ -63,23 +57,15 @@ const ActionsProvider: React.FC<Props> = ({children}) => {
 
   const value = useMemo(
     (): ActionsContextType => ({
-      daoAddress,
+      daoAddress: daoId,
       actions,
-      setDaoAddress,
       addAction,
       removeAction,
       duplicateAction,
       actionsCounter,
       setActionsCounter,
     }),
-    [
-      daoAddress,
-      actions,
-      addAction,
-      removeAction,
-      duplicateAction,
-      actionsCounter,
-    ]
+    [daoId, actions, addAction, removeAction, duplicateAction, actionsCounter]
   );
 
   return (

--- a/packages/web-app/src/context/actions.tsx
+++ b/packages/web-app/src/context/actions.tsx
@@ -15,8 +15,8 @@ const ActionsContext = createContext<ActionsContextType | null>(null);
 type ActionsContextType = {
   daoAddress: Address;
   actions: ActionItem[];
-  actionsCounter: number;
-  setActionsCounter: (index: number) => void;
+  selectedActionIndex: number;
+  setSelectedActionIndex: React.Dispatch<React.SetStateAction<number>>;
   addAction: (value: ActionItem) => void;
   duplicateAction: (index: number) => void;
   removeAction: (index: number) => void;
@@ -28,8 +28,8 @@ type ActionsProviderProps = {
 
 const ActionsProvider: React.FC<ActionsProviderProps> = ({daoId, children}) => {
   const [actions, setActions] = useState<ActionsContextType['actions']>([]);
-  const [actionsCounter, setActionsCounter] =
-    useState<ActionsContextType['actionsCounter']>(0);
+  const [selectedActionIndex, setSelectedActionIndex] =
+    useState<ActionsContextType['selectedActionIndex']>(0);
 
   const {control} = useFormContext();
   const {remove} = useFieldArray({control, name: 'actions'});
@@ -62,10 +62,17 @@ const ActionsProvider: React.FC<ActionsProviderProps> = ({daoId, children}) => {
       addAction,
       removeAction,
       duplicateAction,
-      actionsCounter,
-      setActionsCounter,
+      selectedActionIndex,
+      setSelectedActionIndex,
     }),
-    [daoId, actions, addAction, removeAction, duplicateAction, actionsCounter]
+    [
+      daoId,
+      actions,
+      addAction,
+      removeAction,
+      duplicateAction,
+      selectedActionIndex,
+    ]
   );
 
   return (

--- a/packages/web-app/src/hooks/useDaoActions.tsx
+++ b/packages/web-app/src/hooks/useDaoActions.tsx
@@ -14,6 +14,7 @@ export function useDaoActions(dao: string): HookData<ActionParameter[]> {
       type: 'withdraw_assets',
       title: t('AddActionModal.withdrawAssets'),
       subtitle: t('AddActionModal.withdrawAssetsSubtitle'),
+      isReuseable: true,
     },
     {
       type: 'modify_settings',
@@ -25,6 +26,7 @@ export function useDaoActions(dao: string): HookData<ActionParameter[]> {
       type: 'external_contract',
       title: t('AddActionModal.externalContract'),
       subtitle: t('AddActionModal.externalContractSubtitle'),
+      isReuseable: true,
     },
   ];
 

--- a/packages/web-app/src/hooks/useDaoActions.tsx
+++ b/packages/web-app/src/hooks/useDaoActions.tsx
@@ -1,4 +1,5 @@
 import {useTranslation} from 'react-i18next';
+
 import {ActionParameter, HookData} from 'utils/types';
 import {useDaoMetadata} from './useDaoMetadata';
 
@@ -47,6 +48,7 @@ export function useDaoActions(dao: string): HookData<ActionParameter[]> {
       subtitle: t('AddActionModal.mintTokensSubtitle'),
     },
   ]);
+
   return {
     data: whitelist ? whitelistActions : erc20Actions,
     isLoading,

--- a/packages/web-app/src/pages/mintTokens.tsx
+++ b/packages/web-app/src/pages/mintTokens.tsx
@@ -1,27 +1,27 @@
-import {useTranslation} from 'react-i18next';
+import {AlertInline} from '@aragon/ui-components';
 import {withTransaction} from '@elastic/apm-rum-react';
 import React from 'react';
-import {useForm, FormProvider, useFormState} from 'react-hook-form';
+import {FormProvider, useForm, useFormState} from 'react-hook-form';
+import {useTranslation} from 'react-i18next';
 import {generatePath} from 'react-router-dom';
 
-import {Community} from 'utils/paths';
-import ReviewProposal from 'containers/reviewProposal';
-import {ActionsProvider} from 'context/actions';
 import {FullScreenStepper, Step} from 'components/fullScreenStepper';
-import DefineProposal, {
-  isValid as defineProposalIsValid,
-} from 'containers/defineProposal';
-import SetupVotingForm, {
-  isValid as setupVotingIsValid,
-} from 'containers/setupVotingForm';
-import {useNetwork} from 'context/network';
-import {useDaoParam} from 'hooks/useDaoParam';
 import {Loading} from 'components/temporary';
 import {
   MintTokenDescription,
   MintTokenForm,
 } from 'containers/actionBuilder/mintTokens';
-import {AlertInline} from '@aragon/ui-components';
+import DefineProposal, {
+  isValid as defineProposalIsValid,
+} from 'containers/defineProposal';
+import ReviewProposal from 'containers/reviewProposal';
+import SetupVotingForm, {
+  isValid as setupVotingIsValid,
+} from 'containers/setupVotingForm';
+import {ActionsProvider} from 'context/actions';
+import {useNetwork} from 'context/network';
+import {useDaoParam} from 'hooks/useDaoParam';
+import {Community} from 'utils/paths';
 
 const MintToken: React.FC = () => {
   const {data: dao, loading} = useDaoParam();
@@ -46,7 +46,7 @@ const MintToken: React.FC = () => {
 
   return (
     <FormProvider {...formMethods}>
-      <ActionsProvider>
+      <ActionsProvider daoId={dao}>
         <FullScreenStepper
           wizardProcessName={t('labels.addMember')}
           navLabel={t('labels.addMember')}

--- a/packages/web-app/src/pages/newProposal.tsx
+++ b/packages/web-app/src/pages/newProposal.tsx
@@ -50,7 +50,7 @@ const NewProposal: React.FC = () => {
         showTxModal={showTxModal}
         setShowTxModal={setShowTxModal}
       >
-        <ActionsProvider>
+        <ActionsProvider daoId={dao}>
           <FullScreenStepper
             wizardProcessName={t('newProposal.title')}
             navLabel={t('newProposal.title')}

--- a/packages/web-app/src/pages/newProposal.tsx
+++ b/packages/web-app/src/pages/newProposal.tsx
@@ -1,32 +1,29 @@
-import {useTranslation} from 'react-i18next';
 import {withTransaction} from '@elastic/apm-rum-react';
 import React, {useState} from 'react';
-import {useForm, FormProvider, useFormState} from 'react-hook-form';
+import {FormProvider, useForm, useFormState} from 'react-hook-form';
+import {useTranslation} from 'react-i18next';
 import {generatePath} from 'react-router-dom';
 
-import {Governance} from 'utils/paths';
-import AddActionMenu from 'containers/addActionMenu';
-import ReviewProposal from 'containers/reviewProposal';
+import {FullScreenStepper, Step} from 'components/fullScreenStepper';
+import {Loading} from 'components/temporary';
 import ConfigureActions, {
   isValid as actionsAreValid,
 } from 'containers/configureActions';
-import {ActionsProvider} from 'context/actions';
-import {FullScreenStepper, Step} from 'components/fullScreenStepper';
 import DefineProposal, {
   isValid as defineProposalIsValid,
 } from 'containers/defineProposal';
+import ReviewProposal from 'containers/reviewProposal';
 import SetupVotingForm, {
   isValid as setupVotingIsValid,
 } from 'containers/setupVotingForm';
+import {ActionsProvider} from 'context/actions';
+import {CreateProposalProvider} from 'context/createProposal';
 import {useNetwork} from 'context/network';
 import {useDaoParam} from 'hooks/useDaoParam';
-import {Loading} from 'components/temporary';
-import {CreateProposalProvider} from 'context/createProposal';
-import {useDaoActions} from 'hooks/useDaoActions';
+import {Governance} from 'utils/paths';
 
 const NewProposal: React.FC = () => {
   const {data: dao, loading} = useDaoParam();
-  const {data: actions} = useDaoActions(dao);
   const [showTxModal, setShowTxModal] = useState(false);
 
   const {t} = useTranslation();
@@ -90,8 +87,6 @@ const NewProposal: React.FC = () => {
               <ReviewProposal defineProposalStepNumber={1} />
             </Step>
           </FullScreenStepper>
-
-          <AddActionMenu actions={actions} />
         </ActionsProvider>
       </CreateProposalProvider>
     </FormProvider>

--- a/packages/web-app/src/pages/newWithdraw.tsx
+++ b/packages/web-app/src/pages/newWithdraw.tsx
@@ -1,17 +1,17 @@
-import React, {useState} from 'react';
 import {Address} from '@aragon/ui-components/dist/utils/addresses';
-import {useTranslation} from 'react-i18next';
 import {withTransaction} from '@elastic/apm-rum-react';
-import {useForm, FormProvider, useWatch, useFormState} from 'react-hook-form';
+import React, {useState} from 'react';
+import {FormProvider, useForm, useFormState, useWatch} from 'react-hook-form';
+import {useTranslation} from 'react-i18next';
 
-import TokenMenu from 'containers/tokenMenu';
-import {Finance} from 'utils/paths';
-import {formatUnits} from 'utils/library';
+import {FullScreenStepper, Step} from 'components/fullScreenStepper';
 import ReviewProposal from 'containers/reviewProposal';
-import {BaseTokenInfo} from 'utils/types';
+import TokenMenu from 'containers/tokenMenu';
 import {useDaoBalances} from 'hooks/useDaoBalances';
 import {fetchTokenPrice} from 'services/prices';
-import {FullScreenStepper, Step} from 'components/fullScreenStepper';
+import {formatUnits} from 'utils/library';
+import {Finance} from 'utils/paths';
+import {BaseTokenInfo} from 'utils/types';
 
 import ConfigureWithdrawForm, {
   isValid as configureWithdrawScreenIsValid,
@@ -21,15 +21,15 @@ import DefineProposal, {
   isValid as defineProposalIsValid,
 } from 'containers/defineProposal';
 
+import {Loading} from 'components/temporary';
 import SetupVotingForm, {
   isValid as setupVotingIsValid,
 } from 'containers/setupVotingForm';
-import {generatePath} from 'react-router-dom';
+import {ActionsProvider} from 'context/actions';
+import {CreateProposalProvider} from 'context/createProposal';
 import {useNetwork} from 'context/network';
 import {useDaoParam} from 'hooks/useDaoParam';
-import {Loading} from 'components/temporary';
-import {CreateProposalProvider} from 'context/createProposal';
-import {ActionsProvider} from 'context/actions';
+import {generatePath} from 'react-router-dom';
 
 export type TokenFormData = {
   tokenName: string;
@@ -147,7 +147,7 @@ const NewWithdraw: React.FC = () => {
   return (
     <>
       <FormProvider {...formMethods}>
-        <ActionsProvider>
+        <ActionsProvider daoId={dao}>
           <CreateProposalProvider
             showTxModal={showTxModal}
             setShowTxModal={setShowTxModal}

--- a/packages/web-app/src/pages/newWithdraw.tsx
+++ b/packages/web-app/src/pages/newWithdraw.tsx
@@ -168,7 +168,7 @@ const NewWithdraw: React.FC = () => {
                   )
                 }
               >
-                <ConfigureWithdrawForm />
+                <ConfigureWithdrawForm actionIndex={0} />
               </Step>
               <Step
                 wizardTitle={t('newWithdraw.setupVoting.title')}

--- a/packages/web-app/src/utils/types.ts
+++ b/packages/web-app/src/utils/types.ts
@@ -159,6 +159,10 @@ type ExecutionData = {
 
 /* ACTION TYPES ============================================================= */
 
+export type ActionIndex = {
+  actionIndex: number;
+};
+
 /**
  * Metadata for actions. This data can not really be fetched and is therefore
  * declared locally.

--- a/packages/web-app/src/utils/types.ts
+++ b/packages/web-app/src/utils/types.ts
@@ -159,14 +159,30 @@ type ExecutionData = {
 
 /* ACTION TYPES ============================================================= */
 
+/**
+ * Metadata for actions. This data can not really be fetched and is therefore
+ * declared locally.
+ */
 export type ActionParameter = {
   type: ActionsTypes;
+  /**
+   * Name displayed in the UI
+   */
   title: string;
+  /**
+   * Description displayed in the UI
+   */
   subtitle: string;
+  /**
+   * Whether an action can be used several times in a proposal. Currently
+   * actions are either limited to 1 or not limited at all. This might need to
+   * be changed to a number if the rules for reuseability become more complex.
+   */
+  isReuseable?: boolean;
 };
 
 /**
- * Allowed Actions for each dao
+ * All available types of action for DAOs
  */
 export type ActionsTypes =
   | 'add_address'
@@ -196,6 +212,9 @@ export type ActionAddAddress = {
   };
 };
 
+// TODO: Consider making this a generic type that take other types of the form
+// like ActionAddAddres (or more generically, ActionItem...?) instead taking the
+// union of those subtypes. [VR 11-08-2022]
 export type Action = ActionWithdraw | ActionAddAddress;
 
 export type ParamType = {

--- a/packages/web-app/src/utils/types.ts
+++ b/packages/web-app/src/utils/types.ts
@@ -1,4 +1,5 @@
 import {Address} from '@aragon/ui-components/src/utils/addresses';
+
 import {TimeFilter, TransferTypes} from './constants';
 
 /*************************************************
@@ -156,18 +157,7 @@ type ExecutionData = {
   amount: number;
 };
 
-/* GENERIC HOOK RETURN TYPE ================================================= */
-
-/** Return type for data hooks */
-export type HookData<T> = {
-  data: T;
-  isLoading: boolean;
-  error?: Error;
-};
-
-export type Nullable<T> = T | null;
-
-export type SupportedChainId = 1 | 4;
+/* ACTION TYPES ============================================================= */
 
 export type ActionParameter = {
   type: ActionsTypes;
@@ -231,11 +221,22 @@ export type TransactionItem = {
   };
 };
 
+export type Dao = {
+  address: string;
+};
+
+/* UTILITY TYPES ============================================================ */
+
+/** Return type for data hooks */
+export type HookData<T> = {
+  data: T;
+  isLoading: boolean;
+  error?: Error;
+};
+
+export type Nullable<T> = T | null;
+
 export type StringIndexed = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
-};
-
-export type Dao = {
-  address: string;
 };


### PR DESCRIPTION
## Description

This PR limits the number of certain action in the configure action step. This includes:
- Disabling actions in the `ActionMenu` if the limit is reached
- Removing the option to duplicate certain actions (this was only the case for minting token, AFAIK)

Additionally, this PR contains a bit of renaming and restructuring:
- The action context no longer has a `daoAddress` state (which was not used anyway, btw). Instead, in now receives this as a prop. The reason for this is that it should NEVER be able to have a different value in the context then outside of it.
- Any index that indexes an `action` from the form context is now called `actionIndex`.
- Renamed `actionCounter` because it doesn't count actions. (thanks for the headaches, haha)

Task: [722](https://aragonassociation.atlassian.net/browse/APP-722), [792](https://aragonassociation.atlassian.net/browse/APP-792)

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)