### PR TITLE
fix plugin client hook arg order

### DIFF
--- a/packages/web-app/src/context/createProposal.tsx
+++ b/packages/web-app/src/context/createProposal.tsx
@@ -52,7 +52,7 @@ const CreateProposalProvider: React.FC<Props> = ({
     [type]
   );
 
-  const pluginClient = usePluginClient(pluginType, pluginAddress);
+  const pluginClient = usePluginClient(pluginAddress, pluginType);
 
   const [creationProcessState, setCreationProcessState] =
     useState<TransactionState>(TransactionState.WAITING);

--- a/packages/web-app/src/hooks/useDaoProposal.tsx
+++ b/packages/web-app/src/hooks/useDaoProposal.tsx
@@ -28,7 +28,7 @@ export const useDaoProposal = (
   const [error, setError] = useState<Error>();
   const [isLoading, setIsLoading] = useState(false);
 
-  const client = usePluginClient(type, pluginAddress);
+  const client = usePluginClient(pluginAddress, type);
 
   useEffect(() => {
     async function getDaoProposal() {


### PR DESCRIPTION
## Description

Fixes an error cause by setting one of the `usePlulginClient` to optional and having to reverse the order in the function signature.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
