### PR TITLE
Fix: APP-2140 - DAO Creation Fails when Using Default of 1 Token

### DIFF
--- a/packages/web-app/src/context/createDao.tsx
+++ b/packages/web-app/src/context/createDao.tsx
@@ -199,7 +199,7 @@ const CreateDaoProvider: React.FC = ({children}) => {
         minParticipation: parseInt(minimumParticipation) / 100,
         supportThreshold: parseInt(minimumApproval) / 100,
         minProposerVotingPower:
-          eligibilityType === 'token'
+          eligibilityType === 'token' && eligibilityTokenAmount !== undefined
             ? parseUnits(eligibilityTokenAmount.toString(), 18).toBigInt()
             : BigInt(0),
         votingMode,

--- a/packages/web-app/src/context/createDao.tsx
+++ b/packages/web-app/src/context/createDao.tsx
@@ -203,7 +203,7 @@ const CreateDaoProvider: React.FC = ({children}) => {
             ? parseUnits(eligibilityTokenAmount.toString(), 18).toBigInt()
             : eligibilityType === 'multisig'
             ? BigInt(0)
-            : BigInt(1000000000000000000),        
+            : parseUnits('1', 18).toBigInt(),        
         votingMode,
       },
       translatedNetwork,

--- a/packages/web-app/src/context/createDao.tsx
+++ b/packages/web-app/src/context/createDao.tsx
@@ -201,7 +201,7 @@ const CreateDaoProvider: React.FC = ({children}) => {
         minProposerVotingPower:
           eligibilityType === 'token' && eligibilityTokenAmount !== undefined
             ? parseUnits(eligibilityTokenAmount.toString(), 18).toBigInt()
-            : BigInt(0),
+            : BigInt(1000000000000000000),
         votingMode,
       },
       translatedNetwork,

--- a/packages/web-app/src/context/createDao.tsx
+++ b/packages/web-app/src/context/createDao.tsx
@@ -201,7 +201,9 @@ const CreateDaoProvider: React.FC = ({children}) => {
         minProposerVotingPower:
           eligibilityType === 'token' && eligibilityTokenAmount !== undefined
             ? parseUnits(eligibilityTokenAmount.toString(), 18).toBigInt()
-            : BigInt(1000000000000000000),
+            : eligibilityType === 'multisig'
+            ? BigInt(0)
+            : BigInt(1000000000000000000),        
         votingMode,
       },
       translatedNetwork,


### PR DESCRIPTION
## Description

- This PR fixes the issue of DAO Creation failing for a Token based DAO which takes the default Token Amount of 1 Token. When doing this, the App fails to provide a Gas Estimation, so the DAO CANNOT be deployed

- Tested the fix by creating a Token base DAO with 1 token with a min. proposal threshold of 1 Token, and by voting on a signaling proposal. This succeeded, DAO can be found [here](http://localhost:3000/#/daos/goerli/barukimang9999.dao.eth/governance/proposals/0x06a38c076f8e0ecac33fe95c6b5abcda5f2d91c5_0x0)

Task: [APP-2140](https://aragonassociation.atlassian.net/browse/APP-2140)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2140]: https://aragonassociation.atlassian.net/browse/APP-2140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ