### PR TITLE
App 1072 Fix settings flow issues

### DIFF
--- a/packages/web-app/src/components/addLinks/index.tsx
+++ b/packages/web-app/src/components/addLinks/index.tsx
@@ -1,22 +1,29 @@
-import React from 'react';
-import styled from 'styled-components';
-import {useTranslation} from 'react-i18next';
 import {ButtonText, IconAdd} from '@aragon/ui-components';
-import {useFormContext, useFieldArray, useWatch} from 'react-hook-form';
+import React from 'react';
+import {useFieldArray, useFormContext, useWatch} from 'react-hook-form';
+import {useTranslation} from 'react-i18next';
+import styled from 'styled-components';
 
-import Row from './row';
 import Header from './header';
+import Row from './row';
 
 export type AddLinks = {
+  /** Name of the fieldArray that is the target of the link inputs. Defaults to
+   * 'links' */
+  arrayName?: string;
   buttonPlusIcon?: boolean;
   buttonLabel?: string;
 };
 
-const AddLinks: React.FC<AddLinks> = ({buttonPlusIcon, buttonLabel}) => {
+const AddLinks: React.FC<AddLinks> = ({
+  buttonPlusIcon,
+  buttonLabel,
+  arrayName = 'links',
+}) => {
   const {t} = useTranslation();
   const {control} = useFormContext();
-  const links = useWatch({name: 'links', control});
-  const {fields, append, remove} = useFieldArray({name: 'links', control});
+  const links = useWatch({name: arrayName, control});
+  const {fields, append, remove} = useFieldArray({name: arrayName, control});
 
   const controlledLinks = fields.map((field, index) => {
     return {
@@ -36,7 +43,12 @@ const AddLinks: React.FC<AddLinks> = ({buttonPlusIcon, buttonLabel}) => {
         <ListGroup>
           <Header />
           {controlledLinks.map((field, index) => (
-            <Row key={field.id} index={index} onDelete={() => remove(index)} />
+            <Row
+              key={field.id}
+              index={index}
+              onDelete={() => remove(index)}
+              arrayName={arrayName}
+            />
           ))}
         </ListGroup>
       )}

--- a/packages/web-app/src/components/addLinks/row.tsx
+++ b/packages/web-app/src/components/addLinks/row.tsx
@@ -22,13 +22,20 @@ import {isOnlyWhitespace} from 'utils/library';
 type LinkRowProps = {
   index: number;
   onDelete?: (index: number) => void;
+  /** Name of the fieldArray that is the target of the link inputs. Defaults to
+   * 'links' */
+  arrayName?: string;
 };
 
 const UrlRegex = new RegExp(URL_PATTERN);
 const EmailRegex = new RegExp(EMAIL_PATTERN);
 const UrlWithProtocolRegex = new RegExp(URL_WITH_PROTOCOL_PATTERN);
 
-const LinkRow: React.FC<LinkRowProps> = ({index, onDelete}) => {
+const LinkRow: React.FC<LinkRowProps> = ({
+  index,
+  onDelete,
+  arrayName = 'links',
+}) => {
   const {t} = useTranslation();
   const {control, clearErrors, getValues, trigger, setValue} = useFormContext();
   const {errors} = useFormState();
@@ -59,11 +66,11 @@ const LinkRow: React.FC<LinkRowProps> = ({index, onDelete}) => {
 
   const labelValidator = useCallback(
     (label: string, index: number) => {
-      if (linkedFieldsAreValid(label, `links.${index}.url`)) return;
+      if (linkedFieldsAreValid(label, `${arrayName}.${index}.url`)) return;
 
       return isOnlyWhitespace(label) ? t('errors.required.label') : true;
     },
-    [linkedFieldsAreValid, t]
+    [arrayName, linkedFieldsAreValid, t]
   );
 
   const addProtocolToLinks = useCallback(
@@ -84,7 +91,7 @@ const LinkRow: React.FC<LinkRowProps> = ({index, onDelete}) => {
 
   const linkValidator = useCallback(
     (url: string, index: number) => {
-      if (linkedFieldsAreValid(url, `links.${index}.label`)) return;
+      if (linkedFieldsAreValid(url, `${arrayName}.${index}.label`)) return;
 
       if (url === '') return t('errors.required.link');
 
@@ -92,7 +99,7 @@ const LinkRow: React.FC<LinkRowProps> = ({index, onDelete}) => {
         ? true
         : t('errors.invalidURL');
     },
-    [linkedFieldsAreValid, t]
+    [arrayName, linkedFieldsAreValid, t]
   );
 
   /*************************************************
@@ -103,7 +110,7 @@ const LinkRow: React.FC<LinkRowProps> = ({index, onDelete}) => {
       <LabelContainer>
         <Controller
           control={control}
-          name={`links.${index}.name`}
+          name={`${arrayName}.${index}.name`}
           rules={{
             validate: value => labelValidator(value, index),
           }}
@@ -129,7 +136,7 @@ const LinkRow: React.FC<LinkRowProps> = ({index, onDelete}) => {
 
       <LinkContainer>
         <Controller
-          name={`links.${index}.url`}
+          name={`${arrayName}.${index}.url`}
           control={control}
           rules={{
             validate: value => linkValidator(value, index),

--- a/packages/web-app/src/containers/compareSettings/index.tsx
+++ b/packages/web-app/src/containers/compareSettings/index.tsx
@@ -4,20 +4,28 @@ import {
   ListItemLink,
   Option,
 } from '@aragon/ui-components';
+import React, {useState} from 'react';
+import {useFormContext} from 'react-hook-form';
+import {useTranslation} from 'react-i18next';
+import {generatePath, useNavigate} from 'react-router-dom';
+
 import {Dd, DescriptionListContainer, Dl, Dt} from 'components/descriptionList';
 import {useNetwork} from 'context/network';
 import {useDaoParam} from 'hooks/useDaoParam';
-import React, {useState} from 'react';
-import {useTranslation} from 'react-i18next';
-import {generatePath, useNavigate} from 'react-router-dom';
 import {EditSettings} from 'utils/paths';
 
 const CompareSettings: React.FC = () => {
-  const [selectedButton, setSelectedButton] = useState('new');
   const {t} = useTranslation();
   const navigate = useNavigate();
   const {data: daoId} = useDaoParam();
   const {network} = useNetwork();
+  const {getValues} = useFormContext();
+
+  const [selectedButton, setSelectedButton] = useState<'new' | 'old'>('new');
+
+  const onButtonGroupChangeHandler = () => {
+    setSelectedButton(prev => (prev === 'new' ? 'old' : 'new'));
+  };
 
   return (
     <div className="space-y-2">
@@ -25,7 +33,7 @@ const CompareSettings: React.FC = () => {
         <ButtonGroup
           bgWhite={false}
           defaultValue={selectedButton}
-          onChange={setSelectedButton}
+          onChange={onButtonGroupChangeHandler}
         >
           <Option value="new" label={t('settings.newSettings')} />
           <Option value="old" label={t('settings.oldSettings')} />
@@ -47,21 +55,23 @@ const CompareSettings: React.FC = () => {
         </Dl>
         <Dl>
           <Dt>{t('labels.daoName')}</Dt>
-          <Dd>Aragon DAO</Dd>
+          <Dd>{getValues('daoName')}</Dd>
         </Dl>
         <Dl>
           <Dt>{t('labels.summary')}</Dt>
-          <Dd>
-            This is a short description of your DAO, so please look that
-            it&apos;s not that long as wished. 👀
-          </Dd>
+          <Dd>{getValues('daoSummary')}</Dd>
         </Dl>
         <Dl>
           <Dt>{t('labels.links')}</Dt>
           <Dd>
             <div className="space-y-1.5">
-              <ListItemLink label="Forum" href="https://forum.aragon.org" />
-              <ListItemLink label="Discord" href="https://discord.com" />
+              {getValues('links').map((link: {name: string; url: string}) => (
+                <ListItemLink
+                  key={link.name + link.url}
+                  label={link.name}
+                  href={link.url}
+                />
+              ))}
             </div>
           </Dd>
         </Dl>
@@ -76,15 +86,21 @@ const CompareSettings: React.FC = () => {
       >
         <Dl>
           <Dt>{t('labels.minimumApproval')}</Dt>
-          <Dd>15% (150 TKN)</Dd>
+          <Dd> {getValues('minimumApproval')}%</Dd>
         </Dl>
         <Dl>
           <Dt>{t('labels.minimumSupport')}</Dt>
-          <Dd>50%</Dd>
+          <Dd>{getValues('minimumParticipation')}%</Dd>
         </Dl>
         <Dl>
           <Dt>{t('labels.minimumDuration')}</Dt>
-          <Dd>5 Days 12 Hours 30 Minutes</Dd>
+          <Dd>
+            {t('governance.settings.preview', {
+              days: getValues('durationDays'),
+              hours: getValues('durationHours'),
+              minutes: getValues('durationMinutes'),
+            })}
+          </Dd>
         </Dl>
       </DescriptionListContainer>
     </div>

--- a/packages/web-app/src/containers/compareSettings/index.tsx
+++ b/packages/web-app/src/containers/compareSettings/index.tsx
@@ -65,13 +65,15 @@ const CompareSettings: React.FC = () => {
           <Dt>{t('labels.links')}</Dt>
           <Dd>
             <div className="space-y-1.5">
-              {getValues('links').map((link: {name: string; url: string}) => (
-                <ListItemLink
-                  key={link.name + link.url}
-                  label={link.name}
-                  href={link.url}
-                />
-              ))}
+              {getValues('daoLinks').map(
+                (link: {name: string; url: string}) => (
+                  <ListItemLink
+                    key={link.name + link.url}
+                    label={link.name}
+                    href={link.url}
+                  />
+                )
+              )}
             </div>
           </Dd>
         </Dl>

--- a/packages/web-app/src/containers/defineMetadata/index.tsx
+++ b/packages/web-app/src/containers/defineMetadata/index.tsx
@@ -5,14 +5,14 @@ import {
   TextareaSimple,
   TextInput,
 } from '@aragon/ui-components';
-import styled from 'styled-components';
-import {useTranslation} from 'react-i18next';
 import React, {useCallback} from 'react';
 import {Controller, FieldError, useFormContext} from 'react-hook-form';
+import {useTranslation} from 'react-i18next';
+import styled from 'styled-components';
 
 import AddLinks from 'components/addLinks';
-import {isOnlyWhitespace} from 'utils/library';
 import {URL_PATTERN} from 'utils/constants';
+import {isOnlyWhitespace} from 'utils/library';
 
 const DAO_LOGO = {
   maxDimension: 2400,
@@ -163,7 +163,7 @@ const DefineMetadata: React.FC = () => {
           helpText={t('createDAO.step2.linksSubtitle')}
           isOptional
         />
-        <AddLinks />
+        <AddLinks arrayName="daoLinks" />
       </FormItem>
     </>
   );

--- a/packages/web-app/src/pages/editSettings.tsx
+++ b/packages/web-app/src/pages/editSettings.tsx
@@ -42,7 +42,7 @@ const EditSettings: React.FC = () => {
 
   const {setValue, control} = useFormContext();
   const {fields, replace} = useFieldArray({
-    name: 'links',
+    name: 'daoLinks',
     control,
   });
   const {errors} = useFormState({control});
@@ -82,7 +82,7 @@ const EditSettings: React.FC = () => {
       'durationHours',
       'durationMinutes',
       'membership',
-      'links',
+      'daoLinks',
     ],
     control,
   });
@@ -110,7 +110,11 @@ const EditSettings: React.FC = () => {
         i++
       ) {
         // check if link is filled without error -> then consider it as a proper change
-        if (resourceLinks[i].name && resourceLinks[i].url && !errors.links?.[i])
+        if (
+          resourceLinks[i].name &&
+          resourceLinks[i].url &&
+          !errors.daoLinks?.[i]
+        )
           return false;
       }
     }
@@ -131,7 +135,7 @@ const EditSettings: React.FC = () => {
   }, [
     controlledLinks,
     daoDetails?.metadata.links,
-    errors.links,
+    errors.daoLinks,
     resourceLinks,
   ]);
 
@@ -198,7 +202,7 @@ const EditSettings: React.FC = () => {
      * daoDetails and then replacing them with the proper values
      */
     if (daoDetails?.metadata.links) {
-      setValue('links', [...daoDetails.metadata.links.map(() => ({}))]);
+      setValue('daoLinks', [...daoDetails.metadata.links.map(() => ({}))]);
       replace([...daoDetails.metadata.links]);
     }
   }, [


### PR DESCRIPTION
## Description

Fixes the following issues on the settings and corresponding flow:
- New Settings in the compare view now get actual data from the previously edited settings
- Links for the DAO and links for the proposal are now separated.
- Mockdata for settings page now come from SDK rather than being hardcoded

Task: [APP-1072](https://aragonassociation.atlassian.net/browse/APP-1072)

Some things have not yet been resolved:
- Show old data on new/old settings comparison view
- Fixing minimum approval/participation being NaN

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
