### PR TITLE
Feature: Action Selector Step in SCC Modal

### DIFF
--- a/packages/ui-components/src/components/listItem/action.tsx
+++ b/packages/ui-components/src/components/listItem/action.tsx
@@ -48,8 +48,8 @@ export const ListItemAction: React.FC<ListItemActionProps> = ({
         {/* This could be done with label. However, I can't get the label's text
          to inherit the color (for example, when selected mode is on) */}
         <LabelContainer>
-          <p className="font-bold ft-text-base">{title}</p>
-          {subtitle && <p className="ft-text-sm">{subtitle}</p>}
+          <p className="font-bold truncate ft-text-base">{title}</p>
+          {subtitle && <p className="truncate ft-text-sm">{subtitle}</p>}
         </LabelContainer>
       </LeftContent>
       {iconRight && <span>{iconRight}</span>}
@@ -96,7 +96,9 @@ const Container = styled.button.attrs(
   }
 )<InputContainerProps>``;
 
-const LabelContainer = styled.div.attrs({className: 'text-left'})``;
+const LabelContainer = styled.div.attrs({
+  className: 'text-left overflow-hidden',
+})``;
 const LeftContent = styled.div.attrs({
-  className: 'flex items-center space-x-1.5 flex-1',
+  className: 'flex items-center space-x-1.5 flex-1 overflow-hidden',
 })``;

--- a/packages/web-app/src/containers/smartContractComposer/components/actionListGroup.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/components/actionListGroup.tsx
@@ -21,18 +21,18 @@ const ActionListGroup: React.FC<ActionListGroupProps> = ({actions}) => {
               numConnected: actions.length,
             })}
       </ContractNumberIndicator>
-      {/* {actions.map(c => (
+      {actions.map(a => (
         // TODO: replace with new listitem that takes image
         // or custom component
         <ListItemAction
-          key={c.address}
-          title={c.name}
-          subtitle={`${c.actions.length} Actions`}
+          key={a.name}
+          title={a.name}
+          subtitle={a.name}
           bgWhite
           iconRight={<IconChevronRight />}
-          onClick={() => setValue('selectedSC', c)}
+          onClick={() => setValue('selectedAction', a)}
         />
-      ))} */}
+      ))}
     </ListGroup>
   );
 };
@@ -40,9 +40,9 @@ const ActionListGroup: React.FC<ActionListGroupProps> = ({actions}) => {
 export default ActionListGroup;
 
 const ListGroup = styled.div.attrs({
-  className: 'flex-1 pt-4 pb-2 space-y-1',
+  className: 'flex-1 pt-3 desktop:pt-4 pb-2 space-y-1',
 })``;
 
 const ContractNumberIndicator = styled.div.attrs({
-  className: 'ft-text-sm font-bold text-ui-400',
+  className: 'ft-text-sm font-bold text-ui-400 hidden desktop:block',
 })``;

--- a/packages/web-app/src/containers/smartContractComposer/components/actionListGroup.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/components/actionListGroup.tsx
@@ -6,25 +6,22 @@ import styled from 'styled-components';
 
 import {SmartContract} from 'utils/types';
 
-// NOTE: may come from form, not set in stone
-type SCCListGroupProps = {
-  contracts: Array<SmartContract>;
-};
+type ActionListGroupProps = Pick<SmartContract, 'actions'>;
 
-const SmartContractListGroup: React.FC<SCCListGroupProps> = ({contracts}) => {
+const ActionListGroup: React.FC<ActionListGroupProps> = ({actions}) => {
   const {t} = useTranslation();
   const {setValue} = useFormContext();
 
   return (
     <ListGroup>
       <ContractNumberIndicator>
-        {contracts.length === 1
-          ? t('scc.labels.singleContractConnected')
-          : t('scc.labels.nContractsConnected', {
-              numConnected: contracts.length,
+        {actions.length === 1
+          ? t('scc.labels.singleActionAvailable')
+          : t('scc.labels.nActionsAvailable', {
+              numConnected: actions.length,
             })}
       </ContractNumberIndicator>
-      {contracts.map(c => (
+      {/* {actions.map(c => (
         // TODO: replace with new listitem that takes image
         // or custom component
         <ListItemAction
@@ -35,14 +32,16 @@ const SmartContractListGroup: React.FC<SCCListGroupProps> = ({contracts}) => {
           iconRight={<IconChevronRight />}
           onClick={() => setValue('selectedSC', c)}
         />
-      ))}
+      ))} */}
     </ListGroup>
   );
 };
 
-export default SmartContractListGroup;
+export default ActionListGroup;
 
-const ListGroup = styled.div.attrs({className: 'pb-2 space-y-1'})``;
+const ListGroup = styled.div.attrs({
+  className: 'flex-1 pt-4 pb-2 space-y-1',
+})``;
 
 const ContractNumberIndicator = styled.div.attrs({
   className: 'ft-text-sm font-bold text-ui-400',

--- a/packages/web-app/src/containers/smartContractComposer/components/contractAddressValidation.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/components/contractAddressValidation.tsx
@@ -80,7 +80,7 @@ const ContractAddressValidation: React.FC<Props> = props => {
         setValue('contracts', [
           ...contracts,
           {
-            actions: [{}, {}],
+            actions: JSON.parse(value.ABI),
             address: addressField,
             name: value.ContractName,
           },

--- a/packages/web-app/src/containers/smartContractComposer/desktopModal/header.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/desktopModal/header.tsx
@@ -5,6 +5,7 @@ import {
   IconHome,
 } from '@aragon/ui-components';
 import React from 'react';
+import {useFormContext} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
 
@@ -15,11 +16,20 @@ type DesktopModalHeaderProps = {
 
 const DesktopModalHeader: React.FC<DesktopModalHeaderProps> = props => {
   const {t} = useTranslation();
+  const {setValue} = useFormContext();
 
   return (
     <Container>
       <LeftContent>
-        <ButtonIcon icon={<IconHome />} mode="secondary" bgWhite />
+        <ButtonIcon
+          icon={<IconHome />}
+          mode="secondary"
+          bgWhite
+          onClick={() => {
+            setValue('selectedSC', null);
+            setValue('selectedAction', null);
+          }}
+        />
         <IconChevronRight />
         {props.selectedContract && (
           <>

--- a/packages/web-app/src/containers/smartContractComposer/desktopModal/index.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/desktopModal/index.tsx
@@ -1,11 +1,16 @@
-import {ButtonText, ListItemAction, Modal} from '@aragon/ui-components';
+import {
+  ButtonText,
+  IconMenuVertical,
+  ListItemAction,
+  Modal,
+} from '@aragon/ui-components';
 import React from 'react';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
-import {useFormContext, useWatch} from 'react-hook-form';
+import {useWatch} from 'react-hook-form';
 
 import {StateEmpty} from 'components/stateEmpty';
-import {SmartContract} from 'utils/types';
+import {SmartContract, SmartContractAction} from 'utils/types';
 import SmartContractListGroup from '../components/smartContractListGroup';
 import Header from './header';
 import ActionListGroup from '../components/actionListGroup';
@@ -20,12 +25,14 @@ type DesktopModalProps = {
 
 const DesktopModal: React.FC<DesktopModalProps> = props => {
   const {t} = useTranslation();
-  const {setValue} = useFormContext();
-  const selectedSC: SmartContract = useWatch({name: 'selectedSC'});
+  const [selectedSC, selectedAction]: [SmartContract, SmartContractAction] =
+    useWatch({
+      name: ['selectedSC', 'selectedAction'],
+    });
 
   return (
     <StyledModal isOpen={props.isOpen} onClose={props.onClose}>
-      <Header onClose={props.onClose} />
+      <Header onClose={props.onClose} selectedContract={selectedSC?.name} />
       <Wrapper>
         <Aside>
           {selectedSC ? (
@@ -35,10 +42,16 @@ const DesktopModal: React.FC<DesktopModalProps> = props => {
                 title={selectedSC.name}
                 subtitle={`${selectedSC.actions.length} Actions to compose`}
                 bgWhite
-                // iconRight={<IconChevronRight />}
-                onClick={() => setValue('selectedSC', undefined)}
+                iconRight={<IconMenuVertical />}
               />
-              <ActionListGroup actions={selectedSC.actions} />
+              <ActionListGroup
+                actions={selectedSC.actions.filter(
+                  a =>
+                    a.type === 'function' &&
+                    (a.stateMutability === 'payable' ||
+                      a.stateMutability === 'nonpayable')
+                )}
+              />
             </>
           ) : (
             <>
@@ -55,8 +68,15 @@ const DesktopModal: React.FC<DesktopModalProps> = props => {
         </Aside>
 
         <Main>
-          {/* Add steps here, replace emptyState */}
-          {selectedSC ? null : <DesktopModalEmptyState />}
+          {selectedSC ? (
+            selectedAction && (
+              <div className="p-6 h-full bg-white">
+                TBD: Form to collect inputs for {selectedAction.name} function
+              </div>
+            )
+          ) : (
+            <DesktopModalEmptyState />
+          )}
         </Main>
       </Wrapper>
     </StyledModal>

--- a/packages/web-app/src/containers/smartContractComposer/desktopModal/index.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/desktopModal/index.tsx
@@ -1,12 +1,14 @@
-import {ButtonText, Modal} from '@aragon/ui-components';
+import {ButtonText, ListItemAction, Modal} from '@aragon/ui-components';
 import React from 'react';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
+import {useFormContext, useWatch} from 'react-hook-form';
 
 import {StateEmpty} from 'components/stateEmpty';
 import {SmartContract} from 'utils/types';
 import SmartContractListGroup from '../components/smartContractListGroup';
 import Header from './header';
+import ActionListGroup from '../components/actionListGroup';
 
 type DesktopModalProps = {
   contracts: Array<SmartContract>;
@@ -18,25 +20,43 @@ type DesktopModalProps = {
 
 const DesktopModal: React.FC<DesktopModalProps> = props => {
   const {t} = useTranslation();
+  const {setValue} = useFormContext();
+  const selectedSC: SmartContract = useWatch({name: 'selectedSC'});
 
   return (
     <StyledModal isOpen={props.isOpen} onClose={props.onClose}>
       <Header onClose={props.onClose} />
       <Wrapper>
         <Aside>
-          <SmartContractListGroup contracts={props.contracts} />
-          <ButtonText
-            mode="secondary"
-            size="large"
-            label={t('scc.labels.connect')}
-            onClick={props.onConnect}
-            className="w-full"
-          />
+          {selectedSC ? (
+            <>
+              <ListItemAction
+                key={selectedSC.address}
+                title={selectedSC.name}
+                subtitle={`${selectedSC.actions.length} Actions to compose`}
+                bgWhite
+                // iconRight={<IconChevronRight />}
+                onClick={() => setValue('selectedSC', undefined)}
+              />
+              <ActionListGroup actions={selectedSC.actions} />
+            </>
+          ) : (
+            <>
+              <SmartContractListGroup contracts={props.contracts} />
+              <ButtonText
+                mode="secondary"
+                size="large"
+                label={t('scc.labels.connect')}
+                onClick={props.onConnect}
+                className="w-full"
+              />
+            </>
+          )}
         </Aside>
 
         <Main>
           {/* Add steps here, replace emptyState */}
-          <DesktopModalEmptyState />
+          {selectedSC ? null : <DesktopModalEmptyState />}
         </Main>
       </Wrapper>
     </StyledModal>

--- a/packages/web-app/src/locales/en/common.json
+++ b/packages/web-app/src/locales/en/common.json
@@ -913,7 +913,9 @@
       "connect": "Connect smart contract",
       "singleContractConnected": "One connected contract",
       "nContractsConnected": "{{numConnected}} Connected smart contracts",
-      "searchPlaceholder": "Type to find any action …"
+      "searchPlaceholder": "Type to find any action …",
+      "singleActionAvailable": "One write action",
+      "nActionsAvailable": "{{numConnected}} write actions"
     },
     "emptyState": {
       "modalTitle": "Smart contract composer",

--- a/packages/web-app/src/utils/types.ts
+++ b/packages/web-app/src/utils/types.ts
@@ -372,8 +372,12 @@ export type EtherscanContractResponse = {
   SourceCode: string;
 };
 
-// TODO: Fill out as we go
-export type SmartContractAction = {};
+export type SmartContractAction = {
+  name: string;
+  type: string;
+  stateMutability: string;
+  // inputs:
+};
 
 export type SmartContract = {
   actions: Array<SmartContractAction>;


### PR DESCRIPTION
## Description

- Makes the Modal header buttons work. The search input is still dummy, a separate ticket has been created for it[APP-1322]
- Adds the SC actions to the desktop and mobile modal. I guessed the filter logic based on the functions that I saw on etherscan verified contracts's `Write` tab
- The whole form input for individual function is still TBD

Task: [APP-1126](https://aragonassociation.atlassian.net/browse/APP-1126)

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-1322]: https://aragonassociation.atlassian.net/browse/APP-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APP-1126]: https://aragonassociation.atlassian.net/browse/APP-1126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ