### PR TITLE
Fix: APP-1279 - Mint Tokens Crashing

### DIFF
--- a/packages/web-app/src/containers/actionBuilder/mintTokens/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/mintTokens/index.tsx
@@ -111,7 +111,7 @@ export const MintTokenForm: React.FC<MintTokenFormProps> = ({
     name: `actions.${actionIndex}.inputs.mintTokensToWallets`,
   });
 
-  // NOTE: DO NOT MERGE THESE. Apparently, when returned as a touple, the
+  // NOTE: DO NOT MERGE THESE. Apparently, when returned as a tuple, the
   // useEffects that depend on `mints` do not recognize changes to the `mints`
   // array...
   const mints: MintInfo[] = useWatch({
@@ -152,7 +152,8 @@ export const MintTokenForm: React.FC<MintTokenFormProps> = ({
     if (!mints) return;
 
     const actionErrors =
-      formState.errors?.actions?.[`${actionIndex}`].inputs.mintTokensToWallets;
+      formState.errors?.actions?.[`${actionIndex}`]?.inputs
+        ?.mintTokensToWallets;
 
     actionErrors?.forEach((error: MappedError) => {
       if (error?.address) trigger(error.address.ref?.name);


### PR DESCRIPTION
## Description
- Fix for app crashing when readding mint tokens action after reset and remove. See task description for reproduction steps.

Task: [APP-1279](https://aragonassociation.atlassian.net/browse/APP-1279)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.