### PR TITLE
Fix: calendar date input double icon

### DIFF
--- a/packages/ui-components/src/components/input/dateInput.tsx
+++ b/packages/ui-components/src/components/input/dateInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useRef} from 'react';
 import styled from 'styled-components';
 
 import {IconCalendar} from '../icons';
@@ -10,19 +10,31 @@ export type DateInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 export const DateInput: React.FC<DateInputProps> = ({disabled, ...props}) => {
   const isFF = navigator.userAgent.indexOf('Firefox') !== -1;
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleClick = () => {
+    inputRef.current?.showPicker();
+  };
 
   return (
     <InputContainer data-testid="date-input" disabled={disabled}>
-      <StyledInput type={'date'} required disabled={disabled} {...props} />
-      {/* TODO Rework the whole icon business. The native icon is somehow
-      necessary on chrome to open the native date picker. So currently it's
-      being shown on chrome, although it is not the custom icon from the
-      designs. On the other hand, it doesn't exist on FF, so there, the custom
-      icon is shown.*/}
-      {isFF && (
-        <IconContainer disabled={disabled}>
-          <IconCalendar />
-        </IconContainer>
+      <StyledInput
+        id="date"
+        type={'date'}
+        required
+        disabled={disabled}
+        ref={inputRef}
+        {...props}
+      />
+
+      {/* This is a temporary solution to hide default icon on firefox */}
+      {!disabled && (
+        <>
+          {isFF && <Overlay />}
+          <IconContainer disabled={disabled} onClick={handleClick}>
+            <IconCalendar />
+          </IconContainer>
+        </>
       )}
     </InputContainer>
   );
@@ -35,7 +47,8 @@ allows for hover and active when disabled. */
 type InputContainerProps = Pick<DateInputProps, 'disabled'>;
 
 const InputContainer = styled.div.attrs(({disabled}: InputContainerProps) => {
-  const baseClasses = 'flex items-center p-1 rounded-xl border-2 font-normal';
+  const baseClasses =
+    'flex items-center p-1 rounded-xl border-2 font-normal cursor-pointer';
   let className = `${baseClasses}`;
 
   if (disabled) {
@@ -50,6 +63,14 @@ const InputContainer = styled.div.attrs(({disabled}: InputContainerProps) => {
   return {className, disabled};
 })<DateInputProps>``;
 
+const Overlay = styled.div`
+  width: 32px;
+  height: 32px;
+  position: absolute;
+  right: 58px;
+  background: white;
+`;
+
 const StyledInput = styled.input.attrs(() => {
   const baseClasses = 'w-full bg-transparent';
   const className = `${baseClasses}`;
@@ -57,8 +78,7 @@ const StyledInput = styled.input.attrs(() => {
   return {className};
 })<DateInputProps>`
   ::-webkit-calendar-picker-indicator {
-    margin-top: 4px;
-    margin-bottom: 4px;
+    display: none;
   }
 
   outline: 0;

--- a/packages/ui-components/src/components/input/dateInput.tsx
+++ b/packages/ui-components/src/components/input/dateInput.tsx
@@ -10,7 +10,9 @@ export type DateInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 export const DateInput: React.FC<DateInputProps> = ({disabled, ...props}) => {
   const isFF = navigator.userAgent.indexOf('Firefox') !== -1;
-  const inputRef = useRef<HTMLInputElement>(null);
+  // Temorary add disabled linster for this line typescript cant detect that showPicker is exists on HTMLInputElement
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const inputRef = useRef<any>(null);
 
   const handleClick = () => {
     inputRef.current?.showPicker();

--- a/packages/ui-components/src/components/input/dateInput.tsx
+++ b/packages/ui-components/src/components/input/dateInput.tsx
@@ -29,9 +29,9 @@ export const DateInput: React.FC<DateInputProps> = ({disabled, ...props}) => {
         {...props}
       />
 
-      {/* This is a temporary solution to hide default icon on firefox */}
       {!disabled && (
         <>
+          {/* This is a temporary solution to hide default icon on firefox */}
           {isFF && <Overlay />}
           <IconContainer disabled={disabled} onClick={handleClick}>
             <IconCalendar />

--- a/packages/ui-components/src/components/input/dateInput.tsx
+++ b/packages/ui-components/src/components/input/dateInput.tsx
@@ -50,7 +50,7 @@ type InputContainerProps = Pick<DateInputProps, 'disabled'>;
 
 const InputContainer = styled.div.attrs(({disabled}: InputContainerProps) => {
   const baseClasses =
-    'flex items-center p-1 rounded-xl border-2 font-normal cursor-pointer';
+    'flex relative items-center p-1 rounded-xl border-2 font-normal cursor-pointer';
   let className = `${baseClasses}`;
 
   if (disabled) {
@@ -69,7 +69,7 @@ const Overlay = styled.div`
   width: 32px;
   height: 32px;
   position: absolute;
-  right: 58px;
+  right: 40px;
   background: white;
 `;
 

--- a/packages/ui-components/src/components/input/dateInput.tsx
+++ b/packages/ui-components/src/components/input/dateInput.tsx
@@ -1,23 +1,9 @@
-import React, {useRef} from 'react';
+import React from 'react';
 import styled from 'styled-components';
-
-import {IconCalendar} from '../icons';
-
-// NOTE: Currently, there are no designs for the actual date-picker.
-// TODO: Add styling for date-picker once designs are ready. [VR 07-01-2022]
 
 export type DateInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 export const DateInput: React.FC<DateInputProps> = ({disabled, ...props}) => {
-  const isFF = navigator.userAgent.indexOf('Firefox') !== -1;
-  // Temorary add disabled linster for this line typescript cant detect that showPicker is exists on HTMLInputElement
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const inputRef = useRef<any>(null);
-
-  const handleClick = () => {
-    inputRef.current?.showPicker();
-  };
-
   return (
     <InputContainer data-testid="date-input" disabled={disabled}>
       <StyledInput
@@ -25,26 +11,11 @@ export const DateInput: React.FC<DateInputProps> = ({disabled, ...props}) => {
         type={'date'}
         required
         disabled={disabled}
-        ref={inputRef}
         {...props}
       />
-
-      {!disabled && (
-        <>
-          {/* This is a temporary solution to hide default icon on firefox */}
-          {isFF && <Overlay />}
-          <IconContainer disabled={disabled} onClick={handleClick}>
-            <IconCalendar />
-          </IconContainer>
-        </>
-      )}
     </InputContainer>
   );
 };
-
-/* NOTE: I know very similar code already exists in TextInput. But there were a
-couple of issues that made it hard to adopt. One of which is that it still
-allows for hover and active when disabled. */
 
 type InputContainerProps = Pick<DateInputProps, 'disabled'>;
 
@@ -65,14 +36,6 @@ const InputContainer = styled.div.attrs(({disabled}: InputContainerProps) => {
   return {className, disabled};
 })<DateInputProps>``;
 
-const Overlay = styled.div`
-  width: 32px;
-  height: 32px;
-  position: absolute;
-  right: 40px;
-  background: white;
-`;
-
 const StyledInput = styled.input.attrs(() => {
   const baseClasses = 'w-full bg-transparent';
   const className = `${baseClasses}`;
@@ -80,12 +43,7 @@ const StyledInput = styled.input.attrs(() => {
   return {className};
 })<DateInputProps>`
   ::-webkit-calendar-picker-indicator {
-    display: none;
   }
 
   outline: 0;
 `;
-
-const IconContainer = styled.div.attrs(({disabled}: InputContainerProps) => {
-  return {className: ` p-1 rounded-xl ${disabled ? 'bg-ui-100' : 'bg-ui-50'}`};
-})<DateInputProps>``;


### PR DESCRIPTION
## Description

When the Date Input field is displaying (e.g. on proposal creation when selecting ‘Specific Date + Time’), there is a double display of the calendar icon (Firefox issue only!).

[https://aragonassociation.atlassian.net/browse/APP-1750](https://aragonassociation.atlassian.net/browse/APP-1750)