### PR TITLE
Fix: Multisig DAO - Updated prefixProposalIdWithPlgnAdr to handle bigint hex from SDK

### DIFF
--- a/packages/web-app/src/utils/__tests__/proposals.test.ts
+++ b/packages/web-app/src/utils/__tests__/proposals.test.ts
@@ -23,6 +23,11 @@ const testCases = [
     expectedId: `${pluginAddress}_0x3`,
   },
   {
+    case: 'should convert raw string id to hexadecimal',
+    proposalId: '11',
+    expectedId: `${pluginAddress}_0xb`,
+  },
+  {
     case: 'should return proposal id already prefixed with plugin address unchanged',
     proposalId: `${pluginAddress}_0x1`,
     expectedId: `${pluginAddress}_0x1`,

--- a/packages/web-app/src/utils/proposals.ts
+++ b/packages/web-app/src/utils/proposals.ts
@@ -656,7 +656,7 @@ export function prefixProposalIdWithPlgnAdr(
 
   // proposal id is singular number without hex notation "2"
   if (parts.length === 1) {
-    return `${pluginAddress}_0x${parts[0]}`;
+    return `${pluginAddress}_0x${Number(parts[0]).toString(16)}`;
   }
 
   // proposal id is of the following format "0x1"


### PR DESCRIPTION
## Description
- add a fix for when the SDK returns a `bigint` which should actually be a hex value

Task: No task

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.