### PR TITLE
Chore: Open connect wallet modal on publish proposal if not connected

### DIFF
--- a/packages/web-app/src/app.tsx
+++ b/packages/web-app/src/app.tsx
@@ -184,8 +184,10 @@ const NotFoundWrapper: React.FC = () => {
 
 const ExploreWrapper: React.FC = () => (
   <>
-    <ExploreNav />
-    <Outlet />
+    <div className="min-h-screen">
+      <ExploreNav />
+      <Outlet />
+    </div>
     <ExploreFooter />
   </>
 );

--- a/packages/web-app/src/containers/proposalStepper/index.tsx
+++ b/packages/web-app/src/containers/proposalStepper/index.tsx
@@ -29,6 +29,7 @@ import {removeUnchangedMinimumApprovalAction} from 'utils/library';
 import {Governance} from 'utils/paths';
 import {Action} from 'utils/types';
 import {actionsAreValid} from 'utils/validators';
+import {useGlobalModalContext} from 'context/globalModals';
 
 type ProposalStepperType = {
   enableTxModal: () => void;
@@ -45,11 +46,12 @@ const ProposalStepper: React.FC<ProposalStepperType> = ({
   );
 
   const {actions} = useActionsContext();
+  const {open} = useGlobalModalContext();
 
   const {t} = useTranslation();
   const {network} = useNetwork();
   const {trigger, control, getValues, setValue} = useFormContext();
-  const {address} = useWallet();
+  const {address, isConnected} = useWallet();
 
   const [formActions] = useWatch({
     name: ['actions'],
@@ -157,8 +159,12 @@ const ProposalStepper: React.FC<ProposalStepperType> = ({
         wizardDescription={t('newWithdraw.reviewProposal.description')}
         nextButtonLabel={t('labels.submitProposal')}
         onNextButtonClicked={() => {
-          trackEvent('newProposal_publishBtn_clicked', {dao_address: dao});
-          enableTxModal();
+          if (!isConnected) {
+            open('wallet');
+          } else {
+            trackEvent('newProposal_publishBtn_clicked', {dao_address: dao});
+            enableTxModal();
+          }
         }}
         fullWidth
       >


### PR DESCRIPTION
Task: [APP-1942](https://aragonassociation.atlassian.net/browse/APP-1942)

# Known issue
Connecting the wallet in the last step, unfortunately, purges the whole form state and the user has to fill everything from the beginning. To be fixed later.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-1942]: https://aragonassociation.atlassian.net/browse/APP-1942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ