### PR TITLE
Change subgraph url

### DIFF
--- a/packages/web-app/src/utils/constants/api.ts
+++ b/packages/web-app/src/utils/constants/api.ts
@@ -4,8 +4,7 @@ type SubgraphNetworkUrl = Record<SupportedNetworks, string | undefined>;
 
 export const SUBGRAPH_API_URL: SubgraphNetworkUrl = {
   ethereum: undefined,
-  goerli:
-    'https://api.thegraph.com/subgraphs/name/aragon/aragon-zaragoza-goerli',
+  goerli: "https://subgraph.satsuma-prod.com/qHR2wGfc5RLi6/aragon/core-goerli/api",
   polygon: undefined,
   mumbai:
     'https://api.thegraph.com/subgraphs/name/aragon/aragon-zaragoza-mumbai',

--- a/packages/web-app/src/utils/constants/api.ts
+++ b/packages/web-app/src/utils/constants/api.ts
@@ -4,7 +4,8 @@ type SubgraphNetworkUrl = Record<SupportedNetworks, string | undefined>;
 
 export const SUBGRAPH_API_URL: SubgraphNetworkUrl = {
   ethereum: undefined,
-  goerli: "https://subgraph.satsuma-prod.com/qHR2wGfc5RLi6/aragon/core-goerli/api",
+  goerli:
+    'https://subgraph.satsuma-prod.com/qHR2wGfc5RLi6/aragon/core-goerli/api',
   polygon: undefined,
   mumbai:
     'https://api.thegraph.com/subgraphs/name/aragon/aragon-zaragoza-mumbai',


### PR DESCRIPTION
## Description

Changes one line of config to use Satsuma subgraph. Note, exposes access key as part of url but this is currently unavoidable.

Task: [APP-1406](https://aragonassociation.atlassian.net/browse/APP-1406)

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x ] I have tested my code on the test network.

[APP-1406]: https://aragonassociation.atlassian.net/browse/APP-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ