### PR TITLE
Fix: (ad hoc) Show DAOs with zero plugins on explorer

### DIFF
--- a/packages/web-app/src/containers/daoExplorer/daoExplorer.tsx
+++ b/packages/web-app/src/containers/daoExplorer/daoExplorer.tsx
@@ -109,7 +109,7 @@ export const DaoExplorer = () => {
                 description={dao.metadata.description}
                 chainId={dao.chain || DEFAULT_CHAIN_ID} // Default to Goerli
                 daoType={
-                  (dao?.plugins?.[0]?git .id as PluginTypes) ===
+                  (dao?.plugins?.[0]?.id as PluginTypes) ===
                   'token-voting.plugin.dao.eth'
                     ? 'token-based'
                     : 'wallet-based'

--- a/packages/web-app/src/containers/daoExplorer/daoExplorer.tsx
+++ b/packages/web-app/src/containers/daoExplorer/daoExplorer.tsx
@@ -109,7 +109,7 @@ export const DaoExplorer = () => {
                 description={dao.metadata.description}
                 chainId={dao.chain || DEFAULT_CHAIN_ID} // Default to Goerli
                 daoType={
-                  (dao?.plugins[0].id as PluginTypes) ===
+                  (dao?.plugins?.[0]?git .id as PluginTypes) ===
                   'token-voting.plugin.dao.eth'
                     ? 'token-based'
                     : 'wallet-based'

--- a/packages/web-app/src/hooks/useDaos.tsx
+++ b/packages/web-app/src/hooks/useDaos.tsx
@@ -58,7 +58,7 @@ export function useDaos(
           const sortBy =
             useCase === 'popular' ? DaoSortBy.POPULARITY : DaoSortBy.CREATED_AT;
 
-          const daos =
+          let daos =
             (await client?.methods.getDaos({
               sortBy,
               direction,
@@ -74,6 +74,11 @@ export function useDaos(
               } catch (err) {
                 dao.metadata.avatar = undefined;
               }
+            }
+            if (dao.plugins.length < 1) {
+              console.log(
+                `WARNING: DAO with zero plugins ignored ens: ${dao.ensDomain} address: ${dao.address}`
+              );
             }
           });
           setData(daos);

--- a/packages/web-app/src/hooks/useDaos.tsx
+++ b/packages/web-app/src/hooks/useDaos.tsx
@@ -58,7 +58,7 @@ export function useDaos(
           const sortBy =
             useCase === 'popular' ? DaoSortBy.POPULARITY : DaoSortBy.CREATED_AT;
 
-          let daos =
+          const daos =
             (await client?.methods.getDaos({
               sortBy,
               direction,


### PR DESCRIPTION
## Description

Given DAOs with zero plugins block ability to list them or subsequent DAOs on Explorer, ad hoc fix to at least let DAOs be listed.

Task: [ID]()

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.