### PR TITLE
Fix: APP-1752 - Voting Terminal 

### DIFF
--- a/packages/web-app/src/utils/proposals.ts
+++ b/packages/web-app/src/utils/proposals.ts
@@ -552,7 +552,7 @@ export function getTerminalProps(
 
     return {
       approvals: proposal.approvals,
-      voters: mappedMembers.values(),
+      voters: [...mappedMembers.values()],
       status: proposal.status,
     };
   }


### PR DESCRIPTION
## Description

- returns multisig voters as `Array` instead of `IterableIterator`

Task: [APP-1752](https://aragonassociation.atlassian.net/browse/APP-1752)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-1752]: https://aragonassociation.atlassian.net/browse/APP-1752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ