### PR TITLE
Fix: APP-2222 SCC (Mobile Device) - Input Fields for Long Function Names do NOT Display well

### DIFF
--- a/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
@@ -390,11 +390,8 @@ export const ComponentForTypeWithFormProvider: React.FC<
 };
 
 const ActionName = styled.p.attrs({
-  className: 'text-lg font-bold text-ui-800 capitalize',
-})`
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
+  className: 'text-lg font-bold text-ui-800 capitalize truncate',
+})``;
 
 const ActionDescription = styled.p.attrs({
   className: 'mt-1 text-sm text-ui-600',

--- a/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
@@ -393,6 +393,7 @@ const ActionName = styled.p.attrs({
   className: 'text-lg font-bold text-ui-800 capitalize',
 })`
   overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const ActionDescription = styled.p.attrs({

--- a/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
@@ -168,14 +168,14 @@ const InputForm: React.FC<InputFormProps> = ({
 
   if (!selectedAction) {
     return (
-      <div className="desktop:p-6 min-h-full desktop:bg-white bg-ui-50">
+      <div className="desktop:p-6 min-h-full bg-ui-50 desktop:bg-white">
         Sorry, no public Write functions were found for this contract.
       </div>
     );
   }
 
   return (
-    <div className="desktop:p-6 min-h-full desktop:bg-white bg-ui-50">
+    <div className="desktop:p-6 min-h-full bg-ui-50 desktop:bg-white">
       <div className="desktop:flex items-baseline space-x-3">
         <ActionName>{selectedAction.name}</ActionName>
         <div className="hidden desktop:flex items-center space-x-1 text-primary-600">
@@ -191,10 +191,10 @@ const InputForm: React.FC<InputFormProps> = ({
         <IconSuccess />
       </div>
       {actionInputs.length > 0 ? (
-        <div className="p-3 mt-5 space-y-2 bg-white rounded-xl border desktop:bg-ui-50 border-ui-100 shadow-100">
+        <div className="p-3 mt-5 space-y-2 bg-white desktop:bg-ui-50 rounded-xl border border-ui-100 shadow-100">
           {actionInputs.map(input => (
             <div key={input.name}>
-              <div className="text-base font-bold capitalize text-ui-800">
+              <div className="text-base font-bold text-ui-800 capitalize">
                 {input.name}
                 <span className="ml-0.5 text-sm normal-case">
                   ({input.type})
@@ -331,7 +331,7 @@ export const ComponentForType: React.FC<ComponentForTypeProps> = ({
         <>
           {input.components?.map(component => (
             <div key={component.name}>
-              <div className="mb-1.5 text-base font-bold capitalize text-ui-800">
+              <div className="mb-1.5 text-base font-bold text-ui-800 capitalize">
                 {input.name}
               </div>
               <ComponentForType

--- a/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
@@ -168,14 +168,14 @@ const InputForm: React.FC<InputFormProps> = ({
 
   if (!selectedAction) {
     return (
-      <div className="desktop:p-6 min-h-full bg-ui-50 desktop:bg-white">
+      <div className="desktop:p-6 min-h-full desktop:bg-white bg-ui-50">
         Sorry, no public Write functions were found for this contract.
       </div>
     );
   }
 
   return (
-    <div className="desktop:p-6 min-h-full bg-ui-50 desktop:bg-white">
+    <div className="desktop:p-6 min-h-full desktop:bg-white bg-ui-50">
       <div className="desktop:flex items-baseline space-x-3">
         <ActionName>{selectedAction.name}</ActionName>
         <div className="hidden desktop:flex items-center space-x-1 text-primary-600">
@@ -191,10 +191,10 @@ const InputForm: React.FC<InputFormProps> = ({
         <IconSuccess />
       </div>
       {actionInputs.length > 0 ? (
-        <div className="p-3 mt-5 space-y-2 bg-white desktop:bg-ui-50 rounded-xl border border-ui-100 shadow-100">
+        <div className="p-3 mt-5 space-y-2 bg-white rounded-xl border desktop:bg-ui-50 border-ui-100 shadow-100">
           {actionInputs.map(input => (
             <div key={input.name}>
-              <div className="text-base font-bold text-ui-800 capitalize">
+              <div className="text-base font-bold capitalize text-ui-800">
                 {input.name}
                 <span className="ml-0.5 text-sm normal-case">
                   ({input.type})
@@ -331,7 +331,7 @@ export const ComponentForType: React.FC<ComponentForTypeProps> = ({
         <>
           {input.components?.map(component => (
             <div key={component.name}>
-              <div className="mb-1.5 text-base font-bold text-ui-800 capitalize">
+              <div className="mb-1.5 text-base font-bold capitalize text-ui-800">
                 {input.name}
               </div>
               <ComponentForType
@@ -391,7 +391,9 @@ export const ComponentForTypeWithFormProvider: React.FC<
 
 const ActionName = styled.p.attrs({
   className: 'text-lg font-bold text-ui-800 capitalize',
-})``;
+})`
+  overflow: hidden;
+`;
 
 const ActionDescription = styled.p.attrs({
   className: 'mt-1 text-sm text-ui-600',


### PR DESCRIPTION
## Description

Made long function names look pretty 👗 

Task: [APP-2222](https://aragonassociation.atlassian.net/browse/APP-2222)

<img width="1634" alt="image" src="https://github.com/aragon/app/assets/16764792/3bb7441c-023d-45ef-a282-dc41eb418bd0">

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2222]: https://aragonassociation.atlassian.net/browse/APP-2222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ