### PR TITLE
Fix: APP-1319 Remove UTC Field Error after Undo

### DIFF
--- a/packages/web-app/src/containers/proposalStepper/index.tsx
+++ b/packages/web-app/src/containers/proposalStepper/index.tsx
@@ -84,7 +84,7 @@ const ProposalStepper: React.FC<ProposalStepperType> = ({
       <Step
         wizardTitle={t('newWithdraw.setupVoting.title')}
         wizardDescription={t('newWithdraw.setupVoting.description')}
-        isNextButtonDisabled={!setupVotingIsValid(errors, durationSwitch)}
+        isNextButtonDisabled={!setupVotingIsValid(errors)}
         onNextButtonClicked={next => {
           const [startDate, startTime, startUtc, endDate, endTime, endUtc] =
             getValues([

--- a/packages/web-app/src/containers/proposalStepper/index.tsx
+++ b/packages/web-app/src/containers/proposalStepper/index.tsx
@@ -16,11 +16,11 @@ import SetupVotingForm, {
 import {useActionsContext} from 'context/actions';
 import {useNetwork} from 'context/network';
 import {useDaoParam} from 'hooks/useDaoParam';
+import {useWallet} from 'hooks/useWallet';
+import {trackEvent} from 'services/analytics';
+import {getCanonicalUtcOffset} from 'utils/date';
 import {Governance} from 'utils/paths';
 import {actionsAreValid} from 'utils/validators';
-import {trackEvent} from 'services/analytics';
-import {useWallet} from 'hooks/useWallet';
-import {getCanonicalUtcOffset} from 'utils/date';
 
 type ProposalStepperType = {
   enableTxModal: () => void;
@@ -37,8 +37,8 @@ const ProposalStepper: React.FC<ProposalStepperType> = ({
   const {trigger, control, getValues} = useFormContext();
   const {address} = useWallet();
 
-  const [durationSwitch, formActions] = useWatch({
-    name: ['durationSwitch', 'actions'],
+  const [formActions] = useWatch({
+    name: ['actions'],
     control,
   });
 

--- a/packages/web-app/src/containers/setupVotingForm/index.tsx
+++ b/packages/web-app/src/containers/setupVotingForm/index.tsx
@@ -305,7 +305,7 @@ const SetupVotingForm: React.FC = () => {
                       <NumberInput
                         name={name}
                         value={value}
-                        min={days}
+                        min={days + 1}
                         onChange={onChange}
                         width={144}
                       />

--- a/packages/web-app/src/containers/setupVotingForm/index.tsx
+++ b/packages/web-app/src/containers/setupVotingForm/index.tsx
@@ -393,13 +393,13 @@ export default SetupVotingForm;
  * @param durationSwitch Duration switch value
  * @returns Whether the screen is valid
  */
-export function isValid(errors: StringIndexed, durationSwitch: string) {
-  if (durationSwitch === 'date') {
-    return errors.startDate || errors.startTime || errors.endDate
-      ? false
-      : true;
-  }
-  return errors.startDate || errors.startTime || errors.duration ? false : true;
+export function isValid(errors: StringIndexed) {
+  return !(
+    errors.startDate ||
+    errors.startTime ||
+    errors.endDate ||
+    errors.ednTime
+  );
 }
 
 const FormSection = styled.div.attrs({

--- a/packages/web-app/src/containers/setupVotingForm/index.tsx
+++ b/packages/web-app/src/containers/setupVotingForm/index.tsx
@@ -160,7 +160,7 @@ const SetupVotingForm: React.FC = () => {
     }
 
     return !returnValue ? true : returnValue;
-  }, [clearErrors, getValues, setError, t]);
+  }, [clearErrors, days, getValues, hours, minutes, setError, t]);
 
   // These effects trigger validation when UTC fields are changed.
 

--- a/packages/web-app/src/locales/en/common.json
+++ b/packages/web-app/src/locales/en/common.json
@@ -260,7 +260,7 @@
     }
   },
   "infos": {
-    "voteDuration": "The minimum duration of {{days}} days is defined by DAO Governance Settings. To change the minimum duration a vote is required",
+    "voteDuration": "The minimum duration of {{days}} days is defined by DAO Governance Settings. To change the minimum duration a vote is required.",
     "voteDHDuration": "The minimum duration of {{days}} days and {{hours}} hours is defined by DAO Governance Settings. To change the minimum duration a vote is required",
     "voteDHMDuration": "The minimum duration of {{days}} days, {{hours}} hours, and {{minutes}} minutes is defined by DAO Governance Settings. To change the minimum duration a vote is required",
     "newVotingTypes": "New voting types soon",
@@ -269,8 +269,8 @@
   "errors": {
     "amountWithInvalidToken": "Cannot validate amount with invalid token address",
     "defaultAmountValidationError": "Error validating amount",
-    "durationTooShort": "Duration must be at least 5 days",
-    "endPast": "End date must be more then 5 days from the start",
+    "durationTooShort": "Duration too short",
+    "endPast": "Duration too short",
     "exceedsFractionalParts": "The number of decimals in the amount must not exceed the number of decimals of the token({{decimals}})",
     "includeDecimals": "Include decimals, e.g. 10.0",
     "includeExactAmount": "The token doesn't contain decimals. Please enter the exact amount",

--- a/packages/web-app/src/pages/manageMembers.tsx
+++ b/packages/web-app/src/pages/manageMembers.tsx
@@ -45,8 +45,8 @@ const ManageMembers: React.FC = () => {
     control: formMethods.control,
   });
 
-  const [durationSwitch, formActions] = useWatch({
-    name: ['durationSwitch', 'actions'],
+  const [formActions] = useWatch({
+    name: ['actions'],
     control: formMethods.control,
   });
 

--- a/packages/web-app/src/pages/manageMembers.tsx
+++ b/packages/web-app/src/pages/manageMembers.tsx
@@ -98,7 +98,7 @@ const ManageMembers: React.FC = () => {
             <Step
               wizardTitle={t('newWithdraw.setupVoting.title')}
               wizardDescription={t('newWithdraw.setupVoting.description')}
-              isNextButtonDisabled={!setupVotingIsValid(errors, durationSwitch)}
+              isNextButtonDisabled={!setupVotingIsValid(errors)}
             >
               <SetupVotingForm />
             </Step>

--- a/packages/web-app/src/pages/mintTokens.tsx
+++ b/packages/web-app/src/pages/mintTokens.tsx
@@ -96,7 +96,7 @@ const MintToken: React.FC = () => {
             <Step
               wizardTitle={t('newWithdraw.setupVoting.title')}
               wizardDescription={t('newWithdraw.setupVoting.description')}
-              isNextButtonDisabled={!setupVotingIsValid(errors, durationSwitch)}
+              isNextButtonDisabled={!setupVotingIsValid(errors)}
             >
               <SetupVotingForm />
             </Step>

--- a/packages/web-app/src/pages/mintTokens.tsx
+++ b/packages/web-app/src/pages/mintTokens.tsx
@@ -50,8 +50,8 @@ const MintToken: React.FC = () => {
     control: formMethods.control,
   });
 
-  const [durationSwitch, formActions] = useWatch({
-    name: ['durationSwitch', 'actions'],
+  const [formActions] = useWatch({
+    name: ['actions'],
     control: formMethods.control,
   });
 

--- a/packages/web-app/src/pages/newWithdraw.tsx
+++ b/packages/web-app/src/pages/newWithdraw.tsx
@@ -5,34 +5,31 @@ import {FormProvider, useForm, useFormState, useWatch} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 
 import {FullScreenStepper, Step} from 'components/fullScreenStepper';
-import ReviewProposal from 'containers/reviewProposal';
-import TokenMenu from 'containers/tokenMenu';
-import {useDaoBalances} from 'hooks/useDaoBalances';
-import {fetchTokenPrice} from 'services/prices';
-import {formatUnits} from 'utils/library';
-import {Finance} from 'utils/paths';
-import {BaseTokenInfo} from 'utils/types';
-
+import {Loading} from 'components/temporary';
 import ConfigureWithdrawForm, {
   isValid as configureWithdrawScreenIsValid,
 } from 'containers/configureWithdraw';
-
 import DefineProposal, {
   isValid as defineProposalIsValid,
 } from 'containers/defineProposal';
-
-import {Loading} from 'components/temporary';
+import ReviewProposal from 'containers/reviewProposal';
 import SetupVotingForm, {
   isValid as setupVotingIsValid,
 } from 'containers/setupVotingForm';
+import TokenMenu from 'containers/tokenMenu';
 import {ActionsProvider} from 'context/actions';
 import {CreateProposalProvider} from 'context/createProposal';
 import {useNetwork} from 'context/network';
+import {useDaoBalances} from 'hooks/useDaoBalances';
 import {useDaoParam} from 'hooks/useDaoParam';
+import {useWallet} from 'hooks/useWallet';
 import {generatePath} from 'react-router-dom';
 import {trackEvent} from 'services/analytics';
-import {useWallet} from 'hooks/useWallet';
+import {fetchTokenPrice} from 'services/prices';
 import {getCanonicalUtcOffset} from 'utils/date';
+import {formatUnits} from 'utils/library';
+import {Finance} from 'utils/paths';
+import {BaseTokenInfo} from 'utils/types';
 
 export type TokenFormData = {
   tokenName: string;
@@ -99,8 +96,8 @@ const NewWithdraw: React.FC = () => {
 
   const {errors, dirtyFields} = useFormState({control: formMethods.control});
 
-  const [durationSwitch, tokenAddress] = useWatch({
-    name: ['durationSwitch', 'actions.0.tokenAddress'],
+  const [tokenAddress] = useWatch({
+    name: ['actions.0.tokenAddress'],
     control: formMethods.control,
   });
 

--- a/packages/web-app/src/pages/newWithdraw.tsx
+++ b/packages/web-app/src/pages/newWithdraw.tsx
@@ -195,9 +195,7 @@ const NewWithdraw: React.FC = () => {
               <Step
                 wizardTitle={t('newWithdraw.setupVoting.title')}
                 wizardDescription={t('newWithdraw.setupVoting.description')}
-                isNextButtonDisabled={
-                  !setupVotingIsValid(errors, durationSwitch)
-                }
+                isNextButtonDisabled={!setupVotingIsValid(errors)}
                 onNextButtonClicked={next => {
                   const [
                     startDate,


### PR DESCRIPTION
## Description

This PR essentially hooks the UTC fields in the Voting Setup Step of proposal creations to the `dateTimeValidator`. This results in a correct inline error on the GUI if an invalid UTC value is set, _as well as a correct removal of that error after a changing it back to a valid value_.

Task: [1319](https://aragonassociation.atlassian.net/browse/APP-1319)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)