### PR TITLE
Fix: Finance - Withdrawal - Next button stays disabled

### DIFF
--- a/packages/web-app/src/containers/defineProposal/index.tsx
+++ b/packages/web-app/src/containers/defineProposal/index.tsx
@@ -132,14 +132,10 @@ export default DefineProposal;
  * @param errors List of fields with errors
  * @returns Whether the screen is valid
  */
-export function isValid(
-  dirtyFields: StringIndexed,
-  errors: StringIndexed,
-  proposalTitle?: string
-) {
+export function isValid(dirtyFields: StringIndexed, errors: StringIndexed) {
   // required fields not dirty
   if (
-    !proposalTitle ||
+    !dirtyFields.proposalTitle ||
     !dirtyFields.proposalSummary ||
     errors.proposalTitle ||
     errors.proposalSummary

--- a/packages/web-app/src/containers/proposalStepper/index.tsx
+++ b/packages/web-app/src/containers/proposalStepper/index.tsx
@@ -37,8 +37,8 @@ const ProposalStepper: React.FC<ProposalStepperType> = ({
   const {trigger, control, getValues} = useFormContext();
   const {address} = useWallet();
 
-  const [formActions, proposalTitle] = useWatch({
-    name: ['actions', 'proposalTitle'],
+  const [formActions] = useWatch({
+    name: ['actions'],
     control,
   });
 
@@ -63,9 +63,7 @@ const ProposalStepper: React.FC<ProposalStepperType> = ({
       <Step
         wizardTitle={t('newWithdraw.defineProposal.heading')}
         wizardDescription={t('newWithdraw.defineProposal.description')}
-        isNextButtonDisabled={
-          !defineProposalIsValid(dirtyFields, errors, proposalTitle)
-        }
+        isNextButtonDisabled={!defineProposalIsValid(dirtyFields, errors)}
         onNextButtonClicked={next => {
           trackEvent('newProposal_nextBtn_clicked', {
             dao_address: dao,

--- a/packages/web-app/src/pages/manageMembers.tsx
+++ b/packages/web-app/src/pages/manageMembers.tsx
@@ -73,9 +73,9 @@ const ManageMembers: React.FC = () => {
     control: formMethods.control,
   });
 
-  const [formActions, proposalTitle] = useWatch({
+  const [formActions] = useWatch({
     control: formMethods.control,
-    name: ['actions', 'proposalTitle'],
+    name: ['actions'],
   });
 
   const [showTxModal, setShowTxModal] = useState(false);
@@ -137,9 +137,7 @@ const ManageMembers: React.FC = () => {
             <Step
               wizardTitle={t('newWithdraw.defineProposal.heading')}
               wizardDescription={t('newWithdraw.defineProposal.description')}
-              isNextButtonDisabled={
-                !defineProposalIsValid(dirtyFields, errors, proposalTitle)
-              }
+              isNextButtonDisabled={!defineProposalIsValid(dirtyFields, errors)}
             >
               <DefineProposal />
             </Step>


### PR DESCRIPTION
## Description

When creating a Withdrawal proposal from the Finance page (only), in the ‘Create a proposal’ step even filling in all fields does not make the Next button become active.

[Task: [APP-1742](https://aragonassociation.atlassian.net/browse/APP-1742)](https://aragonassociation.atlassian.net/browse/APP-1742)

[APP-1742]: https://aragonassociation.atlassian.net/browse/APP-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ