### PR TITLE
upgrade sdk-client to 0.16.0-alpha

### DIFF
--- a/packages/web-app/package.json
+++ b/packages/web-app/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.5.8",
-    "@aragon/sdk-client": "^0.15.2-alpha",
+    "@aragon/sdk-client": "^0.16.0-alpha",
     "@aragon/ui-components": "^0.1.0",
     "@elastic/apm-rum-react": "^1.3.1",
     "@radix-ui/react-accordion": "^0.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -179,13 +179,13 @@
     "@web3-react/types" "^6.0.7"
     tiny-warning "^1.0.3"
 
-"@aragon/sdk-client@^0.15.2-alpha":
-  version "0.15.2-alpha"
-  resolved "https://registry.yarnpkg.com/@aragon/sdk-client/-/sdk-client-0.15.2-alpha.tgz#003ad95ecfee08bcd84e7576d5bc2cd10272ce03"
-  integrity sha512-OTEfr0Oa+uasZU/KYzSFXIHipiNpLzV98bzGNZE0s/B4im7Bt/6A30HoeUPGfUZzzJ+//tmmlQIm1rIPSabnOg==
+"@aragon/sdk-client@^0.16.0-alpha":
+  version "0.16.0-alpha"
+  resolved "https://registry.yarnpkg.com/@aragon/sdk-client/-/sdk-client-0.16.0-alpha.tgz#823b165e178c2274941bb015eef743e8fdb8d4b9"
+  integrity sha512-F2NG8Y4skgRWyGQFJZ9ijMllmuJN/97WNw5KRtTpuk5Y1e8OW4AOhPv6l9U/Te7Llmt/dgllF5vzfYIQ4RtXFw==
   dependencies:
     "@aragon/core-contracts-ethers" "^0.4.1-alpha"
-    "@aragon/sdk-common" "^0.8.0-alpha"
+    "@aragon/sdk-common" "^0.9.0-alpha"
     "@aragon/sdk-ipfs" "^0.2.0-alpha"
     "@ethersproject/abstract-signer" "^5.5.0"
     "@ethersproject/bignumber" "^5.6.0"
@@ -196,10 +196,12 @@
     graphql "^16.5.0"
     graphql-request "^4.3.0"
 
-"@aragon/sdk-common@^0.8.0-alpha":
-  version "0.8.0-alpha"
-  resolved "https://registry.yarnpkg.com/@aragon/sdk-common/-/sdk-common-0.8.0-alpha.tgz#3747b1e8609ab1b73382125956a3e2860837e4b5"
-  integrity sha512-cYmyDRvWe06KVyBx5O1lsUJb6ildjC8zW1VYDZkvocYxr5bBa/CN9QojZOk5P5KHs5rJDojrl+gN9anUYGNeCg==
+"@aragon/sdk-common@^0.9.0-alpha":
+  version "0.9.0-alpha"
+  resolved "https://registry.yarnpkg.com/@aragon/sdk-common/-/sdk-common-0.9.0-alpha.tgz#3673243edd7bfcef4941e21edbf6f16a1f5b5ae0"
+  integrity sha512-c5uXfg2YBDCGhWbM3br9GuV0tyAetwpgFFDJ/PIFVKj8qCq2sxuUzR3V+08LNYwlYLZGN9z1cSYDHy4tDT7NJg==
+  dependencies:
+    parse-url "^8.1.0"
 
 "@aragon/sdk-ipfs@^0.2.0-alpha":
   version "0.2.0-alpha"
@@ -18541,6 +18543,13 @@ parse-path@^4.0.0:
     qs "^6.9.4"
     query-string "^6.13.8"
 
+parse-path@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-7.0.0.tgz#605a2d58d0a749c8594405d8cc3a2bf76d16099b"
+  integrity sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==
+  dependencies:
+    protocols "^2.0.0"
+
 parse-repo@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/parse-repo/-/parse-repo-1.0.4.tgz#74b91d2cb8675d11b99976a0065f6ce17fa1bcc8"
@@ -18555,6 +18564,13 @@ parse-url@^6.0.0:
     normalize-url "^6.1.0"
     parse-path "^4.0.0"
     protocols "^1.4.0"
+
+parse-url@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-8.1.0.tgz#972e0827ed4b57fc85f0ea6b0d839f0d8a57a57d"
+  integrity sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==
+  dependencies:
+    parse-path "^7.0.0"
 
 parse5@5.1.0:
   version "5.1.0"
@@ -19570,6 +19586,11 @@ protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.8.tgz#48eea2d8f58d9644a4a32caae5d5db290a075ce8"
   integrity sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==
+
+protocols@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/protocols/-/protocols-2.0.1.tgz#8f155da3fc0f32644e83c5782c8e8212ccf70a86"
+  integrity sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==
 
 proxy-addr@~2.0.5:
   version "2.0.7"


### PR DESCRIPTION
## Description

Updates the `@aragon/sdk-client` package from `0.15.2-alpha` to `0.16.0-alpha` 