### PR TITLE
Fix: APP-1407 duplicate subgraph calls

### DIFF
--- a/packages/web-app/package.json
+++ b/packages/web-app/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && vite build --sourcemap true",
     "serve": "vite preview",
     "serve:docker": "vite --host --port 5000",
-    "test": "jest",
+    "test": "jest --coverage=false",
     "lint": "eslint src --max-warnings=0 && yarn check-types",
     "lint:fix": "eslint src --fix",
     "check-types": "tsc --noemit",

--- a/packages/web-app/src/utils/__tests__/cache.test.ts
+++ b/packages/web-app/src/utils/__tests__/cache.test.ts
@@ -73,10 +73,10 @@ describe('Expiring Promise Cache', () => {
     cache.add('aaa', testPromise(10, 'morning'));
     const gotItem = cache.get('aaa');
     await gotItem;
-    await wait(20);
+    await wait(15);
     cache.add('qqq', testPromise(20, 'evening'));
     cache.add('yyy', testPromise(20, 'goodbye'));
-    const gotItem2 = cache.get('xxx');
+    const gotItem2 = cache.get('aaa');
     expect(gotItem2).toBeUndefined();
     const gotItem3 = cache.get('qqq');
     expect(gotItem3).not.toBeUndefined();

--- a/packages/web-app/src/utils/__tests__/cache.test.ts
+++ b/packages/web-app/src/utils/__tests__/cache.test.ts
@@ -1,0 +1,86 @@
+import {ExpiringCache} from 'utils/expiringCache';
+import {ExpiringPromiseCache} from 'utils/expiringPromiseCache';
+
+interface TestItem {
+  x: string;
+}
+
+const wait = (ms: number) =>
+  new Promise<void>(res => setTimeout(() => res(), ms));
+
+describe('Expiring Cache', () => {
+  test('Add and retrieve', () => {
+    const cache = new ExpiringCache<TestItem>(10);
+    cache.add('abc', {x: 'hello'} as TestItem);
+    const gotItem = cache.get('abc');
+    expect(gotItem?.x).toBe('hello');
+  });
+  test('Add and expire', async () => {
+    const cache = new ExpiringCache<TestItem>(10);
+    cache.add('abc', {x: 'hello'} as TestItem);
+    await wait(20);
+    cache.add('def', {x: 'goodbye'} as TestItem);
+    const gotItem = cache.get('abc');
+    expect(gotItem).toBeUndefined();
+  });
+  test('Add several and retrieve', async () => {
+    const cache = new ExpiringCache<TestItem>(10);
+    cache.add('abc', {x: 'hello'} as TestItem);
+    await wait(20);
+    cache.add('def', {x: 'goodbye'} as TestItem);
+    cache.add('ghi', {x: 'chicken'} as TestItem);
+    const gotItem = cache.get('def');
+    expect(gotItem?.x).toBe('goodbye');
+  });
+});
+
+const testPromise = async (delayMs: number, val: string) => {
+  await wait(delayMs);
+  return val;
+};
+
+describe('Expiring Promise Cache', () => {
+  test('Add unresolved promise', async () => {
+    const cache = new ExpiringPromiseCache(10);
+    cache.add('xxx', testPromise(20, 'hello'));
+    const gotItem = cache.get('xxx');
+    expect(gotItem).not.toBeUndefined();
+    const val = await gotItem;
+    expect(val).toBe('hello');
+  });
+  test('Expiry starts after promise resolves', async () => {
+    const cache = new ExpiringPromiseCache(10);
+    cache.add('xxx', testPromise(20, 'hello'));
+    const gotItem = cache.get('xxx');
+    await gotItem;
+    cache.add('yyy', testPromise(20, 'goodbye'));
+    const gotItem2 = cache.get('xxx');
+    expect(gotItem2).not.toBeUndefined();
+  });
+  test('Expiry', async () => {
+    const cache = new ExpiringPromiseCache(10);
+    cache.add('xxx', testPromise(20, 'hello'));
+    const gotItem = cache.get('xxx');
+    await gotItem;
+    await wait(20);
+    cache.add('yyy', testPromise(20, 'goodbye'));
+    const gotItem2 = cache.get('xxx');
+    expect(gotItem2).toBeUndefined();
+  });
+  test('Multiple', async () => {
+    const cache = new ExpiringPromiseCache(10);
+    cache.add('xxx', testPromise(20, 'hello'));
+    cache.add('aaa', testPromise(10, 'morning'));
+    const gotItem = cache.get('aaa');
+    await gotItem;
+    await wait(20);
+    cache.add('qqq', testPromise(20, 'evening'));
+    cache.add('yyy', testPromise(20, 'goodbye'));
+    const gotItem2 = cache.get('xxx');
+    expect(gotItem2).toBeUndefined();
+    const gotItem3 = cache.get('qqq');
+    expect(gotItem3).not.toBeUndefined();
+    const val = await gotItem3;
+    expect(val).toBe('evening');
+  });
+});

--- a/packages/web-app/src/utils/expiringCache.ts
+++ b/packages/web-app/src/utils/expiringCache.ts
@@ -1,0 +1,50 @@
+export class ExpiringCache<T, K = string> {
+  private cache: Map<K, T & {_timestamp: number}> = new Map<
+    K,
+    T & {_timestamp: number}
+  >();
+
+  constructor(public expiryMs: number) {}
+
+  private expiryQueue: K[] = [];
+
+  private expireItems() {
+    let key: K | undefined = this.expiryQueue[0];
+    const now = new Date().getTime();
+    while (key && this.cache.get(key)!._timestamp < now - this.expiryMs) {
+      this.cache.delete(key);
+      this.expiryQueue.shift();
+      key = this.expiryQueue[0];
+    }
+  }
+
+  private delete(key: K) {
+    this.cache.delete(key);
+    const expiryPos = this.expiryQueue.findIndex(k => k === key);
+    if (expiryPos >= 0) this.expiryQueue.splice(expiryPos, 1);
+  }
+
+  add(key: K, value: T) {
+    const timestamp = new Date().getTime();
+    const item = {...value, _timestamp: timestamp};
+    this.delete(key); // need to update timestamp
+    this.expireItems();
+    this.cache.set(key, item);
+    this.expiryQueue.push(key);
+    console.log(
+      `CACHE ADD ${key} items: ${this.cache.size} expiryQ: ${this.expiryQueue.length}`
+    );
+  }
+
+  get(key: K): T {
+    const foundItem = this.cache.get(key);
+    if (foundItem) {
+      foundItem._timestamp = new Date().getTime(); // update timestamp
+      this.cache.set(key, foundItem);
+      console.log(`CACHE HIT ${key}`);
+    } else {
+      console.log(`CACHE MISS ${key}`);
+    }
+    return foundItem as T;
+  }
+}

--- a/packages/web-app/src/utils/expiringPromiseCache.ts
+++ b/packages/web-app/src/utils/expiringPromiseCache.ts
@@ -1,0 +1,59 @@
+interface Expiry<K> {
+  key: K;
+  expiry: number;
+}
+
+/**
+ * Cache for promises for data retrieval processes: can be used to ensure
+ * multiple simultaneous requests are not made for the same resource
+ */
+export class ExpiringPromiseCache<T, K = string> {
+  private cache: Map<K, Promise<T>> = new Map<K, Promise<T>>();
+
+  /**
+   * @param {number} expiryMs Minimum time a promise is held in cache after it has resolved
+   */
+  constructor(public expiryMs: number) {}
+
+  private expiryQueue: Expiry<K>[] = [];
+
+  private expireItems() {
+    const now = new Date().getTime();
+    while (this.expiryQueue.length > 0 && this.expiryQueue[0].expiry < now) {
+      const {key} = this.expiryQueue.shift()!;
+      this.cache.delete(key);
+    }
+  }
+
+  /**
+   * Add a promise to the cache, removing any expired promises at the same time
+   * @param {K} key The key for the stored item
+   * @param {Promise<T> | undefined} promise The promise to store, allowed to be undefined
+   * @returns {Promise<T> | undefined} The promise passed in for chaining
+   */
+  add(key: K, promise: Promise<T> | undefined) {
+    if (!promise) return promise;
+
+    this.expireItems();
+    this.cache.set(
+      key,
+      promise.then(res => {
+        const expiry = new Date().getTime() + this.expiryMs;
+        this.expiryQueue.push({key, expiry});
+        return res;
+      })
+    );
+    return promise;
+  }
+
+  /**
+   * Get the promise with key supplied. Note you can get the resolved value
+   * of a promise multiple times.
+   * @param key Cache key of promise
+   * @returns {Promise<T> | undefined} The promise or undefined if it's not present in cache
+   */
+  get(key: K): Promise<T> | undefined {
+    const foundPromise = this.cache.get(key);
+    return foundPromise;
+  }
+}


### PR DESCRIPTION
## Description

This fixes the worst culprit for duplicate subgraph calls on our side, useDaoDetails. It adds a cache which caches async requests via the SDK for DAO details to ensure only one is running for a given id at the same time, and returns the result of the first request to all locations requesting this data.

Task: [APP-1407](https://aragonassociation.atlassian.net/browse/APP-1407)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-1407]: https://aragonassociation.atlassian.net/browse/APP-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ