### PR TITLE
subgraph -> 0.7.2

### DIFF
--- a/packages/web-app/src/utils/constants/api.ts
+++ b/packages/web-app/src/utils/constants/api.ts
@@ -5,7 +5,7 @@ type SubgraphNetworkUrl = Record<SupportedNetworks, string | undefined>;
 export const SUBGRAPH_API_URL: SubgraphNetworkUrl = {
   ethereum: undefined,
   goerli:
-    'https://subgraph.satsuma-prod.com/qHR2wGfc5RLi6/aragon/core-goerli-2/version/v0.9.0-alpha/api',
+    'https://subgraph.satsuma-prod.com/qHR2wGfc5RLi6/aragon/core-goerli/version/v0.7.2-alpha/api',
   polygon: undefined,
   mumbai:
     'https://api.thegraph.com/subgraphs/name/aragon/aragon-zaragoza-mumbai',


### PR DESCRIPTION
## Description

Revert subgraph 0.7.2 to avoid multisig DAOs return empty plugin list on 0.9.0

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
