### PR TITLE
Fix: Dao name validation on settings page

### DIFF
--- a/packages/web-app/src/containers/defineMetadata/index.tsx
+++ b/packages/web-app/src/containers/defineMetadata/index.tsx
@@ -24,16 +24,20 @@ const DAO_LOGO = {
 
 export type DefineMetadataProps = {
   arrayName?: string;
+  currentDaoName?: string;
   bgWhite?: boolean;
 };
 
 const DefineMetadata: React.FC<DefineMetadataProps> = ({
   arrayName = 'links',
   bgWhite = false,
+  currentDaoName = '',
 }) => {
   const {t} = useTranslation();
   const {control, setError, clearErrors, getValues} = useFormContext();
   const {infura: provider} = useProviders();
+
+  const isMyName = currentDaoName === getValues('daoName');
 
   const handleImageError = useCallback(
     (error: {code: string; message: string}) => {
@@ -102,8 +106,19 @@ const DefineMetadata: React.FC<DefineMetadataProps> = ({
           defaultValue=""
           rules={{
             required: t('errors.required.name'),
-            validate: value =>
-              isDaoNameValid(value, provider, setError, clearErrors, getValues),
+            validate: value => {
+              if (isMyName) {
+                return true;
+              }
+
+              return isDaoNameValid(
+                value,
+                provider,
+                setError,
+                clearErrors,
+                getValues
+              );
+            },
           }}
           render={({
             field: {onBlur, onChange, value, name},
@@ -115,7 +130,7 @@ const DefineMetadata: React.FC<DefineMetadataProps> = ({
                 placeholder={t('placeHolders.daoName')}
               />
               <InputCount>{`${value.length}/128`}</InputCount>
-              <ErrorHandler {...{value, error}} />
+              {!isMyName && <ErrorHandler {...{value, error}} />}
             </>
           )}
         />

--- a/packages/web-app/src/pages/editSettings.tsx
+++ b/packages/web-app/src/pages/editSettings.tsx
@@ -48,7 +48,7 @@ const EditSettings: React.FC = () => {
     name: 'daoLinks',
     control,
   });
-  const {errors} = useFormState({control});
+  const {errors, isValid} = useFormState({control});
 
   const {data: daoDetails, isLoading: detailsAreLoading} = useDaoDetails(
     daoId!
@@ -402,7 +402,7 @@ const EditSettings: React.FC = () => {
                 label={t('settings.reviewProposal')}
                 iconLeft={<IconGovernance />}
                 size="large"
-                disabled={settingsUnchanged}
+                disabled={settingsUnchanged || !isValid}
                 onClick={() =>
                   navigate(
                     generatePath(ProposeNewSettings, {network, dao: daoId})
@@ -414,7 +414,7 @@ const EditSettings: React.FC = () => {
                 label={t('settings.resetChanges')}
                 mode="secondary"
                 size="large"
-                disabled={settingsUnchanged}
+                disabled={settingsUnchanged || !isValid}
                 onClick={handleResetChanges}
               />
             </HStack>

--- a/packages/web-app/src/pages/editSettings.tsx
+++ b/packages/web-app/src/pages/editSettings.tsx
@@ -414,7 +414,7 @@ const EditSettings: React.FC = () => {
                 label={t('settings.resetChanges')}
                 mode="secondary"
                 size="large"
-                disabled={settingsUnchanged || !isValid}
+                disabled={settingsUnchanged}
                 onClick={handleResetChanges}
               />
             </HStack>

--- a/packages/web-app/src/pages/editSettings.tsx
+++ b/packages/web-app/src/pages/editSettings.tsx
@@ -357,7 +357,11 @@ const EditSettings: React.FC = () => {
                 dropdownItems={metadataAction}
               >
                 <AccordionContent>
-                  <DefineMetadata bgWhite arrayName="daoLinks" />
+                  <DefineMetadata
+                    bgWhite
+                    arrayName="daoLinks"
+                    currentDaoName={daoDetails?.metadata?.name || ''}
+                  />
                 </AccordionContent>
               </AccordionItem>
 


### PR DESCRIPTION
## Description

On settings page, when editing, changing the DAO name field then manually reverting it to the original name wrongly results in a ‘Name is already taken’ error.

https://aragonassociation.atlassian.net/browse/APP-1771