### PR TITLE
Fix: APP-2176 Multisig proposals should default creation time to now

### DIFF
--- a/packages/web-app/src/containers/dateTimeSelector/index.tsx
+++ b/packages/web-app/src/containers/dateTimeSelector/index.tsx
@@ -117,7 +117,7 @@ const DateTimeSelector: React.FC<Props> = ({
       setTimeout(() => {
         // automatically correct the start date to now
         setValue('startDate', getCanonicalDate());
-        setValue('startTime', getCanonicalTime({minutes: 10}));
+        setValue('startTime', getCanonicalTime({minutes}));
         setValue('startUtc', currTimezone);
       }, CORRECTION_DELAY);
 
@@ -170,6 +170,7 @@ const DateTimeSelector: React.FC<Props> = ({
     maxDurationMills,
     minDurationAlert,
     minDurationMills,
+    minutes,
     setValue,
     t,
   ]);

--- a/packages/web-app/src/containers/reviewProposal/index.tsx
+++ b/packages/web-app/src/containers/reviewProposal/index.tsx
@@ -105,6 +105,9 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
     )} ${getFormattedUtcOffset()}`;
   }, [daoSettings, startDate, t, values]);
 
+  /**
+   * This is the primary (approximate) end date display which is rendered in Voting Terminal
+   */
   const formattedEndDate = useMemo(() => {
     const {
       durationDays,
@@ -134,12 +137,18 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
 
     const locale = (Locales as Record<string, Locale>)[i18n.language];
 
-    return formatDistanceToNow(endDateTime, {
+    const resultDate = formatDistanceToNow(endDateTime, {
       includeSeconds: true,
       locale,
     });
-  }, [i18n.language, values]);
 
+    return `${t('votingTerminal.label.in')} ${resultDate}`;
+  }, [i18n.language, t, values]);
+
+  /**
+   * This is the secondary, supplementary (precisely clear) end date display which is rendered in Voting Terminal
+   * UNDER primary end date.
+   */
   const formattedPreciseEndDate = useMemo(() => {
     let endDateTime: Date;
     const {

--- a/packages/web-app/src/containers/reviewProposal/index.tsx
+++ b/packages/web-app/src/containers/reviewProposal/index.tsx
@@ -77,10 +77,12 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
 
   const startDate = useMemo(() => {
     const {startSwitch, startDate, startTime, startUtc} = values;
+
     if (startSwitch === 'now') {
+      const startMinutesDelay = isMultisigVotingSettings(daoSettings) ? 0 : 10;
       return new Date(
         `${getCanonicalDate()}T${getCanonicalTime({
-          minutes: 10,
+          minutes: startMinutesDelay,
         })}:00${getCanonicalUtcOffset()}`
       );
     } else {
@@ -88,7 +90,7 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
         `${startDate}T${startTime}:00${getCanonicalUtcOffset(startUtc)}`
       );
     }
-  }, [values]);
+  }, [daoSettings, values]);
 
   const formattedStartDate = useMemo(
     () =>
@@ -129,14 +131,17 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
 
     // adding 10 minutes to offset the 10 minutes added by starting now
     if (startSwitch === 'now') {
-      endDateTime = new Date(endDateTime.getTime() + minutesToMills(10));
+      const startMinutesDelay = isMultisigVotingSettings(daoSettings) ? 0 : 10;
+      endDateTime = new Date(
+        endDateTime.getTime() + minutesToMills(startMinutesDelay)
+      );
     }
 
     return `${format(
       endDateTime,
       KNOWN_FORMATS.proposals
     )} ${getFormattedUtcOffset()}`;
-  }, [values]);
+  }, [daoSettings, values]);
 
   const terminalProps = useMemo(
     () =>

--- a/packages/web-app/src/containers/votingTerminal/index.tsx
+++ b/packages/web-app/src/containers/votingTerminal/index.tsx
@@ -39,6 +39,7 @@ export type VotingTerminalProps = {
   voteNowDisabled?: boolean;
   startDate?: string;
   endDate?: string;
+  preciseEndDate?: string;
   minApproval?: number;
   minParticipation?: string;
   currentParticipation?: string;
@@ -80,6 +81,7 @@ export const VotingTerminal: React.FC<VotingTerminalProps> = ({
   token,
   startDate,
   endDate,
+  preciseEndDate,
   status,
   statusLabel,
   strategy,
@@ -193,6 +195,7 @@ export const VotingTerminal: React.FC<VotingTerminalProps> = ({
           currentParticipation={currentParticipation}
           currentApprovals={approvals?.length}
           endDate={endDate}
+          preciseEndDate={preciseEndDate}
           memberCount={voters.length}
           minApproval={minApproval}
           minimumReached={minimumReached}

--- a/packages/web-app/src/containers/votingTerminal/infoTab.tsx
+++ b/packages/web-app/src/containers/votingTerminal/infoTab.tsx
@@ -19,6 +19,7 @@ type Props = Pick<
   | 'missingParticipation'
   | 'startDate'
   | 'endDate'
+  | 'preciseEndDate'
   | 'status'
 > & {
   currentApprovals?: number;
@@ -28,7 +29,6 @@ type Props = Pick<
   missingApprovalOrParticipation: number;
   uniqueVoters?: number;
   voteOptions: string;
-  preciseEndDate?: string;
 };
 
 const InfoTab: React.FC<Props> = ({
@@ -173,9 +173,7 @@ const InfoTab: React.FC<Props> = ({
         <InfoLine>
           <p>{t('votingTerminal.endDate')}</p>
           <EndDateWrapper>
-            <Strong>
-              {t('votingTerminal.label.in')} {endDate}
-            </Strong>
+            <Strong>{endDate}</Strong>
             {preciseEndDate && (
               <div className="flex gap-x-1 justify-end">
                 <p className="text-right text-ui-400 ft-text-sm">

--- a/packages/web-app/src/containers/votingTerminal/infoTab.tsx
+++ b/packages/web-app/src/containers/votingTerminal/infoTab.tsx
@@ -28,6 +28,7 @@ type Props = Pick<
   missingApprovalOrParticipation: number;
   uniqueVoters?: number;
   voteOptions: string;
+  preciseEndDate?: string;
 };
 
 const InfoTab: React.FC<Props> = ({
@@ -45,6 +46,7 @@ const InfoTab: React.FC<Props> = ({
   strategy,
   supportThreshold,
   uniqueVoters,
+  preciseEndDate,
 }) => {
   const {t} = useTranslation();
 
@@ -170,7 +172,16 @@ const InfoTab: React.FC<Props> = ({
         </InfoLine>
         <InfoLine>
           <p>{t('votingTerminal.endDate')}</p>
-          <Strong>{endDate}</Strong>
+          <EndDateWrapper>
+            <Strong>{endDate}</Strong>
+            {preciseEndDate && (
+              <div className="flex gap-x-1 justify-end">
+                <p className="text-right text-ui-400 ft-text-sm">
+                  {preciseEndDate}
+                </p>
+              </div>
+            )}
+          </EndDateWrapper>
         </InfoLine>
       </VStackSection>
     </>
@@ -178,6 +189,10 @@ const InfoTab: React.FC<Props> = ({
 };
 
 export default InfoTab;
+
+const EndDateWrapper = styled.div.attrs({
+  className: 'space-y-0.5 text-right',
+})``;
 
 const CurrentParticipationWrapper = styled.div.attrs({
   className: 'space-y-0.5 text-right',

--- a/packages/web-app/src/containers/votingTerminal/infoTab.tsx
+++ b/packages/web-app/src/containers/votingTerminal/infoTab.tsx
@@ -173,7 +173,9 @@ const InfoTab: React.FC<Props> = ({
         <InfoLine>
           <p>{t('votingTerminal.endDate')}</p>
           <EndDateWrapper>
-            <Strong>{endDate}</Strong>
+            <Strong>
+              {t('votingTerminal.label.in')} {endDate}
+            </Strong>
             {preciseEndDate && (
               <div className="flex gap-x-1 justify-end">
                 <p className="text-right text-ui-400 ft-text-sm">

--- a/packages/web-app/src/context/createProposal.tsx
+++ b/packages/web-app/src/context/createProposal.tsx
@@ -274,16 +274,22 @@ const CreateProposalProvider: React.FC<Props> = ({
       const ipfsUri = await pluginClient?.methods.pinMetadata(metadata);
 
       // getting dates
-      let startDateTime =
-        startSwitch === 'now'
-          ? new Date(
-              `${getCanonicalDate()}T${getCanonicalTime({
-                minutes: 10,
-              })}:00${getCanonicalUtcOffset()}`
-            )
-          : new Date(
-              `${startDate}T${startTime}:00${getCanonicalUtcOffset(startUtc)}`
-            );
+      let startDateTime: Date;
+      const startMinutesDelay = isMultisigVotingSettings(pluginSettings)
+        ? 0
+        : 10;
+
+      if (startSwitch === 'now') {
+        startDateTime = new Date(
+          `${getCanonicalDate()}T${getCanonicalTime({
+            minutes: startMinutesDelay,
+          })}:00${getCanonicalUtcOffset()}`
+        );
+      } else {
+        startDateTime = new Date(
+          `${startDate}T${startTime}:00${getCanonicalUtcOffset(startUtc)}`
+        );
+      }
 
       // End date
       let endDateTime;
@@ -306,12 +312,14 @@ const CreateProposalProvider: React.FC<Props> = ({
       }
 
       if (startSwitch === 'now') {
-        endDateTime = new Date(endDateTime.getTime() + minutesToMills(10));
+        endDateTime = new Date(
+          endDateTime.getTime() + minutesToMills(startMinutesDelay)
+        );
       } else {
         if (startDateTime.valueOf() < new Date().valueOf()) {
           startDateTime = new Date(
             `${getCanonicalDate()}T${getCanonicalTime({
-              minutes: 10,
+              minutes: startMinutesDelay,
             })}:00${getCanonicalUtcOffset()}`
           );
         }
@@ -350,6 +358,7 @@ const CreateProposalProvider: React.FC<Props> = ({
       minMinutes,
       pluginAddress,
       pluginClient?.methods,
+      pluginSettings,
     ]);
 
   const estimateCreationFees = useCallback(async () => {

--- a/packages/web-app/src/context/createProposal.tsx
+++ b/packages/web-app/src/context/createProposal.tsx
@@ -342,11 +342,22 @@ const CreateProposalProvider: React.FC<Props> = ({
         }
       }
 
+      /**
+       * For multisig proposals, in case "now" as start time is selected, we want
+       * to keep startDate undefined, so it's automatically evaluated.
+       * If we just provide "Date.now()", than after user still goes through the flow
+       * it's going to be date from the past. And SC-call evaluation will fail.
+       */
+      const finalStartDate =
+        startSwitch === 'now' && isMultisigVotingSettings(pluginSettings)
+          ? undefined
+          : startDateTime;
+
       // Ignore encoding if the proposal had no actions
       return {
         pluginAddress,
         metadataUri: ipfsUri || '',
-        startDate: startDateTime,
+        startDate: finalStartDate,
         endDate: endDateTime,
         actions,
       };

--- a/packages/web-app/src/locales/en/common.json
+++ b/packages/web-app/src/locales/en/common.json
@@ -805,6 +805,9 @@
       "titleSearch": "No result found for {{query}}",
       "title": "No voters yet",
       "subtitle": "Search for another wallet address or ENS"
+    },
+    "label": {
+      "in": "In"
     }
   },
   "explore": {

--- a/packages/web-app/src/pages/proposeSettings.tsx
+++ b/packages/web-app/src/pages/proposeSettings.tsx
@@ -515,11 +515,23 @@ const ProposeSettingWrapper: React.FC<Props> = ({
             endDateTime = new Date(endMills);
           }
         }
+
+        /**
+         * For multisig proposals, in case "now" as start time is selected, we want
+         * to keep startDate undefined, so it's automatically evaluated.
+         * If we just provide "Date.now()", than after user still goes through the flow
+         * it's going to be date from the past. And SC-call evaluation will fail.
+         */
+        const finalStartDate =
+          startSwitch === 'now' && isMultisigVotingSettings(pluginSettings)
+            ? undefined
+            : startDateTime;
+
         // Ignore encoding if the proposal had no actions
         return {
           pluginAddress,
           metadataUri: ipfsUri || '',
-          startDate: startDateTime,
+          startDate: finalStartDate,
           endDate: endDateTime,
           actions,
         };

--- a/packages/web-app/src/pages/proposeSettings.tsx
+++ b/packages/web-app/src/pages/proposeSettings.tsx
@@ -448,16 +448,22 @@ const ProposeSettingWrapper: React.FC<Props> = ({
         const ipfsUri = await pluginClient?.methods.pinMetadata(metadata);
 
         // getting dates
-        let startDateTime =
-          startSwitch === 'now'
-            ? new Date(
-                `${getCanonicalDate()}T${getCanonicalTime({
-                  minutes: 10,
-                })}:00${getCanonicalUtcOffset()}`
-              )
-            : new Date(
-                `${startDate}T${startTime}:00${getCanonicalUtcOffset(startUtc)}`
-              );
+        let startDateTime: Date;
+        const startMinutesDelay = isMultisigVotingSettings(pluginSettings)
+          ? 0
+          : 10;
+
+        if (startSwitch === 'now') {
+          startDateTime = new Date(
+            `${getCanonicalDate()}T${getCanonicalTime({
+              minutes: startMinutesDelay,
+            })}:00${getCanonicalUtcOffset()}`
+          );
+        } else {
+          startDateTime = new Date(
+            `${startDate}T${startTime}:00${getCanonicalUtcOffset(startUtc)}`
+          );
+        }
 
         // End date
         let endDateTime;
@@ -480,12 +486,14 @@ const ProposeSettingWrapper: React.FC<Props> = ({
         }
 
         if (startSwitch === 'now') {
-          endDateTime = new Date(endDateTime.getTime() + minutesToMills(10));
+          endDateTime = new Date(
+            endDateTime.getTime() + minutesToMills(startMinutesDelay)
+          );
         } else {
           if (startDateTime.valueOf() < new Date().valueOf()) {
             startDateTime = new Date(
               `${getCanonicalDate()}T${getCanonicalTime({
-                minutes: 10,
+                minutes: startMinutesDelay,
               })}:00${getCanonicalUtcOffset()}`
             );
           }
@@ -535,6 +543,7 @@ const ProposeSettingWrapper: React.FC<Props> = ({
     minMinutes,
     pluginAddress,
     pluginClient,
+    pluginSettings,
     showTxModal,
   ]);
 


### PR DESCRIPTION
## Description

Multisig wallets are used for speed and performance, not for “voting” (they don’t even vote, but approve tx). It’s understandable we start ERC20Voting proposals +10 minutes after proposal creation, but that shouldn’t happen for multisig proposals where default starting time should be 0 (which is used by the protocol as “now”).

Task: [APP-2176](https://aragonassociation.atlassian.net/jira/software/c/projects/APP/boards/40?modal=detail&selectedIssue=APP-2176&assignee=712020%3A6ea8272e-a7c7-4fcc-8652-afd007bf3dba)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2176]: https://aragonassociation.atlassian.net/browse/APP-2176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ