### PR TITLE
Fix: Hide AlertChip with z-index

### DIFF
--- a/packages/ui-components/src/components/alerts/alertChip.tsx
+++ b/packages/ui-components/src/components/alerts/alertChip.tsx
@@ -96,9 +96,10 @@ const WrapperAnimationCSS = css`
 
 const Wrapper = styled.div.attrs(({isShown}: ContainerProps) => ({
   className: `fixed w-full flex items-center justify-center top-3 ${
-    isShown ? 'opacity-100 fixed z-50' : 'opacity-0 none z-0'
+    isShown ? 'opacity-100 fixed' : 'opacity-0 none'
   }`,
 }))`
+  z-index: ${props => (props.isShown ? '50' : '-50')};
   ${WrapperAnimationCSS}
 `;
 


### PR DESCRIPTION
## Description

- Fixes the alert chip causing navigation breadcrumb to not work

Task: [APP-1792](https://aragonassociation.atlassian.net/browse/APP-1792)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-1792]: https://aragonassociation.atlassian.net/browse/APP-1792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ