### PR TITLE
Feature: APP-1255 - SCC Empty State Modal

### DIFF
--- a/packages/web-app/src/app.tsx
+++ b/packages/web-app/src/app.tsx
@@ -36,6 +36,7 @@ import {NotFound} from 'utils/paths';
 import ProtectedRoute from 'components/protectedRoute';
 import {useTransactionDetailContext} from 'context/transactionDetail';
 
+const DemoSCCPage = lazy(() => import('pages/demoScc'));
 const ExplorePage = lazy(() => import('pages/explore'));
 const NotFoundPage = lazy(() => import('pages/notFound'));
 
@@ -89,6 +90,8 @@ function App() {
       {/* TODO: replace with loading indicator */}
       <Suspense fallback={<Loading />}>
         <Routes>
+          <Route path="/scc" element={<DemoSCCPage />} />
+
           <Route element={<ExploreWrapper />}>
             <Route path="/" element={<ExplorePage />} />
           </Route>

--- a/packages/web-app/src/containers/smartContractComposer/emptyState.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/emptyState.tsx
@@ -1,42 +1,48 @@
-import {ButtonIcon, IconChevronLeft} from '@aragon/ui-components';
 import ModalBottomSheetSwitcher from 'components/modalBottomSheetSwitcher';
-import {t} from 'i18next';
+import {StateEmpty} from 'components/stateEmpty';
 import React from 'react';
+import ModalHeader from './modalHeader';
+import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
 
 type Props = {
   isOpen: boolean;
   onClose: () => void;
-  onBackClicked: () => void;
+  onBackButtonClicked: () => void;
 };
 
+// not exactly sure where opening will be happen or if
+// these modals will be global modals. For now, keeping
+// this as a "controlled" component
 const EmptyState: React.FC<Props> = props => {
+  const {t} = useTranslation();
+
+  const handleConnectSCC = () => {};
+
   return (
     <ModalBottomSheetSwitcher isOpen={props.isOpen} onClose={props.onClose}>
-      <ModalHeader>
-        <ButtonIcon
-          mode="secondary"
-          size="small"
-          bgWhite
-          icon={<IconChevronLeft />}
-          onClick={props.onBackClicked}
+      <ModalHeader
+        title={t('scc.emptyState.modalTitle')}
+        onClose={props.onClose}
+        onBackButtonClicked={props.onBackButtonClicked}
+      />
+      <Content>
+        <StateEmpty
+          mode="inline"
+          type="Object"
+          object="smart_contract"
+          title={t('scc.emptyState.title')}
+          description={t('scc.emptyState.description')}
+          primaryButton={{
+            label: t('scc.emptyState.primaryBtnLabel'),
+            onClick: handleConnectSCC,
+          }}
         />
-        <Title>{t('sCC.emptyTitle')}</Title>
-        <div role="presentation" className="w-4 h-4" />
-      </ModalHeader>
+      </Content>
     </ModalBottomSheetSwitcher>
   );
 };
 
 export default EmptyState;
 
-const ModalHeader = styled.div.attrs({
-  className: 'flex items-center p-2 space-x-2 bg-ui-0 rounded-xl sticky top-0',
-})`
-  box-shadow: 0px 4px 8px rgba(31, 41, 51, 0.04),
-    0px 0px 2px rgba(31, 41, 51, 0.06), 0px 0px 1px rgba(31, 41, 51, 0.04);
-`;
-
-const Title = styled.div.attrs({
-  className: 'flex-1 font-bold text-center text-ui-800',
-})``;
+const Content = styled.div.attrs({className: 'px-2 tablet:px-3 pb-3'})``;

--- a/packages/web-app/src/containers/smartContractComposer/emptyState.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/emptyState.tsx
@@ -1,0 +1,42 @@
+import {ButtonIcon, IconChevronLeft} from '@aragon/ui-components';
+import ModalBottomSheetSwitcher from 'components/modalBottomSheetSwitcher';
+import {t} from 'i18next';
+import React from 'react';
+import styled from 'styled-components';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  onBackClicked: () => void;
+};
+
+const EmptyState: React.FC<Props> = props => {
+  return (
+    <ModalBottomSheetSwitcher isOpen={props.isOpen} onClose={props.onClose}>
+      <ModalHeader>
+        <ButtonIcon
+          mode="secondary"
+          size="small"
+          bgWhite
+          icon={<IconChevronLeft />}
+          onClick={props.onBackClicked}
+        />
+        <Title>{t('sCC.emptyTitle')}</Title>
+        <div role="presentation" className="w-4 h-4" />
+      </ModalHeader>
+    </ModalBottomSheetSwitcher>
+  );
+};
+
+export default EmptyState;
+
+const ModalHeader = styled.div.attrs({
+  className: 'flex items-center p-2 space-x-2 bg-ui-0 rounded-xl sticky top-0',
+})`
+  box-shadow: 0px 4px 8px rgba(31, 41, 51, 0.04),
+    0px 0px 2px rgba(31, 41, 51, 0.06), 0px 0px 1px rgba(31, 41, 51, 0.04);
+`;
+
+const Title = styled.div.attrs({
+  className: 'flex-1 font-bold text-center text-ui-800',
+})``;

--- a/packages/web-app/src/containers/smartContractComposer/modalHeader.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/modalHeader.tsx
@@ -1,0 +1,54 @@
+import {ButtonIcon, IconChevronLeft, IconClose} from '@aragon/ui-components';
+import React from 'react';
+import styled from 'styled-components';
+
+type Props = {
+  title: string;
+  onBackButtonClicked: () => void;
+  onClose?: () => void;
+};
+
+// NOTE: While this header is technically a ui-component,
+// keeping it here so we can progressively build it up as needed
+// Also, because this will be ui-component, it is encouraged for now
+// to use classNames to hide if necessary instead of useScreen and JS
+const Header: React.FC<Props> = props => {
+  return (
+    <ModalHeader>
+      <ButtonIcon
+        mode="secondary"
+        size="small"
+        icon={<IconChevronLeft />}
+        onClick={props.onBackButtonClicked}
+        bgWhite
+      />
+      <Title>{props.title}</Title>
+      <ButtonWrapper className="w-4 h-4">
+        <ButtonIcon
+          mode="secondary"
+          size="small"
+          icon={<IconClose />}
+          onClick={props.onClose}
+          bgWhite
+          className="hidden desktop:block"
+        />
+      </ButtonWrapper>
+    </ModalHeader>
+  );
+};
+
+export default Header;
+
+const ModalHeader = styled.div.attrs({
+  className:
+    'flex items-center rounded-xl space-x-2 desktop:space-x-3 p-2 desktop:p-3',
+})`
+  box-shadow: 0px 4px 8px rgba(31, 41, 51, 0.04),
+    0px 0px 2px rgba(31, 41, 51, 0.06), 0px 0px 1px rgba(31, 41, 51, 0.04);
+`;
+
+const Title = styled.div.attrs({
+  className: 'flex-1 font-bold text-ui-800 text-center desktop:text-left',
+})``;
+
+const ButtonWrapper = styled.div.attrs({className: 'w-4 h-4'})``;

--- a/packages/web-app/src/locales/en/common.json
+++ b/packages/web-app/src/locales/en/common.json
@@ -708,5 +708,13 @@
       "description": "Ready to distribute tokens or pay members? Initiate a token transfer here. For ideas on how to distribute your community's token, read our guide on token distribution.",
       "buttonLabel": "Initiate Transfer"
     }
+  },
+  "scc": {
+    "emptyState": {
+      "modalTitle": "Smart Contract Composer",
+      "title": "No Smart Contract",
+      "description": "Add a smart contract to interact with its actions",
+      "primaryBtnLabel": "Connect Smart Contract"
+    }
   }
 }

--- a/packages/web-app/src/pages/demoScc.tsx
+++ b/packages/web-app/src/pages/demoScc.tsx
@@ -12,7 +12,7 @@ const SCC: React.FC = () => {
       <TemporarySection purpose="SCC - Initial Modal, Empty State">
         <ButtonText
           label="Show EmptyState"
-          onClick={() => setEmptyStateIsOpen(false)}
+          onClick={() => setEmptyStateIsOpen(true)}
         />
         <EmptyState
           isOpen={emptyStateIsOpen}

--- a/packages/web-app/src/pages/demoScc.tsx
+++ b/packages/web-app/src/pages/demoScc.tsx
@@ -9,16 +9,17 @@ const SCC: React.FC = () => {
 
   return (
     <Container>
-      <TemporarySection purpose="SMART CONTRACT COMPOSER COMPONENTS" />
-
-      <ButtonText
-        label="Toggle EmptyState"
-        onClick={() => setEmptyStateIsOpen(s => !s)}
-      />
-      <EmptyState
-        isOpen={emptyStateIsOpen}
-        onClose={() => setEmptyStateIsOpen(false)}
-      />
+      <TemporarySection purpose="SCC - Initial Modal, Empty State">
+        <ButtonText
+          label="Show EmptyState"
+          onClick={() => setEmptyStateIsOpen(false)}
+        />
+        <EmptyState
+          isOpen={emptyStateIsOpen}
+          onClose={() => setEmptyStateIsOpen(false)}
+          onBackButtonClicked={() => setEmptyStateIsOpen(false)}
+        />
+      </TemporarySection>
     </Container>
   );
 };

--- a/packages/web-app/src/pages/demoScc.tsx
+++ b/packages/web-app/src/pages/demoScc.tsx
@@ -1,0 +1,28 @@
+import {ButtonText} from '@aragon/ui-components';
+import {TemporarySection} from 'components/temporary';
+import EmptyState from 'containers/smartContractComposer/emptyState';
+import React from 'react';
+import styled from 'styled-components';
+
+const SCC: React.FC = () => {
+  const [emptyStateIsOpen, setEmptyStateIsOpen] = React.useState(false);
+
+  return (
+    <Container>
+      <TemporarySection purpose="SMART CONTRACT COMPOSER COMPONENTS" />
+
+      <ButtonText
+        label="Toggle EmptyState"
+        onClick={() => setEmptyStateIsOpen(s => !s)}
+      />
+      <EmptyState
+        isOpen={emptyStateIsOpen}
+        onClose={() => setEmptyStateIsOpen(false)}
+      />
+    </Container>
+  );
+};
+
+export default SCC;
+
+const Container = styled.div``;


### PR DESCRIPTION
## Description

- Adds empty state modal for Smart Contract Composer
- Adds demo route `http://localhost:3000/#/scc`

~~NOTE: Branch is based on #550, hence all the duplicated commits. Can hold off on review until base is merged and this one rebased.~~

Task: [APP-1255](https://aragonassociation.atlassian.net/browse/APP-1255)

## Type of change

<!--- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.