### PR TITLE
Feature: APP-1081 - Proposal Creation Nav: Main & Withdraw Flows

### DIFF
--- a/packages/web-app/src/containers/actionBuilder/mintTokens/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/mintTokens/index.tsx
@@ -150,8 +150,8 @@ export const MintTokenForm: React.FC<MintTokenFormProps> = ({
 
   useEffect(() => {
     // Fetching necessary info about the token.
-    if (daoToken?.id) {
-      getTokenInfo(daoToken.id, infura, nativeCurrency)
+    if (daoToken?.address) {
+      getTokenInfo(daoToken.address, infura, nativeCurrency)
         .then((r: Awaited<ReturnType<typeof getTokenInfo>>) => {
           const formattedNumber = parseFloat(
             formatUnits(r.totalSupply, r.decimals)
@@ -167,7 +167,7 @@ export const MintTokenForm: React.FC<MintTokenFormProps> = ({
           );
           setValue(
             `actions.${actionIndex}.summary.daoTokenAddress`,
-            daoToken.id
+            daoToken.address
           );
         })
         .catch(e =>
@@ -175,17 +175,17 @@ export const MintTokenForm: React.FC<MintTokenFormProps> = ({
         );
     }
   }, [
-    daoToken.id,
+    daoToken?.address,
     nativeCurrency,
     infura,
     setValue,
     actionIndex,
-    daoToken.symbol,
+    daoToken?.symbol,
   ]);
 
   // Count number of addresses that don't yet own token
   useEffect(() => {
-    if (mints && daoToken?.id) {
+    if (mints && daoToken?.address) {
       // only check rows where form input holds address
       const validInputs = mints.filter(
         m => m.address !== '' && isAddress(m.address)
@@ -211,7 +211,7 @@ export const MintTokenForm: React.FC<MintTokenFormProps> = ({
         const promises: Promise<AddressBalance>[] = uncheckedAddresses.map(
           (m: MintInfo) =>
             fetchBalance(
-              daoToken.id,
+              daoToken.address,
               m.address,
               infura,
               nativeCurrency,
@@ -252,7 +252,7 @@ export const MintTokenForm: React.FC<MintTokenFormProps> = ({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mints, daoToken.id]);
+  }, [mints, daoToken?.address]);
 
   useEffect(() => {
     // Collecting token amounts that are to be minted
@@ -280,7 +280,7 @@ export const MintTokenForm: React.FC<MintTokenFormProps> = ({
         );
       }
     }
-  }, [mints, daoToken, daoToken.id, setValue, actionIndex, newTokens]);
+  }, [mints, daoToken, daoToken?.address, setValue, actionIndex, newTokens]);
 
   /*************************************************
    *             Callbacks and Handlers            *
@@ -383,7 +383,7 @@ export const MintTokenForm: React.FC<MintTokenFormProps> = ({
           <HStack>
             <Label>{t('labels.newTokens')}</Label>
             <p>
-              +{'' + newTokens} {daoToken.symbol}
+              +{'' + newTokens} {daoToken?.symbol}
             </p>
           </HStack>
           <HStack>
@@ -394,7 +394,7 @@ export const MintTokenForm: React.FC<MintTokenFormProps> = ({
             <Label>{t('labels.totalTokens')}</Label>
             {tokenSupply ? (
               <p>
-                {'' + newTokens.plus(Big(tokenSupply))} {daoToken.symbol}
+                {'' + newTokens.plus(Big(tokenSupply))} {daoToken?.symbol}
               </p>
             ) : (
               <p>...</p>

--- a/packages/web-app/src/context/apolloClient.tsx
+++ b/packages/web-app/src/context/apolloClient.tsx
@@ -9,7 +9,14 @@ import {AddressListProposal, Deposit, Erc20Proposal} from '@aragon/sdk-client';
 import {RestLink} from 'apollo-link-rest';
 import {CachePersistor, LocalStorageWrapper} from 'apollo3-cache-persist';
 
-import {BASE_URL, SUBGRAPH_API_URL, SupportedNetworks} from 'utils/constants';
+import {
+  BASE_URL,
+  PENDING_DEPOSITS_KEY,
+  PENDING_PROPOSALS_KEY,
+  PENDING_VOTES_KEY,
+  SUBGRAPH_API_URL,
+  SupportedNetworks,
+} from 'utils/constants';
 import {customJSONReviver} from 'utils/library';
 import {AddressListVote, Erc20ProposalVote} from 'utils/types';
 import {PRIVACY_KEY} from './privacyContext';
@@ -127,7 +134,9 @@ const favoriteDAOs = makeVar<Array<favoriteDAO>>([
 ]);
 selectedDAO(favoriteDAOs()[0]);
 
-const depositTxs = JSON.parse(localStorage.getItem('pendingDeposits') || '[]');
+const depositTxs = JSON.parse(
+  localStorage.getItem(PENDING_DEPOSITS_KEY) || '[]'
+);
 const pendingDeposits = makeVar<Deposit[]>(depositTxs);
 
 // PENDING VOTES
@@ -135,7 +144,9 @@ type PendingVotes = {
   /** key is proposal id */
   [key: string]: AddressListVote | Erc20ProposalVote;
 };
-const pendingVotes = JSON.parse(localStorage.getItem('pendingVotes') || '{}');
+const pendingVotes = JSON.parse(
+  localStorage.getItem(PENDING_VOTES_KEY) || '{}'
+);
 const pendingVotesVar = makeVar<PendingVotes>(pendingVotes);
 
 // PENDING PROPOSAL
@@ -144,7 +155,7 @@ type PendingProposals = {
   [key: string]: Erc20Proposal | AddressListProposal;
 };
 const pendingProposals = JSON.parse(
-  localStorage.getItem('pendingProposals') || '{}',
+  localStorage.getItem(PENDING_PROPOSALS_KEY) || '{}',
   customJSONReviver
 );
 const pendingProposalsVar = makeVar<PendingProposals>(pendingProposals);

--- a/packages/web-app/src/context/apolloClient.tsx
+++ b/packages/web-app/src/context/apolloClient.tsx
@@ -10,6 +10,7 @@ import {RestLink} from 'apollo-link-rest';
 import {CachePersistor, LocalStorageWrapper} from 'apollo3-cache-persist';
 
 import {BASE_URL, SUBGRAPH_API_URL, SupportedNetworks} from 'utils/constants';
+import {customJSONReviver} from 'utils/library';
 import {AddressListVote, Erc20ProposalVote} from 'utils/types';
 import {PRIVACY_KEY} from './privacyContext';
 
@@ -138,14 +139,15 @@ const pendingVotes = JSON.parse(localStorage.getItem('pendingVotes') || '{}');
 const pendingVotesVar = makeVar<PendingVotes>(pendingVotes);
 
 // PENDING PROPOSAL
-type PendingProposal = {
+type PendingProposals = {
   /** key is proposal id */
   [key: string]: Erc20Proposal | AddressListProposal;
 };
 const pendingProposals = JSON.parse(
-  localStorage.getItem('pendingProposals') || '{}'
+  localStorage.getItem('pendingProposals') || '{}',
+  customJSONReviver
 );
-const pendingProposalsVar = makeVar<PendingProposal>(pendingProposals);
+const pendingProposalsVar = makeVar<PendingProposals>(pendingProposals);
 
 export {
   client,

--- a/packages/web-app/src/context/apolloClient.tsx
+++ b/packages/web-app/src/context/apolloClient.tsx
@@ -5,7 +5,7 @@ import {
   makeVar,
   NormalizedCacheObject,
 } from '@apollo/client';
-import {Deposit} from '@aragon/sdk-client';
+import {AddressListProposal, Deposit, Erc20Proposal} from '@aragon/sdk-client';
 import {RestLink} from 'apollo-link-rest';
 import {CachePersistor, LocalStorageWrapper} from 'apollo3-cache-persist';
 
@@ -131,9 +131,27 @@ const pendingDeposits = makeVar<Deposit[]>(depositTxs);
 
 // PENDING VOTES
 type PendingVotes = {
+  /** key is proposal id */
   [key: string]: AddressListVote | Erc20ProposalVote;
 };
 const pendingVotes = JSON.parse(localStorage.getItem('pendingVotes') || '{}');
 const pendingVotesVar = makeVar<PendingVotes>(pendingVotes);
 
-export {client, favoriteDAOs, selectedDAO, pendingDeposits, pendingVotesVar};
+// PENDING PROPOSAL
+type PendingProposal = {
+  /** key is proposal id */
+  [key: string]: Erc20Proposal | AddressListProposal;
+};
+const pendingProposals = JSON.parse(
+  localStorage.getItem('pendingProposals') || '{}'
+);
+const pendingProposalsVar = makeVar<PendingProposal>(pendingProposals);
+
+export {
+  client,
+  favoriteDAOs,
+  selectedDAO,
+  pendingDeposits,
+  pendingProposalsVar,
+  pendingVotesVar,
+};

--- a/packages/web-app/src/context/deposit.tsx
+++ b/packages/web-app/src/context/deposit.tsx
@@ -21,7 +21,7 @@ import {useWallet} from 'hooks/useWallet';
 import {useNetwork} from './network';
 import DepositModal from 'containers/transactionModals/DepositModal';
 import {DepositFormData} from 'pages/newDeposit';
-import {TransactionState} from 'utils/constants';
+import {PENDING_DEPOSITS_KEY, TransactionState} from 'utils/constants';
 import {isNativeToken} from 'utils/tokens';
 import {useStepper} from 'hooks/useStepper';
 import {usePollGasFee} from 'hooks/usePollGasfee';
@@ -244,7 +244,10 @@ const DepositProvider = ({children}: {children: ReactNode}) => {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           pendingDeposits(depositTxs);
-          localStorage.setItem('pendingDeposits', JSON.stringify(depositTxs));
+          localStorage.setItem(
+            PENDING_DEPOSITS_KEY,
+            JSON.stringify(depositTxs)
+          );
           trackEvent('newDeposit_transaction_signed', {
             network,
             wallet_provider: provider?.connection.url,

--- a/packages/web-app/src/hooks/useDaoActions.tsx
+++ b/packages/web-app/src/hooks/useDaoActions.tsx
@@ -1,11 +1,11 @@
 import {useTranslation} from 'react-i18next';
 
 import {ActionParameter, HookData} from 'utils/types';
-import {useDaoMetadata} from './useDaoMetadata';
+import {useDaoDetails} from './useDaoDetails';
 
 export function useDaoActions(dao: string): HookData<ActionParameter[]> {
-  const {data, error, isLoading} = useDaoMetadata(dao);
-  const whitelist = data?.packages[0].pkg.__typename === 'AllowlistPackage';
+  const {data: daoDetails, error, isLoading} = useDaoDetails(dao);
+  const whitelist = daoDetails?.plugins[0].id === 'addresslistvoting.dao.eth';
 
   const {t} = useTranslation();
 

--- a/packages/web-app/src/hooks/useDaoProposal.tsx
+++ b/packages/web-app/src/hooks/useDaoProposal.tsx
@@ -15,14 +15,12 @@ import {useCallback, useEffect, useState} from 'react';
 
 import {pendingProposalsVar, pendingVotesVar} from 'context/apolloClient';
 import {isTokenBasedProposal, MappedVotes} from 'utils/proposals';
-import {Erc20ProposalVote, HookData} from 'utils/types';
+import {DetailedProposal, Erc20ProposalVote, HookData} from 'utils/types';
 import {useClient} from './useClient';
 import {PluginTypes, usePluginClient} from './usePluginClient';
 import {usePrivacyContext} from 'context/privacyContext';
 import {PENDING_PROPOSALS_KEY, PENDING_VOTES_KEY} from 'utils/constants';
 import {customJSONReplacer} from 'utils/library';
-
-export type DetailedProposal = Erc20Proposal | AddressListProposal;
 
 /**
  * Retrieve a single detailed proposal

--- a/packages/web-app/src/hooks/useDaoProposal.tsx
+++ b/packages/web-app/src/hooks/useDaoProposal.tsx
@@ -19,6 +19,7 @@ import {Erc20ProposalVote, HookData} from 'utils/types';
 import {useClient} from './useClient';
 import {PluginTypes, usePluginClient} from './usePluginClient';
 import {usePrivacyContext} from 'context/privacyContext';
+import {PENDING_PROPOSALS_KEY} from 'utils/constants';
 
 export type DetailedProposal = Erc20Proposal | AddressListProposal;
 
@@ -153,7 +154,7 @@ export const useDaoProposal = (
           if (cachedProposal) {
             pendingProposalsVar({});
             if (preferences?.functional) {
-              localStorage.setItem('pendingProposals', '{}');
+              localStorage.setItem(PENDING_PROPOSALS_KEY, '{}');
             }
           }
         } else if (cachedProposal) {

--- a/packages/web-app/src/hooks/useDaoProposal.tsx
+++ b/packages/web-app/src/hooks/useDaoProposal.tsx
@@ -18,6 +18,7 @@ import {isTokenBasedProposal, MappedVotes} from 'utils/proposals';
 import {Erc20ProposalVote, HookData} from 'utils/types';
 import {useClient} from './useClient';
 import {PluginTypes, usePluginClient} from './usePluginClient';
+import {usePrivacyContext} from 'context/privacyContext';
 
 export type DetailedProposal = Erc20Proposal | AddressListProposal;
 
@@ -41,6 +42,7 @@ export const useDaoProposal = (
   const {client: globalClient} = useClient();
   const pluginClient = usePluginClient(pluginType);
 
+  const {preferences} = usePrivacyContext();
   const cachedVotes = useReactiveVar(pendingVotesVar);
   const cachedProposals = useReactiveVar(pendingProposalsVar);
 
@@ -149,8 +151,10 @@ export const useDaoProposal = (
 
           // remove cache there's already a proposal
           if (cachedProposal) {
-            delete cachedProposals[proposalId];
-            pendingProposalsVar({...cachedProposals});
+            pendingProposalsVar({});
+            if (preferences?.functional) {
+              localStorage.setItem('pendingProposals', '{}');
+            }
           }
         } else if (cachedProposal) {
           setData({...augmentProposalWithCache(cachedProposal)});
@@ -168,6 +172,7 @@ export const useDaoProposal = (
     cachedProposals,
     getEncodedAction,
     pluginClient?.methods,
+    preferences?.functional,
     proposalId,
   ]);
 

--- a/packages/web-app/src/hooks/useDaoProposal.tsx
+++ b/packages/web-app/src/hooks/useDaoProposal.tsx
@@ -19,7 +19,8 @@ import {Erc20ProposalVote, HookData} from 'utils/types';
 import {useClient} from './useClient';
 import {PluginTypes, usePluginClient} from './usePluginClient';
 import {usePrivacyContext} from 'context/privacyContext';
-import {PENDING_PROPOSALS_KEY} from 'utils/constants';
+import {PENDING_PROPOSALS_KEY, PENDING_VOTES_KEY} from 'utils/constants';
+import {customJSONReplacer} from 'utils/library';
 
 export type DetailedProposal = Erc20Proposal | AddressListProposal;
 
@@ -104,7 +105,14 @@ export const useDaoProposal = (
       if (proposal.votes.some(voter => voter.address === cachedVote.address)) {
         const newCache = {...cachedVotes};
         delete newCache[proposal.id];
+
         pendingVotesVar({...newCache});
+        if (preferences?.functional) {
+          localStorage.setItem(
+            PENDING_VOTES_KEY,
+            JSON.stringify(newCache, customJSONReplacer)
+          );
+        }
         return proposal;
       }
 
@@ -134,7 +142,7 @@ export const useDaoProposal = (
         } as AddressListProposal;
       }
     },
-    [cachedVotes]
+    [cachedVotes, preferences?.functional]
   );
 
   useEffect(() => {

--- a/packages/web-app/src/hooks/useDaoTransfers.tsx
+++ b/packages/web-app/src/hooks/useDaoTransfers.tsx
@@ -6,6 +6,7 @@ import {useEffect, useState} from 'react';
 import {pendingDeposits} from 'context/apolloClient';
 import {HookData} from 'utils/types';
 import {useClient} from './useClient';
+import {PENDING_DEPOSITS_KEY} from 'utils/constants';
 
 export type IAssetTransfers = Transfer[];
 
@@ -50,7 +51,7 @@ export const useDaoTransfers = (
           }
 
           localStorage.setItem(
-            'pendingDeposits',
+            PENDING_DEPOSITS_KEY,
             JSON.stringify(pendingDepositsTxs)
           );
 

--- a/packages/web-app/src/hooks/useProposals.tsx
+++ b/packages/web-app/src/hooks/useProposals.tsx
@@ -38,7 +38,7 @@ export function useProposals(
   const augmentProposalsWithCache = useCallback(
     (fetchedProposals: Proposal[]) => {
       const newCache = {...proposalCache};
-      const augmentedProposals = {...fetchedProposals};
+      const augmentedProposals = [...fetchedProposals];
 
       for (const key in proposalCache) {
         if (fetchedProposals.some(p => p.id === key)) {
@@ -60,7 +60,11 @@ export function useProposals(
 
       return augmentedProposals;
     },
-    [preferences?.functional, proposalCache]
+
+    // intentionally leaving out proposalCache so that this doesn't
+    // get re-run when items are removed from the cache
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [preferences?.functional]
   );
 
   useEffect(() => {
@@ -72,7 +76,8 @@ export function useProposals(
           sortBy: ProposalSortBy.CREATED_AT,
           daoAddressOrEns,
         });
-        setData({...augmentProposalsWithCache(proposals || [])});
+
+        setData([...augmentProposalsWithCache(proposals || [])]);
       } catch (err) {
         console.error(err);
         setError(err as Error);

--- a/packages/web-app/src/hooks/useProposals.tsx
+++ b/packages/web-app/src/hooks/useProposals.tsx
@@ -7,6 +7,7 @@ import {
 import {pendingProposalsVar} from 'context/apolloClient';
 import {usePrivacyContext} from 'context/privacyContext';
 import {useCallback, useEffect, useState} from 'react';
+import {PENDING_PROPOSALS_KEY} from 'utils/constants';
 import {customJSONReplacer} from 'utils/library';
 import {HookData} from 'utils/types';
 
@@ -52,7 +53,7 @@ export function useProposals(
       pendingProposalsVar(newCache);
       if (preferences?.functional) {
         localStorage.setItem(
-          'pendingProposals',
+          PENDING_PROPOSALS_KEY,
           JSON.stringify(newCache, customJSONReplacer)
         );
       }

--- a/packages/web-app/src/hooks/useProposals.tsx
+++ b/packages/web-app/src/hooks/useProposals.tsx
@@ -1,9 +1,13 @@
+import {useReactiveVar} from '@apollo/client';
 import {
   AddressListProposalListItem,
   Erc20ProposalListItem,
   ProposalSortBy,
 } from '@aragon/sdk-client';
-import {useEffect, useState} from 'react';
+import {pendingProposalsVar} from 'context/apolloClient';
+import {usePrivacyContext} from 'context/privacyContext';
+import {useCallback, useEffect, useState} from 'react';
+import {customJSONReplacer} from 'utils/library';
 import {HookData} from 'utils/types';
 
 import {PluginTypes, usePluginClient} from './usePluginClient';
@@ -27,6 +31,37 @@ export function useProposals(
 
   const client = usePluginClient(type);
 
+  const {preferences} = usePrivacyContext();
+  const proposalCache = useReactiveVar(pendingProposalsVar);
+
+  const augmentProposalsWithCache = useCallback(
+    (fetchedProposals: Proposal[]) => {
+      const newCache = {...proposalCache};
+      const augmentedProposals = {...fetchedProposals};
+
+      for (const key in proposalCache) {
+        if (fetchedProposals.some(p => p.id === key)) {
+          // proposal already picked up
+          delete newCache[key];
+        } else {
+          augmentedProposals.unshift({...proposalCache[key]} as Proposal);
+        }
+      }
+
+      // cache and store new values
+      pendingProposalsVar(newCache);
+      if (preferences?.functional) {
+        localStorage.setItem(
+          'pendingProposals',
+          JSON.stringify(newCache, customJSONReplacer)
+        );
+      }
+
+      return augmentedProposals;
+    },
+    [preferences?.functional, proposalCache]
+  );
+
   useEffect(() => {
     async function getDaoProposals() {
       try {
@@ -36,7 +71,7 @@ export function useProposals(
           sortBy: ProposalSortBy.CREATED_AT,
           daoAddressOrEns,
         });
-        if (proposals) setData(proposals);
+        setData({...augmentProposalsWithCache(proposals || [])});
       } catch (err) {
         console.error(err);
         setError(err as Error);
@@ -46,7 +81,7 @@ export function useProposals(
     }
 
     if (daoAddressOrEns) getDaoProposals();
-  }, [client?.methods, daoAddressOrEns]);
+  }, [augmentProposalsWithCache, client?.methods, daoAddressOrEns]);
 
   return {data, error, isLoading};
 }

--- a/packages/web-app/src/pages/settings.tsx
+++ b/packages/web-app/src/pages/settings.tsx
@@ -61,8 +61,8 @@ const Settings: React.FC = () => {
 
   useEffect(() => {
     // Fetching necessary info about the token.
-    if (daoToken?.id) {
-      getTokenInfo(daoToken.id, infura, nativeCurrency)
+    if (daoToken?.address) {
+      getTokenInfo(daoToken.address, infura, nativeCurrency)
         .then((r: Awaited<ReturnType<typeof getTokenInfo>>) => {
           const formattedNumber = parseFloat(
             formatUnits(r.totalSupply, r.decimals)
@@ -73,7 +73,7 @@ const Settings: React.FC = () => {
           console.error('Error happened when fetching token infos: ', e)
         );
     }
-  }, [daoToken.id, nativeCurrency, infura, network]);
+  }, [daoToken?.address, nativeCurrency, infura, network]);
 
   if (
     isLoading ||
@@ -161,8 +161,8 @@ const Settings: React.FC = () => {
                 <Dt>{t('votingTerminal.token')}</Dt>
                 <Dd>
                   <div className="flex items-center space-x-1.5">
-                    <p>{daoToken.name}</p>
-                    <p>{daoToken.symbol}</p>
+                    <p>{daoToken?.name}</p>
+                    <p>{daoToken?.symbol}</p>
                   </div>
                 </Dd>
               </Dl>
@@ -171,7 +171,7 @@ const Settings: React.FC = () => {
                 <Dd>
                   <div className="flex items-center space-x-1.5">
                     <p>
-                      {tokenSupply} {daoToken.symbol}
+                      {tokenSupply} {daoToken?.symbol}
                     </p>
                     <Badge label="Mintable" />
                   </div>
@@ -203,7 +203,7 @@ const Settings: React.FC = () => {
             {isErc20Plugin ? (
               <Dd>
                 {Math.round(daoSettings.minTurnout * 100)}% (
-                {daoSettings.minTurnout * tokenSupply} {daoToken.symbol})
+                {daoSettings.minTurnout * tokenSupply} {daoToken?.symbol})
               </Dd>
             ) : (
               <Dd>{Math.round(daoSettings.minTurnout * 100)}%</Dd>

--- a/packages/web-app/src/utils/constants/misc.ts
+++ b/packages/web-app/src/utils/constants/misc.ts
@@ -110,3 +110,8 @@ export const PROPOSAL_STATE_LABELS = [
   i18n.t('governance.proposals.states.succeeded'),
   i18n.t('governance.proposals.states.defeated'),
 ];
+
+// Storage and cacheing keys
+export const PENDING_DEPOSITS_KEY = 'pendingDeposits';
+export const PENDING_PROPOSALS_KEY = 'pendingProposals';
+export const PENDING_VOTES_KEY = 'pendingVotes';

--- a/packages/web-app/src/utils/constants/regex.ts
+++ b/packages/web-app/src/utils/constants/regex.ts
@@ -11,3 +11,8 @@ export const TOKEN_AMOUNT_REGEX =
   /(?<integers>[\d*]*)[.]*(?<decimals>[\d]*)\s*(?<symbol>[A-Za-z]*)/;
 
 export const ALPHA_NUMERIC_PATTERN = /^[a-zA-Z\s0-9]+$/g;
+
+export const ISO_DATE_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*))(?:Z|(\+|-)([\d|:]*))?$/;
+
+export const BIGINT_PATTERN = /^\d+n$/;

--- a/packages/web-app/src/utils/library.ts
+++ b/packages/web-app/src/utils/library.ts
@@ -215,12 +215,8 @@ export const customJSONReplacer = (_: string, value: unknown) => {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const customJSONReviver = (_: string, value: any) => {
   // deserialize uint8array
-  try {
-    if ('flag' in value && value.flag === FLAG_TYPED_ARRAY) {
-      return new Uint8Array(value.data);
-    }
-  } catch (e) {
-    // not an object? do nothing
+  if (value.flag === FLAG_TYPED_ARRAY) {
+    return new Uint8Array(value.data);
   }
 
   if (typeof value === 'string') {

--- a/packages/web-app/src/utils/library.ts
+++ b/packages/web-app/src/utils/library.ts
@@ -5,7 +5,11 @@ import {ApolloClient} from '@apollo/client';
 import {Client, ClientAddressList} from '@aragon/sdk-client';
 
 import {fetchTokenData} from 'services/prices';
-import {SupportedNetworks} from 'utils/constants';
+import {
+  BIGINT_PATTERN,
+  ISO_DATE_PATTERN,
+  SupportedNetworks,
+} from 'utils/constants';
 
 import {
   ActionAddAddress,
@@ -178,3 +182,31 @@ export async function decodeRemoveMembersToAction(
     },
   });
 }
+
+/**
+ *  Custom serializer that includes fix for BigInt type
+ * @param _ key; unused
+ * @param value value to serialize
+ * @returns serialized value
+ */
+export const customJSONReplacer = (_: string, value: unknown) =>
+  typeof value === 'bigint' ? value.toString() + 'n' : value;
+
+/**
+ * Custom function to deserialize values, including Date and BigInt types
+ * @param _ key: unused
+ * @param value value to deserialize
+ * @returns deserialized value
+ */
+export const customJSONReviver = (_: string, value: unknown) => {
+  if (typeof value === 'string') {
+    // BigInt
+    if (BIGINT_PATTERN.test(value))
+      return BigInt(value.slice(8, value.length - 1));
+
+    // Date
+    if (ISO_DATE_PATTERN.test(value)) return new Date(value);
+  }
+
+  return value;
+};

--- a/packages/web-app/src/utils/proposals.ts
+++ b/packages/web-app/src/utils/proposals.ts
@@ -17,11 +17,11 @@ import Big from 'big.js';
 import {format} from 'date-fns';
 
 import {ProposalVoteResults} from 'containers/votingTerminal';
-import {DetailedProposal} from 'hooks/useDaoProposal';
 import {i18n} from '../../i18n.config';
 import {getFormattedUtcOffset, KNOWN_FORMATS} from './date';
 import {formatUnits} from './library';
 import {abbreviateTokenAmount} from './tokens';
+import {DetailedProposal} from './types';
 
 export const MappedVotes: {[key in VoteValues]: VoterType['option']} = {
   1: 'abstain',

--- a/packages/web-app/src/utils/types.ts
+++ b/packages/web-app/src/utils/types.ts
@@ -1,4 +1,8 @@
-import {VoteValues} from '@aragon/sdk-client';
+import {
+  AddressListProposal,
+  Erc20Proposal,
+  VoteValues,
+} from '@aragon/sdk-client';
 import {Address} from '@aragon/ui-components/src/utils/addresses';
 
 import {TimeFilter, TransferTypes} from './constants';
@@ -167,6 +171,8 @@ export type AddressListVote = {
 export type Erc20ProposalVote = AddressListVote & {
   weight: bigint;
 };
+
+export type DetailedProposal = Erc20Proposal | AddressListProposal;
 
 /* ACTION TYPES ============================================================= */
 


### PR DESCRIPTION
## Description
- Caches newly published proposal
- Redirects to `ProposalDetails` page once proposal is successfully published
- Uses cached proposal for `ProposalDetails` page if SDK data for proposal not yet available
- Uses cached proposals in DAO proposal lists (`Governance`, `Dashboard`) if SDK data for cached proposal not yet available
- Persists cached proposals if functional cookies are set
- Updates `useDaoToken` hook to use SDK (had to be done for caching)

NOTE: This lays the foundation for the other singular proposal flows, hence the size.
Also, currently directly accessing localstorage; would like to refactor and hide it behind the `useCache` hook

Task: [APP-1081](https://aragonassociation.atlassian.net/browse/APP-1081)

## Type of change

<!--- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.