### PR TITLE
Fix: APP-2061 - Explorer: Wrong network crash

### DIFF
--- a/packages/web-app/src/app.tsx
+++ b/packages/web-app/src/app.tsx
@@ -86,12 +86,6 @@ function App() {
     window.scrollTo(0, 0);
   }, [pathname]);
 
-  // This only happens as an intermediate state as unsupported network
-  // causes immediate navigation to 404 page
-  if (network === 'unsupported') {
-    return <Loading />;
-  }
-
   return (
     <>
       {/* TODO: replace with loading indicator */}

--- a/packages/web-app/src/context/network.tsx
+++ b/packages/web-app/src/context/network.tsx
@@ -101,11 +101,12 @@ export function NetworkProvider({children}: NetworkProviderProps) {
   );
 
   useEffect(() => {
-    if (networkState === 'unsupported') {
+    // unsupported network based on the networkUrlSegment network
+    if (networkState === 'unsupported' && networkUrlSegment) {
       console.warn('network unsupported');
       navigate(NotFound, {replace: true});
     }
-  }, [networkState, navigate]);
+  }, [networkState, navigate, networkUrlSegment]);
 
   return (
     <NetworkContext.Provider

--- a/packages/web-app/src/hooks/useClient.tsx
+++ b/packages/web-app/src/hooks/useClient.tsx
@@ -48,10 +48,10 @@ const translateToSdkNetwork = (
   }
 
   switch (appNetwork) {
-    case 'polygon':
-      return 'matic';
-    case 'mumbai':
-      return 'maticmum';
+    // case 'polygon':
+    //   return 'matic';
+    // case 'mumbai':
+    //   return 'maticmum';
     case 'ethereum':
       return 'mainnet';
     case 'goerli':

--- a/packages/web-app/src/hooks/useClient.tsx
+++ b/packages/web-app/src/hooks/useClient.tsx
@@ -1,6 +1,13 @@
-import {Client, Context as SdkContext, ContextParams} from '@aragon/sdk-client';
+import {
+  Client,
+  Context as SdkContext,
+  ContextParams,
+  SupportedNetworks as SdkSupportedNetworks,
+  SupportedNetworksArray,
+} from '@aragon/sdk-client';
 import {useNetwork} from 'context/network';
 import React, {createContext, useContext, useEffect, useState} from 'react';
+
 import {
   CHAIN_METADATA,
   IPFS_ENDPOINT_MAIN_0,
@@ -9,7 +16,6 @@ import {
   SUBGRAPH_API_URL,
   SupportedNetworks,
 } from 'utils/constants';
-
 import {useWallet} from './useWallet';
 
 interface ClientContext {
@@ -56,7 +62,13 @@ export const UseClientProvider: React.FC = ({children}) => {
   const [context, setContext] = useState<SdkContext>();
 
   useEffect(() => {
-    if (network === 'unsupported') return;
+    const translatedNetwork =
+      network === 'ethereum' ? 'mainnet' : (network as SdkSupportedNetworks);
+
+    // when network not supported by the SDK, don't set network
+    if (!SupportedNetworksArray.includes(translatedNetwork)) {
+      return;
+    }
 
     let ipfsNodes = [
       {
@@ -84,7 +96,7 @@ export const UseClientProvider: React.FC = ({children}) => {
     }
     const contextParams: ContextParams = {
       //TODO: replace ethereum with mainnet for network
-      network: network === 'ethereum' ? 'mainnet' : network,
+      network: translatedNetwork,
       signer: signer || undefined,
       web3Providers: CHAIN_METADATA[network].rpc[0],
       ipfsNodes,

--- a/packages/web-app/src/hooks/useClient.tsx
+++ b/packages/web-app/src/hooks/useClient.tsx
@@ -40,6 +40,27 @@ const translateNetwork = (
   return 'unsupported';
 };
 
+const translateToSdkNetwork = (
+  appNetwork: SupportedNetworks
+): SdkSupportedNetworks | 'unsupported' => {
+  if (typeof appNetwork !== 'string') {
+    return 'unsupported';
+  }
+
+  switch (appNetwork) {
+    case 'polygon':
+      return 'matic';
+    case 'mumbai':
+      return 'maticmum';
+    case 'ethereum':
+      return 'mainnet';
+    case 'goerli':
+      return 'goerli';
+  }
+
+  return 'unsupported';
+};
+
 const UseClientContext = createContext<ClientContext>({} as ClientContext);
 
 export const useClient = () => {
@@ -62,8 +83,9 @@ export const UseClientProvider: React.FC = ({children}) => {
   const [context, setContext] = useState<SdkContext>();
 
   useEffect(() => {
-    const translatedNetwork =
-      network === 'ethereum' ? 'mainnet' : (network as SdkSupportedNetworks);
+    const translatedNetwork = translateToSdkNetwork(
+      network
+    ) as SdkSupportedNetworks;
 
     // when network not supported by the SDK, don't set network
     if (!SupportedNetworksArray.includes(translatedNetwork)) {

--- a/packages/web-app/src/pages/explore.tsx
+++ b/packages/web-app/src/pages/explore.tsx
@@ -1,7 +1,8 @@
 // TODO: Remove when statistics are available
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import React from 'react';
+import {SupportedNetworks, SupportedNetworksArray} from '@aragon/sdk-client';
+import React, {useEffect} from 'react';
 import 'react-responsive-carousel/lib/styles/carousel.min.css';
 import styled from 'styled-components';
 
@@ -10,9 +11,23 @@ import {GridLayout} from 'components/layout';
 import Carousel from 'containers/carousel';
 import {DaoExplorer} from 'containers/daoExplorer';
 import Hero from 'containers/hero';
+import {useNetwork} from 'context/network';
 import {i18n} from '../../i18n.config';
 
 const Explore: React.FC = () => {
+  const {network, setNetwork} = useNetwork();
+
+  useEffect(() => {
+    const translatedNetwork =
+      network === 'ethereum' ? 'mainnet' : (network as SupportedNetworks);
+
+    // when network not supported by the SDK, default to ethereum
+    if (!SupportedNetworksArray.includes(translatedNetwork)) {
+      console.warn('Unsupported network, defaulting to ethereum');
+      setNetwork('ethereum');
+    }
+  }, [network, setNetwork]);
+
   return (
     <>
       <Hero />

--- a/packages/web-app/src/pages/explore.tsx
+++ b/packages/web-app/src/pages/explore.tsx
@@ -1,7 +1,7 @@
 // TODO: Remove when statistics are available
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import React, {useEffect} from 'react';
+import React from 'react';
 import 'react-responsive-carousel/lib/styles/carousel.min.css';
 import styled from 'styled-components';
 
@@ -11,13 +11,8 @@ import Carousel from 'containers/carousel';
 import {DaoExplorer} from 'containers/daoExplorer';
 import Hero from 'containers/hero';
 import {i18n} from '../../i18n.config';
-import {useNetwork} from 'context/network';
-import {getSupportedNetworkByChainId, SupportedNetworks} from 'utils/constants';
-import {useWallet} from 'hooks/useWallet';
 
 const Explore: React.FC = () => {
-  const {setNetwork} = useNetwork();
-
   return (
     <>
       <Hero />

--- a/packages/web-app/src/pages/explore.tsx
+++ b/packages/web-app/src/pages/explore.tsx
@@ -12,12 +12,16 @@ import Carousel from 'containers/carousel';
 import {DaoExplorer} from 'containers/daoExplorer';
 import Hero from 'containers/hero';
 import {useNetwork} from 'context/network';
+import {useWallet} from 'hooks/useWallet';
+import {getSupportedNetworkByChainId} from 'utils/constants';
 import {i18n} from '../../i18n.config';
 
 const Explore: React.FC = () => {
-  const {network, setNetwork} = useNetwork();
+  const {chainId} = useWallet();
+  const {setNetwork} = useNetwork();
 
   useEffect(() => {
+    const network = getSupportedNetworkByChainId(chainId);
     const translatedNetwork =
       network === 'ethereum' ? 'mainnet' : (network as SupportedNetworks);
 
@@ -26,7 +30,7 @@ const Explore: React.FC = () => {
       console.warn('Unsupported network, defaulting to ethereum');
       setNetwork('ethereum');
     }
-  }, [network, setNetwork]);
+  }, [chainId, setNetwork]);
 
   return (
     <>


### PR DESCRIPTION
## Description

- prevents app from crashing when accessing Explore page with wallet connected to unsupported network
- defaults to Ethereum Mainnet when wallet is connected to unsupported network (Explore page)

Task: [APP-2061](https://aragonassociation.atlassian.net/browse/APP-2061)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2061]: https://aragonassociation.atlassian.net/browse/APP-2061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ