### PR TITLE
Fix: APP-2097 - Metamask not disconnecting properly

### DIFF
--- a/packages/web-app/src/context/signer.tsx
+++ b/packages/web-app/src/context/signer.tsx
@@ -144,6 +144,15 @@ export function UseSignerProvider({
     });
 
     instance.on('disconnect', (error: {code: number; message: string}) => {
+      // @DEV: see https://github.com/MetaMask/metamask-extension/issues/13375
+      // 1013 indicates that MetaMask is attempting to reestablish the connection
+      // https://github.com/MetaMask/providers/releases/tag/v8.0.0
+      if (error.code === 1013) {
+        console.warn(
+          'MetaMask logged connection error 1013: "Try again later"'
+        );
+        return;
+      }
       console.log(error);
       setAddress(null);
       setConnected(false);


### PR DESCRIPTION
## Description

- Fixes the error where sometimes switching to a network with a custom rpc causes Metamask to not disconnect properly.

Note: The issue is an ongoing one. This is a workaround that merely ignores the error as the wallet doesn't actually get disconnected. For more information, take a look at the Github [issue](https://github.com/MetaMask/metamask-extension/issues/13375)

Task: [APP-2097](https://aragonassociation.atlassian.net/browse/APP-2097)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2097]: https://aragonassociation.atlassian.net/browse/APP-2097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ