### PR TITLE
Fix: Change buttons to secondary on edit settings page

### DIFF
--- a/packages/web-app/src/app.tsx
+++ b/packages/web-app/src/app.tsx
@@ -22,6 +22,7 @@ import Footer from 'containers/exploreFooter';
 import NetworkErrorMenu from 'containers/networkErrorMenu';
 import TransferMenu from 'containers/transferMenu';
 import {useWallet} from 'hooks/useWallet';
+import {useForm, FormProvider} from 'react-hook-form';
 
 const ExplorePage = lazy(() => import('pages/explore'));
 const NotFoundPage = lazy(() => import('pages/notFound'));
@@ -97,11 +98,13 @@ function App() {
               />
               <Route path="community" element={<CommunityPage />} />
               <Route path="settings" element={<SettingsPage />} />
-              <Route path="settings/edit" element={<EditSettingsPage />} />
-              <Route
-                path="settings/new-proposal"
-                element={<ProposeSettingsPage />}
-              />
+              <Route element={<NewSettingsWrapper />}>
+                <Route path="settings/edit" element={<EditSettingsPage />} />
+                <Route
+                  path="settings/new-proposal"
+                  element={<ProposeSettingsPage />}
+                />
+              </Route>
               <Route
                 path="community/mint-tokens"
                 element={<MintTokensProposalPage />}
@@ -120,6 +123,18 @@ function App() {
     </>
   );
 }
+
+const NewSettingsWrapper: React.FC = () => {
+  const formMethods = useForm({
+    mode: 'onChange',
+  });
+
+  return (
+    <FormProvider {...formMethods}>
+      <Outlet />
+    </FormProvider>
+  );
+};
 
 const NotFoundWrapper: React.FC = () => {
   const {pathname} = useLocation();

--- a/packages/web-app/src/pages/editSettings.tsx
+++ b/packages/web-app/src/pages/editSettings.tsx
@@ -98,7 +98,7 @@ const EditSettings: React.FC = () => {
                     : t('settings.edit')
                 }
                 disabled={currentMenu === 'metadata'}
-                mode={currentMenu === 'metadata' ? 'secondary' : 'primary'}
+                mode="secondary"
                 onClick={() => setCurrentMenu('metadata')}
                 bgWhite
               />
@@ -124,7 +124,7 @@ const EditSettings: React.FC = () => {
                     : t('settings.edit')
                 }
                 disabled={currentMenu === 'governance'}
-                mode={currentMenu === 'governance' ? 'secondary' : 'primary'}
+                mode="secondary"
                 onClick={() => setCurrentMenu('governance')}
                 bgWhite
               />

--- a/packages/web-app/src/pages/editSettings.tsx
+++ b/packages/web-app/src/pages/editSettings.tsx
@@ -1,6 +1,5 @@
 import React, {useState} from 'react';
 import {withTransaction} from '@elastic/apm-rum-react';
-import {FormProvider, useForm} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 import {
   AlertInline,
@@ -9,7 +8,6 @@ import {
   IconGovernance,
   Wizard,
 } from '@aragon/ui-components';
-import {constants} from 'ethers';
 import styled from 'styled-components';
 import {
   generatePath,
@@ -27,13 +25,6 @@ import {Loading} from 'components/temporary';
 import {ProposeNewSettings} from 'utils/paths';
 import {useNetwork} from 'context/network';
 
-const defaultValues = {
-  links: [{label: '', href: ''}],
-  wallets: [{address: constants.AddressZero, amount: '0'}],
-  membership: 'token',
-  whitelistWallets: [],
-};
-
 const EditSettings: React.FC = () => {
   const [currentMenu, setCurrentMenu] = useState<'metadata' | 'governance'>(
     'metadata'
@@ -45,123 +36,114 @@ const EditSettings: React.FC = () => {
   const {network} = useNetwork();
   const {dao} = useParams();
   const {breadcrumbs, icon, tag} = useMappedBreadcrumbs();
-  const formMethods = useForm({
-    mode: 'onChange',
-    defaultValues,
-  });
 
   if (loading) {
     return <Loading />;
   }
 
   return (
-    <FormProvider {...formMethods}>
-      <Container>
-        <div className="-mx-2 desktop:mx-0">
-          <Wizard
-            includeStepper={false}
-            title={t('settings.editDaoSettings')}
-            description={t('settings.editSubtitle')}
-            nav={
-              <Breadcrumb
-                icon={icon}
-                crumbs={breadcrumbs}
-                onClick={navigate}
-                tag={tag}
-              />
-            }
-          />
+    <Container>
+      <div className="-mx-2 desktop:mx-0">
+        <Wizard
+          includeStepper={false}
+          title={t('settings.editDaoSettings')}
+          description={t('settings.editSubtitle')}
+          nav={
+            <Breadcrumb
+              icon={icon}
+              crumbs={breadcrumbs}
+              onClick={navigate}
+              tag={tag}
+            />
+          }
+        />
 
-          {isMobile && (
-            <div className="px-2 pb-3 -mt-1 bg-white">
-              <ButtonText
-                className="w-full tablet:w-max"
-                label={t('settings.resetChanges')}
-                mode="secondary"
-                size={isMobile ? 'large' : 'medium'}
-                disabled
-              />
-            </div>
-          )}
-        </div>
-
-        <div>
-          <Accordion>
-            <Heading>{t('labels.review.daoMetadata')}</Heading>
-
-            <HStack>
-              <AlertInline label={t('settings.newSettings')} mode="neutral" />
-              <ButtonText
-                label={
-                  currentMenu === 'metadata'
-                    ? t('settings.resetChanges')
-                    : t('settings.edit')
-                }
-                disabled={currentMenu === 'metadata'}
-                mode="secondary"
-                onClick={() => setCurrentMenu('metadata')}
-                bgWhite
-              />
-            </HStack>
-          </Accordion>
-          {currentMenu === 'metadata' && (
-            <AccordionContent>
-              <DefineMetadata />
-            </AccordionContent>
-          )}
-        </div>
-
-        <div>
-          <Accordion>
-            <Heading>{t('labels.review.governance')}</Heading>
-
-            <HStack>
-              <AlertInline label={t('settings.newSettings')} mode="neutral" />
-              <ButtonText
-                label={
-                  currentMenu === 'governance'
-                    ? t('settings.resetChanges')
-                    : t('settings.edit')
-                }
-                disabled={currentMenu === 'governance'}
-                mode="secondary"
-                onClick={() => setCurrentMenu('governance')}
-                bgWhite
-              />
-            </HStack>
-          </Accordion>
-          {currentMenu === 'governance' && (
-            <AccordionContent>
-              <ConfigureCommunity />
-            </AccordionContent>
-          )}
-        </div>
-
-        <ButtonContainer>
-          <HStack>
-            <RouterLink to={generatePath(ProposeNewSettings, {network, dao})}>
-              <ButtonText
-                className="w-full tablet:w-max"
-                label={t('settings.proposeSettings')}
-                iconLeft={<IconGovernance />}
-                size={isMobile ? 'large' : 'medium'}
-              />
-            </RouterLink>
+        {isMobile && (
+          <div className="px-2 pb-3 -mt-1 bg-white">
             <ButtonText
               className="w-full tablet:w-max"
               label={t('settings.resetChanges')}
               mode="secondary"
               size={isMobile ? 'large' : 'medium'}
+              disabled
+            />
+          </div>
+        )}
+      </div>
+
+      <div>
+        <Accordion>
+          <Heading>{t('labels.review.daoMetadata')}</Heading>
+
+          <HStack>
+            <AlertInline label={t('settings.newSettings')} mode="neutral" />
+            <ButtonText
+              label={
+                currentMenu === 'metadata'
+                  ? t('settings.resetChanges')
+                  : t('settings.edit')
+              }
+              disabled={currentMenu === 'metadata'}
+              mode="secondary"
+              onClick={() => setCurrentMenu('metadata')}
+              bgWhite
             />
           </HStack>
+        </Accordion>
+        {currentMenu === 'metadata' && (
+          <AccordionContent>
+            <DefineMetadata />
+          </AccordionContent>
+        )}
+      </div>
 
-          <AlertInline
-            label={t('settings.proposeSettingsInfo')}
-            mode="neutral"
+      <div>
+        <Accordion>
+          <Heading>{t('labels.review.governance')}</Heading>
+
+          <HStack>
+            <AlertInline label={t('settings.newSettings')} mode="neutral" />
+            <ButtonText
+              label={
+                currentMenu === 'governance'
+                  ? t('settings.resetChanges')
+                  : t('settings.edit')
+              }
+              disabled={currentMenu === 'governance'}
+              mode="secondary"
+              onClick={() => setCurrentMenu('governance')}
+              bgWhite
+            />
+          </HStack>
+        </Accordion>
+        {currentMenu === 'governance' && (
+          <AccordionContent>
+            <ConfigureCommunity />
+          </AccordionContent>
+        )}
+      </div>
+
+      <ButtonContainer>
+        <HStack>
+          <RouterLink to={generatePath(ProposeNewSettings, {network, dao})}>
+            <ButtonText
+              className="w-full tablet:w-max"
+              label={t('settings.proposeSettings')}
+              iconLeft={<IconGovernance />}
+              size={isMobile ? 'large' : 'medium'}
+            />
+          </RouterLink>
+          <ButtonText
+            className="w-full tablet:w-max"
+            label={t('settings.resetChanges')}
+            mode="secondary"
+            size={isMobile ? 'large' : 'medium'}
           />
-        </ButtonContainer>
-      </Container>
-    </FormProvider>
+        </HStack>
+
+        <AlertInline label={t('settings.proposeSettingsInfo')} mode="neutral" />
+      </ButtonContainer>
+    </Container>
   );
 };
 

--- a/packages/web-app/src/pages/proposeSettings.tsx
+++ b/packages/web-app/src/pages/proposeSettings.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {useTranslation} from 'react-i18next';
 import {withTransaction} from '@elastic/apm-rum-react';
-import {useForm, FormProvider} from 'react-hook-form';
 import {generatePath, useParams} from 'react-router-dom';
 
 import ReviewProposal from 'containers/reviewProposal';
@@ -17,47 +16,41 @@ const ProposeSettings: React.FC = () => {
   const {dao} = useParams();
   const {network} = useNetwork();
 
-  const formMethods = useForm({
-    mode: 'onChange',
-  });
-
   return (
     <>
-      <FormProvider {...formMethods}>
-        <FullScreenStepper
-          wizardProcessName={t('newProposal.title')}
-          navLabel={t('navLinks.settings')}
-          returnPath={generatePath(EditSettings, {network, dao})}
+      <FullScreenStepper
+        wizardProcessName={t('newProposal.title')}
+        navLabel={t('navLinks.settings')}
+        returnPath={generatePath(EditSettings, {network, dao})}
+      >
+        <Step
+          wizardTitle={t('settings.proposeSettings')}
+          wizardDescription={t('settings.proposeSettingsSubtitle')}
         >
-          <Step
-            wizardTitle={t('settings.proposeSettings')}
-            wizardDescription={t('settings.proposeSettingsSubtitle')}
-          >
-            <CompareSettings />
-          </Step>
-          <Step
-            wizardTitle={t('newWithdraw.defineProposal.heading')}
-            wizardDescription={t('newWithdraw.defineProposal.description')}
-          >
-            <DefineProposal />
-          </Step>
-          <Step
-            wizardTitle={t('newWithdraw.setupVoting.title')}
-            wizardDescription={t('newWithdraw.setupVoting.description')}
-          >
-            <SetupVotingForm />
-          </Step>
-          <Step
-            wizardTitle={t('newWithdraw.reviewProposal.heading')}
-            wizardDescription={t('newWithdraw.reviewProposal.description')}
-            nextButtonLabel={t('labels.submitWithdraw')}
-            isNextButtonDisabled
-            fullWidth
-          >
-            <ReviewProposal defineProposalStepNumber={2} />
-          </Step>
-        </FullScreenStepper>
-      </FormProvider>
+          <CompareSettings />
+        </Step>
+        <Step
+          wizardTitle={t('newWithdraw.defineProposal.heading')}
+          wizardDescription={t('newWithdraw.defineProposal.description')}
+        >
+          <DefineProposal />
+        </Step>
+        <Step
+          wizardTitle={t('newWithdraw.setupVoting.title')}
+          wizardDescription={t('newWithdraw.setupVoting.description')}
+        >
+          <SetupVotingForm />
+        </Step>
+        <Step
+          wizardTitle={t('newWithdraw.reviewProposal.heading')}
+          wizardDescription={t('newWithdraw.reviewProposal.description')}
+          nextButtonLabel={t('labels.submitWithdraw')}
+          isNextButtonDisabled
+          fullWidth
+        >
+          <ReviewProposal defineProposalStepNumber={2} />
+        </Step>
+      </FullScreenStepper>
     </>
   );
 };


### PR DESCRIPTION
## Description

- Changes the "Edit Settings" button on the edit settings page to secondary
 
**The rest is just formatting of code. I had removed FormProvider from both edit settings & propose new settings page and added a common form provider in app.tsx for those 2 pages as form values need to be shared between the two pages**

Task: [APP-820](https://aragonassociation.atlassian.net/browse/APP-820)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.