### PR TITLE
Fix: APP-2183 - Polygon DAO Crashes on Resolving ENS Name

### DIFF
--- a/packages/web-app/src/containers/actionBuilder/mintTokens/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/mintTokens/index.tsx
@@ -2,7 +2,7 @@ import {ButtonText, ListItemAction} from '@aragon/ui-components';
 import Big from 'big.js';
 import {BigNumber} from 'ethers';
 import {isAddress} from 'ethers/lib/utils';
-import React, {useEffect, useState, useMemo} from 'react';
+import React, {useEffect, useState} from 'react';
 import {
   FieldError,
   useFieldArray,

--- a/packages/web-app/src/containers/selectChainForm/index.tsx
+++ b/packages/web-app/src/containers/selectChainForm/index.tsx
@@ -23,7 +23,7 @@ const SelectChainForm: React.FC = () => {
   const {t} = useTranslation();
   const {isMobile} = useScreen();
   const {setNetwork, network} = useNetwork();
-  const {control} = useFormContext();
+  const {control, resetField} = useFormContext();
 
   // const [isOpen, setIsOpen] = useState(false);
   // const [sortFilter, setFilter] = useState<SortFilter>('cost');
@@ -153,6 +153,13 @@ const SelectChainForm: React.FC = () => {
                     label: CHAIN_METADATA[selectedNetwork].name,
                     network: networkType,
                   });
+                  if (
+                    CHAIN_METADATA[selectedNetwork].name === 'Polygon' ||
+                    CHAIN_METADATA[selectedNetwork].name === 'Matic'
+                  ) {
+                    // reset daoEnsName if network changed to L2
+                    resetField('daoEnsName');
+                  }
                 }}
                 selected={CHAIN_METADATA[selectedNetwork].id === field.value.id}
                 // tag={index === 0 ? labels[sortFilter].tag : undefined}

--- a/packages/web-app/src/containers/selectChainForm/index.tsx
+++ b/packages/web-app/src/containers/selectChainForm/index.tsx
@@ -153,10 +153,7 @@ const SelectChainForm: React.FC = () => {
                     label: CHAIN_METADATA[selectedNetwork].name,
                     network: networkType,
                   });
-                  if (
-                    CHAIN_METADATA[selectedNetwork].name === 'Polygon' ||
-                    CHAIN_METADATA[selectedNetwork].name === 'Matic'
-                  ) {
+                  if (!CHAIN_METADATA[selectedNetwork].supportsEns) {
                     // reset daoEnsName if network changed to L2
                     resetField('daoEnsName');
                   }

--- a/packages/web-app/src/hooks/useDaoDetails.tsx
+++ b/packages/web-app/src/hooks/useDaoDetails.tsx
@@ -112,8 +112,12 @@ export const useDaoDetailsQuery = () => {
 
   useEffect(() => {
     if (apiResponse.isFetched) {
+      // navigate to 404 if the DAO is not found or there is some sort of error
       if (apiResponse.error || apiResponse.data === null) {
-        console.error('Failed to fetch DAO details');
+        navigate(NotFound, {
+          replace: true,
+          state: {incorrectDao: daoAddressOrEns},
+        });
       }
 
       //navigate to url with ens domain

--- a/packages/web-app/src/hooks/useDaoDetails.tsx
+++ b/packages/web-app/src/hooks/useDaoDetails.tsx
@@ -66,7 +66,7 @@ export const useDaoQuery = (
 
   const isL2NetworkEns = useMemo(
     () =>
-      (network === 'polygon' || network === 'mumbai') &&
+      !CHAIN_METADATA[network].supportsEns &&
       !isAddress(daoAddressOrEns as string),
     [daoAddressOrEns, network]
   );

--- a/packages/web-app/src/hooks/useDaoDetails.tsx
+++ b/packages/web-app/src/hooks/useDaoDetails.tsx
@@ -74,6 +74,7 @@ export const useDaoDetailsQuery = () => {
   const {dao} = useParams();
   const navigate = useNavigate();
   const location = useLocation();
+  const {network} = useNetwork();
 
   const daoAddressOrEns = dao?.toLowerCase();
   const apiResponse = useDaoQuery(daoAddressOrEns);
@@ -90,6 +91,7 @@ export const useDaoDetailsQuery = () => {
 
       //navigate to url with ens domain
       else if (
+        (network === 'ethereum' || network === 'goerli') &&
         isAddress(daoAddressOrEns as string) &&
         toDisplayEns(apiResponse.data?.ensDomain)
       ) {

--- a/packages/web-app/src/utils/constants/chains.ts
+++ b/packages/web-app/src/utils/constants/chains.ts
@@ -74,6 +74,7 @@ export type ChainData = {
   nativeCurrency: NativeTokenData;
   etherscanApi: string;
   alchemyApi: string;
+  supportsEns: boolean;
 };
 
 export type ChainList = Record<SupportedNetworks, ChainData>;
@@ -93,6 +94,7 @@ export const CHAIN_METADATA: ChainList = {
     },
     etherscanApi: 'https://api.arbiscan.io/api',
     alchemyApi: 'https://arb-mainnet.g.alchemy.com/v2',
+    supportsEns: false,
   },
   ethereum: {
     id: 1,
@@ -112,6 +114,7 @@ export const CHAIN_METADATA: ChainList = {
     },
     etherscanApi: 'https://api.etherscan.io/api',
     alchemyApi: 'https://eth-mainnet.g.alchemy.com/v2',
+    supportsEns: true,
   },
   polygon: {
     id: 137,
@@ -131,6 +134,7 @@ export const CHAIN_METADATA: ChainList = {
     },
     etherscanApi: 'https://api.polygonscan.com/api',
     alchemyApi: 'https://polygon-mainnet.g.alchemy.com/v2',
+    supportsEns: false,
   },
   'arbitrum-test': {
     id: 421613,
@@ -147,6 +151,7 @@ export const CHAIN_METADATA: ChainList = {
     },
     etherscanApi: 'https://api-goerli.arbiscan.io/api',
     alchemyApi: 'https://arb-goerli.g.alchemy.com/v2',
+    supportsEns: false,
   },
   goerli: {
     id: 5,
@@ -166,6 +171,7 @@ export const CHAIN_METADATA: ChainList = {
     },
     etherscanApi: 'https://api-goerli.etherscan.io/api',
     alchemyApi: 'https://eth-goerli.g.alchemy.com/v2',
+    supportsEns: true,
   },
   mumbai: {
     id: 80001,
@@ -185,6 +191,7 @@ export const CHAIN_METADATA: ChainList = {
     },
     etherscanApi: 'https://api-testnet.polygonscan.com/api',
     alchemyApi: 'https://polygon-mumbai.g.alchemy.com/v2',
+    supportsEns: false,
   },
   unsupported: {
     id: 1,
@@ -201,5 +208,6 @@ export const CHAIN_METADATA: ChainList = {
     },
     etherscanApi: '',
     alchemyApi: '',
+    supportsEns: false,
   },
 };


### PR DESCRIPTION
## Description

@sepehr2github with this fix it is possible to open DAOs on Polygon and Mumbai which do have an ENS Domain (whether created from the SDK or from the App somehow). This Polygon DAO with ENS Domain can open e.g.: [click here](http://localhost:3000/#/daos/polygon/0x3782242c028028acb9282b9c88b28810364e66fd/dashboard)

This is by no means a comprehensive fix yet, since many other pages apart from the Dashboard make use of the `toDisplayEns()` function, but a first attempt :) Feel free to take it from here.

- add Ens resolver for L2 daos that could register their ens name
- fix the bug that users could register L2 ens names in dao creation

Task: [APP-2138](https://aragonassociation.atlassian.net/browse/APP-2183)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2138]: https://aragonassociation.atlassian.net/browse/APP-2138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ