### PR TITLE
Fix: Empty Links section on settings page

### DIFF
--- a/packages/web-app/src/containers/compareSettings/index.tsx
+++ b/packages/web-app/src/containers/compareSettings/index.tsx
@@ -18,6 +18,7 @@ import {PluginTypes} from 'hooks/usePluginClient';
 import {usePluginSettings} from 'hooks/usePluginSettings';
 import {getDHMFromSeconds} from 'utils/date';
 import {EditSettings} from 'utils/paths';
+import {ProposalResource} from 'utils/types';
 
 const CompareSettings: React.FC = () => {
   const {t} = useTranslation();
@@ -50,7 +51,9 @@ const CompareSettings: React.FC = () => {
     displayedInfo = {
       name: getValues('daoName'),
       summary: getValues('daoSummary'),
-      links: getValues('daoLinks'),
+      links: getValues('daoLinks').filter(
+        (l: ProposalResource) => l.name && l.url
+      ),
       minParticipation: getValues('minimumParticipation'),
       approvalThreshold: getValues('minimumApproval'),
       days: getValues('durationDays'),
@@ -62,7 +65,7 @@ const CompareSettings: React.FC = () => {
     displayedInfo = {
       name: daoDetails?.metadata.name,
       summary: daoDetails?.metadata.description,
-      links: daoDetails?.metadata.links,
+      links: daoDetails?.metadata.links.filter(l => l.name && l.url),
       minParticipation: daoSettings.minTurnout * 100,
       approvalThreshold: daoSettings.minSupport * 100,
       days: duration.days,
@@ -105,20 +108,24 @@ const CompareSettings: React.FC = () => {
           <Dt>{t('labels.summary')}</Dt>
           <Dd>{displayedInfo.summary}</Dd>
         </Dl>
-        <Dl>
-          <Dt>{t('labels.links')}</Dt>
-          <Dd>
-            <div className="space-y-1.5">
-              {displayedInfo.links.map((link: {name: string; url: string}) => (
-                <ListItemLink
-                  key={link.name + link.url}
-                  label={link.name}
-                  href={link.url}
-                />
-              ))}
-            </div>
-          </Dd>
-        </Dl>
+        {displayedInfo.links && displayedInfo.links.length > 0 && (
+          <Dl>
+            <Dt>{t('labels.links')}</Dt>
+            <Dd>
+              <div className="space-y-1.5">
+                {displayedInfo.links.map(
+                  (link: {name: string; url: string}) => (
+                    <ListItemLink
+                      key={link.name + link.url}
+                      label={link.name}
+                      href={link.url}
+                    />
+                  )
+                )}
+              </div>
+            </Dd>
+          </Dl>
+        )}
       </DescriptionListContainer>
 
       <DescriptionListContainer

--- a/packages/web-app/src/context/createDao.tsx
+++ b/packages/web-app/src/context/createDao.tsx
@@ -247,7 +247,7 @@ const CreateDaoProvider: React.FC<Props> = ({children}) => {
         name: daoName,
         description: daoSummary,
         avatar: daoLogo,
-        links: links,
+        links: links.filter(r => r.name && r.url),
       },
       // TODO: We're using dao name without spaces for ens, We need to add alert to inform this to user
       ensSubdomain: daoName?.replace(/ /g, '_'),

--- a/packages/web-app/src/pages/settings.tsx
+++ b/packages/web-app/src/pages/settings.tsx
@@ -88,6 +88,9 @@ const Settings: React.FC = () => {
   const isErc20Plugin =
     (daoDetails?.plugins?.[0]?.id as PluginTypes) === 'erc20voting.dao.eth';
 
+  const resourceLinks = daoDetails?.metadata.links.filter(l => l.name && l.url);
+  console.log(daoDetails);
+
   return (
     <SettingsWrapper>
       <div className="mt-3 desktop:mt-8 space-y-5">
@@ -126,16 +129,18 @@ const Settings: React.FC = () => {
             <Dt>{t('labels.summary')}</Dt>
             <Dd>{daoDetails?.metadata.description}</Dd>
           </Dl>
-          <Dl>
-            <Dt>{t('labels.links')}</Dt>
-            <Dd>
-              <div className="space-y-1.5">
-                {daoDetails?.metadata.links.map(({name, url}) => (
-                  <ListItemLink label={name} href={url} key={url} />
-                ))}
-              </div>
-            </Dd>
-          </Dl>
+          {resourceLinks && resourceLinks.length > 0 && (
+            <Dl>
+              <Dt>{t('labels.links')}</Dt>
+              <Dd>
+                <div className="space-y-1.5">
+                  {resourceLinks.map(({name, url}) => (
+                    <ListItemLink label={name} href={url} key={url} />
+                  ))}
+                </div>
+              </Dd>
+            </Dl>
+          )}
         </DescriptionListContainer>
 
         <DescriptionListContainer

--- a/packages/web-app/src/pages/settings.tsx
+++ b/packages/web-app/src/pages/settings.tsx
@@ -89,7 +89,6 @@ const Settings: React.FC = () => {
     (daoDetails?.plugins?.[0]?.id as PluginTypes) === 'erc20voting.dao.eth';
 
   const resourceLinks = daoDetails?.metadata.links.filter(l => l.name && l.url);
-  console.log(daoDetails);
 
   return (
     <SettingsWrapper>


### PR DESCRIPTION
## Description

- Fixes the empty links section problem on the Settings page. Also, now sending an empty link array instead of a link object containing empty strings like in proposal creation.
- Minimum duration on the Settings page works as expected. In the DAO's created by the core team using CI scripts, the minimunDuration is set as 0. So the two DAO's we have on explore page will show '0' as minimum duration. For daos created using the front end, this works as expected 

Task: [APP-1327](https://aragonassociation.atlassian.net/browse/APP-1327)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.