### PR TITLE
Fix: DAO Cards on explore & Empty DAO name on header upon navigation after creation

### DIFF
--- a/packages/web-app/src/components/daoCard/index.tsx
+++ b/packages/web-app/src/components/daoCard/index.tsx
@@ -11,6 +11,7 @@ export interface IDaoCardProps {
   description: string;
   chainId: number;
   daoType: DaoType;
+  onClick?: () => void;
 }
 
 export type DaoType = 'wallet-based' | 'token-based';
@@ -46,7 +47,7 @@ export const DaoCard = (props: IDaoCardProps) => {
   }, [props.chainId]);
 
   return (
-    <Container data-testid="daoCard">
+    <Container data-testid="daoCard" onClick={props.onClick}>
       <DaoDataWrapper>
         <HeaderContainer>
           <AvatarDao daoName={props.name} src={props.logo} />

--- a/packages/web-app/src/containers/daoExplorer/daoExplorer.tsx
+++ b/packages/web-app/src/containers/daoExplorer/daoExplorer.tsx
@@ -87,6 +87,7 @@ export const DaoExplorer = () => {
               onClick={() =>
                 navigate(
                   generatePath(Dashboard, {
+                    // TODO: Remove the hardcoded network param
                     network: 'goerli',
                     dao: dao.address,
                   })

--- a/packages/web-app/src/containers/daoExplorer/daoExplorer.tsx
+++ b/packages/web-app/src/containers/daoExplorer/daoExplorer.tsx
@@ -7,10 +7,12 @@ import {
 import React, {useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
+import {generatePath, useNavigate} from 'react-router-dom';
 
 import {DaoCard} from 'components/daoCard';
 import {useDaos} from 'hooks/useDaos';
 import {PluginTypes} from 'hooks/usePluginClient';
+import {Dashboard} from 'utils/paths';
 
 const EXPLORE_FILTER = ['newest', 'popular'] as const;
 
@@ -29,6 +31,7 @@ export const DaoExplorer = () => {
   const [showCount, setShowCount] = useState(PAGE_SIZE);
   const [filterValue, setFilterValue] = useState<ExploreFilter>('newest');
   const {data} = useDaos(filterValue, showCount);
+  const navigate = useNavigate();
 
   const handleShowMoreClick = () => {
     setShowCount(prev => prev + PAGE_SIZE);
@@ -81,6 +84,14 @@ export const DaoExplorer = () => {
                   : 'wallet-based'
               }
               key={index}
+              onClick={() =>
+                navigate(
+                  generatePath(Dashboard, {
+                    network: 'goerli',
+                    dao: dao.address,
+                  })
+                )
+              }
             />
           ))}
         </CardsWrapper>

--- a/packages/web-app/src/hooks/useDaoDetails.tsx
+++ b/packages/web-app/src/hooks/useDaoDetails.tsx
@@ -31,6 +31,16 @@ export function useDaoDetails(
         setIsLoading(true);
 
         if (cachedDaos?.[network]?.[daoId.toLowerCase()]) {
+          const pendingDAO = cachedDaos?.[network]?.[daoId.toLowerCase()];
+          if (pendingDAO) {
+            setData({
+              address: daoId,
+              ensDomain: pendingDAO.ensSubdomain,
+              metadata: pendingDAO.metadata,
+              plugins: [],
+              creationDate: new Date(),
+            });
+          }
           setWaitingForSubgraph(true);
         } else {
           const dao = await client?.methods.getDao(daoId.toLowerCase());

--- a/packages/web-app/src/pages/dashboard.tsx
+++ b/packages/web-app/src/pages/dashboard.tsx
@@ -67,7 +67,7 @@ const Dashboard: React.FC = () => {
 
   const {data: topTen, isLoading: proposalsAreLoading} = useProposals(
     daoId,
-    dao?.plugins[0].id as PluginTypes
+    dao?.plugins[0]?.id as PluginTypes
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Description

- DAO cards on explore page linked to the goerli dashboards. The network hardcoding needs to be removed 
- Upon navigation after DAO creation, the DAO name is empty on the navbar. Reading that from the cache during this waiting for subgraph data state


Task: [APP-1347](https://aragonassociation.atlassian.net/browse/APP-1347), [APP-1356](https://aragonassociation.atlassian.net/browse/APP-1356)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.