### PR TITLE
Feature: APP-2131: Add Search Methods to Transfers List

### DIFF
--- a/packages/web-app/src/pages/transfers.tsx
+++ b/packages/web-app/src/pages/transfers.tsx
@@ -40,13 +40,20 @@ const Transfers: React.FC = () => {
   const filterValidator = useCallback(
     (transfer: Transfer) => {
       let returnValue = true;
+      let matchesFilter = true;
+      let matchesSearch = true;
+
       if (filterValue !== '') {
-        returnValue = Boolean(transfer.transferType === filterValue);
+        matchesFilter = (Boolean(transfer.transferType === filterValue));
       }
+
       if (searchValue !== '') {
         const re = new RegExp(searchValue, 'i');
-        returnValue = Boolean(transfer?.title.match(re) || transfer.tokenSymbol.match(re) || transfer.tokenAmount.match(re));
+        matchesSearch = Boolean(transfer?.title.match(re) || transfer.tokenSymbol.match(re) || transfer.tokenAmount.match(re));
       }
+
+      returnValue = matchesFilter && matchesSearch;
+
       return returnValue;
     },
     [searchValue, filterValue]

--- a/packages/web-app/src/pages/transfers.tsx
+++ b/packages/web-app/src/pages/transfers.tsx
@@ -42,18 +42,14 @@ const Transfers: React.FC = () => {
       let returnValue = true;
       let matchesFilter = true;
       let matchesSearch = true;
-
       if (filterValue !== '') {
         matchesFilter = (Boolean(transfer.transferType === filterValue));
       }
-
       if (searchValue !== '') {
         const re = new RegExp(searchValue, 'i');
         matchesSearch = Boolean(transfer?.title.match(re) || transfer.tokenSymbol.match(re) || transfer.tokenAmount.match(re));
       }
-
       returnValue = matchesFilter && matchesSearch;
-
       return returnValue;
     },
     [searchValue, filterValue]

--- a/packages/web-app/src/pages/transfers.tsx
+++ b/packages/web-app/src/pages/transfers.tsx
@@ -45,7 +45,7 @@ const Transfers: React.FC = () => {
       }
       if (searchValue !== '') {
         const re = new RegExp(searchValue, 'i');
-        returnValue = Boolean(transfer?.title.match(re));
+        returnValue = Boolean(transfer?.title.match(re) || transfer.tokenSymbol.match(re) || transfer.tokenAmount.match(re));
       }
       return returnValue;
     },


### PR DESCRIPTION
## Description

In the DAO Transfers List it was only possible to search on `transfer.title`. This PR makes it possible to also search on `transfer.tokenSymbol` and `transfer.tokenAmount` for all transfers. And it fixes the search on these methods when the Transfers List has been filtered on Withdrawals or Deposits only.

Task: [APP-2131](https://aragonassociation.atlassian.net/browse/APP-2131)

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2131]: https://aragonassociation.atlassian.net/browse/APP-2131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ