### PR TITLE
Feature APP-2216 Natspec inheritance, show natspec on params

### DIFF
--- a/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
@@ -397,10 +397,6 @@ const ActionDescription = styled.p.attrs({
   className: 'mt-1 text-sm text-ui-600',
 })``;
 
-const ParamDescription = styled.p.attrs({
-  className: 'mt-1 text-sm text-ui-600',
-})``;
-
 const HStack = styled.div.attrs({
   className: 'flex justify-between items-center space-x-3 mt-5 ft-text-base',
 })``;

--- a/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
@@ -397,6 +397,10 @@ const ActionDescription = styled.p.attrs({
   className: 'mt-1 text-sm text-ui-600',
 })``;
 
+const ParamDescription = styled.p.attrs({
+  className: 'mt-1 text-sm text-ui-600',
+})``;
+
 const HStack = styled.div.attrs({
   className: 'flex justify-between items-center space-x-3 mt-5 ft-text-base',
 })``;

--- a/packages/web-app/src/containers/smartContractComposer/components/listHeaderContract.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/components/listHeaderContract.tsx
@@ -9,8 +9,10 @@ import {
   ListItemActionProps,
 } from '@aragon/ui-components';
 import {useAlertContext} from 'context/alert';
+import {useNetwork} from 'context/network';
 import {t} from 'i18next';
 import React from 'react';
+import {chainExplorerAddressLink} from 'utils/constants/chains';
 import {handleClipboardActions} from 'utils/library';
 import {SmartContract} from 'utils/types';
 
@@ -25,6 +27,7 @@ export const ListHeaderContract: React.FC<Props> = ({
   ...rest
 }) => {
   const {alert} = useAlertContext();
+  const {network} = useNetwork();
 
   const iconRight = (
     <Dropdown
@@ -44,7 +47,7 @@ export const ListHeaderContract: React.FC<Props> = ({
               iconRight={
                 <IconFeedback height={13} width={13} className="ml-4" />
               }
-              href={`https://etherscan.io/address/${sc.address}#code`}
+              href={chainExplorerAddressLink(network, sc.address) + '#code'}
               label={t('scc.detailContract.dropdownExplorerLinkLabel', {
                 address: sc.address,
               })}

--- a/packages/web-app/src/utils/__tests__/contract.test.ts
+++ b/packages/web-app/src/utils/__tests__/contract.test.ts
@@ -96,6 +96,37 @@ describe('Natspec Block', () => {
       notice: 'abc\n- def',
     });
   });
+
+  test('interfaces and abstract', () => {
+    const source = `
+      abstract contract Parent {
+        /// @notice x
+        function x() public virtual;
+      }
+
+      interface InheritFrom {
+        /// @notice z
+        function z() public {
+        }
+      }
+
+      /// @notice Child
+      contract Child is Parent {
+        /// @notice y
+        function y() public {
+        }
+
+        /// @inheritdoc InheritFrom
+        function z() public {
+        }
+      }
+    `;
+    const natspec = extractNatSpec(source);
+    const collapsed = collapseNatspec(natspec, 'Child');
+    expect(collapsed.details.x.tags.notice).toStrictEqual('x');
+    expect(collapsed.details.y.tags.notice).toStrictEqual('y');
+    expect(collapsed.details.z.tags.notice).toStrictEqual('z');
+  });
   test('collapseNatspec', () => {
     const source = `
       /// @notice SuperParent

--- a/packages/web-app/src/utils/__tests__/contract.test.ts
+++ b/packages/web-app/src/utils/__tests__/contract.test.ts
@@ -1,0 +1,741 @@
+import {NatspecDetails, extractNatSpec, scanNatspecBlock} from 'utils/contract';
+
+describe('Natspec Block', () => {
+  test('empty', () => {
+    const source = `
+            ///
+        `;
+    let pos = 0;
+    let block: NatspecDetails = {keyword: '', name: '', tags: {}};
+    [pos, block] = scanNatspecBlock(source, pos, '');
+    expect(block.tags).toStrictEqual({});
+  });
+  test('empty multiline', () => {
+    const source = `
+            /** */
+        `;
+    let pos = 0;
+    let block: NatspecDetails = {keyword: '', name: '', tags: {}};
+    [pos, block] = scanNatspecBlock(source, pos, '*/');
+    expect(block.tags).toStrictEqual({});
+  });
+  test('simple', () => {
+    const source = `
+            /// @notice abc
+        `;
+    let pos = 0;
+    let block: NatspecDetails = {keyword: '', name: '', tags: {}};
+    [pos, block] = scanNatspecBlock(source, pos, '');
+    expect(block.tags).toStrictEqual({notice: 'abc'});
+  });
+  test('simple multiline', () => {
+    const source = `
+             * @notice abc
+             */
+        `;
+    let pos = 0;
+    let block: NatspecDetails = {keyword: '', name: '', tags: {}};
+    [pos, block] = scanNatspecBlock(source, pos, '*/');
+    expect(block.tags).toStrictEqual({notice: 'abc'});
+  });
+  test('multi singleline', () => {
+    const source = `
+            /// @notice abc
+            /// @dev note for dev
+        `;
+    let pos = 0;
+    let block: NatspecDetails = {keyword: '', name: '', tags: {}};
+    [pos, block] = scanNatspecBlock(source, pos, '');
+    expect(block.tags).toStrictEqual({
+      notice: 'abc',
+      dev: 'note for dev',
+    });
+  });
+  test('params', () => {
+    const source = `
+            /**
+             * @param p1 comment for p1
+             * @param p2 comment for p2
+             */
+        `;
+    let pos = 0;
+    let block: NatspecDetails = {keyword: '', name: '', tags: {}};
+    [pos, block] = scanNatspecBlock(source, pos, '*/');
+    expect(block.tags).toStrictEqual({
+      param: {p1: 'comment for p1', p2: 'comment for p2'},
+    });
+  });
+  test('runover', () => {
+    const source = `
+            /// @notice abc
+            /// - def
+        `;
+    let pos = 0;
+    let block: NatspecDetails = {keyword: '', name: '', tags: {}};
+    [pos, block] = scanNatspecBlock(source, pos, '');
+    expect(block.tags).toStrictEqual({
+      notice: 'abc\n- def',
+    });
+  });
+  test('runover multiline', () => {
+    const source = `
+            /**
+            * @notice abc
+            - def
+            */
+        `;
+    let pos = 0;
+    let block: NatspecDetails = {keyword: '', name: '', tags: {}};
+    [pos, block] = scanNatspecBlock(source, pos, '*/');
+    expect(block.tags).toStrictEqual({
+      notice: 'abc\n- def',
+    });
+  });
+});
+
+describe('Extract Natspec', () => {
+  test('easy /**/', () => {
+    const source = `
+    /**
+     * @title MyContractTitle
+     * @author John Doe
+     */
+    contract MyContract {
+      /**
+       * @notice Increments the counter
+       * @dev Only for demonstration purposes
+       */
+      function increment() public {
+        // ...
+      }
+    }
+    `;
+    const natspec = extractNatSpec(source);
+    expect(natspec['MyContract'].tags['title']).toBe('MyContractTitle');
+    expect(natspec['MyContract'].details['increment'].tags['notice']).toBe(
+      'Increments the counter'
+    );
+  });
+  test('easy ///', () => {
+    const source = `
+    /// @title MyContractTitle
+    /// @author John Doe
+    contract MyContract {
+      /// @notice Increments the counter
+      /// @dev Only for demonstration purposes
+      function increment() public {
+        // ...
+      }
+    }
+    `;
+    const natspec = extractNatSpec(source);
+    expect(natspec['MyContract'].tags['title']).toBe('MyContractTitle');
+    expect(natspec['MyContract'].details['increment'].tags['notice']).toBe(
+      'Increments the counter'
+    );
+  });
+  test('big', () => {
+    const source = `
+    // SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity 0.8.17;
+
+import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165StorageUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721ReceiverUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC1155/IERC1155Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC1155/IERC1155ReceiverUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
+import "@openzeppelin/contracts/interfaces/IERC1271.sol";
+
+import {PermissionManager} from "../permission/PermissionManager.sol";
+import {CallbackHandler} from "../utils/CallbackHandler.sol";
+import {hasBit, flipBit} from "../utils/BitMap.sol";
+import {IEIP4824} from "./IEIP4824.sol";
+import {IDAO} from "./IDAO.sol";
+
+/// @title DAO
+/// @author Aragon Association - 2021-2023
+/// @notice This contract is the entry point to the Aragon DAO framework and provides our users a simple and easy to use public interface.
+/// @dev Public API of the Aragon DAO framework.
+contract DAO is
+    IEIP4824,
+    Initializable,
+    IERC1271,
+    ERC165StorageUpgradeable,
+    IDAO,
+    UUPSUpgradeable,
+    PermissionManager,
+    CallbackHandler
+{
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using AddressUpgradeable for address;'
+    /// @notice The ID of the permission required to call the 'execute' function.
+    bytes32 public constant EXECUTE_PERMISSION_ID = keccak256("EXECUTE_PERMISSION");
+
+    /// @notice The ID of the permission required to call the '_authorizeUpgrade' function.
+    bytes32 public constant UPGRADE_DAO_PERMISSION_ID = keccak256("UPGRADE_DAO_PERMISSION");
+
+    /// @notice The ID of the permission required to call the 'setMetadata' function.
+    bytes32 public constant SET_METADATA_PERMISSION_ID = keccak256("SET_METADATA_PERMISSION");
+
+    /// @notice The ID of the permission required to call the 'setTrustedForwarder' function.
+    bytes32 public constant SET_TRUSTED_FORWARDER_PERMISSION_ID =
+        keccak256("SET_TRUSTED_FORWARDER_PERMISSION");
+
+    /// @notice The ID of the permission required to call the 'setSignatureValidator' function.
+    bytes32 public constant SET_SIGNATURE_VALIDATOR_PERMISSION_ID =
+        keccak256("SET_SIGNATURE_VALIDATOR_PERMISSION");
+
+    /// @notice The ID of the permission required to call the 'registerStandardCallback' function.
+    bytes32 public constant REGISTER_STANDARD_CALLBACK_PERMISSION_ID =
+        keccak256("REGISTER_STANDARD_CALLBACK_PERMISSION");
+
+    /// @notice The internal constant storing the maximal action array length.
+    uint256 internal constant MAX_ACTIONS = 256;
+
+    /// @notice The [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) signature validator contract.
+    IERC1271 public signatureValidator;
+
+    /// @notice The address of the trusted forwarder verifying meta transactions.
+    address private trustedForwarder;
+
+    /// @notice The [EIP-4824](https://eips.ethereum.org/EIPS/eip-4824) DAO uri.
+    string private _daoURI;
+
+    /// @notice Thrown if the action array length is larger than 'MAX_ACTIONS'.
+    error TooManyActions();
+
+    /// @notice Thrown if action execution has failed.
+    /// @param index The index of the action in the action array that failed.
+    error ActionFailed(uint256 index);
+
+    /// @notice Thrown if an action has insufficent gas left.
+    error InsufficientGas();
+
+    /// @notice Thrown if the deposit amount is zero.
+    error ZeroAmount();
+
+    /// @notice Thrown if there is a mismatch between the expected and actually deposited amount of native tokens.
+    /// @param expected The expected native token amount.
+    /// @param actual The actual native token amount deposited.
+    error NativeTokenDepositAmountMismatch(uint256 expected, uint256 actual);
+
+    /// @notice Emitted when a new DAO uri is set.
+    /// @param daoURI The new uri.
+    event NewURI(string daoURI);
+
+    /// @notice Disables the initializers on the implementation contract to prevent it from being left uninitialized.
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initializes the DAO by
+    /// - registering the [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface ID
+    /// - setting the trusted forwarder for meta transactions
+    /// - giving the 'ROOT_PERMISSION_ID' permission to the initial owner (that should be revoked and transferred to the DAO after setup).
+    /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
+    /// @param _metadata IPFS hash that points to all the metadata (logo, description, tags, etc.) of a DAO.
+    /// @param _initialOwner The initial owner of the DAO having the 'ROOT_PERMISSION_ID' permission.
+    /// @param _trustedForwarder The trusted forwarder responsible for verifying meta transactions.
+    function initialize(
+        bytes calldata _metadata,
+        address _initialOwner,
+        address _trustedForwarder,
+        string calldata daoURI_
+    ) external initializer {
+        _registerInterface(type(IDAO).interfaceId);
+        _registerInterface(type(IERC1271).interfaceId);
+        _registerInterface(type(IEIP4824).interfaceId);
+        _registerTokenInterfaces();
+
+        _setMetadata(_metadata);
+        _setTrustedForwarder(_trustedForwarder);
+        _setDaoURI(daoURI_);
+        __PermissionManager_init(_initialOwner);
+    }
+
+    /// @inheritdoc PermissionManager
+    function isPermissionRestrictedForAnyAddr(
+        bytes32 _permissionId
+    ) internal pure override returns (bool) {
+        return
+            _permissionId == EXECUTE_PERMISSION_ID ||
+            _permissionId == UPGRADE_DAO_PERMISSION_ID ||
+            _permissionId == SET_METADATA_PERMISSION_ID ||
+            _permissionId == SET_TRUSTED_FORWARDER_PERMISSION_ID ||
+            _permissionId == SET_SIGNATURE_VALIDATOR_PERMISSION_ID ||
+            _permissionId == REGISTER_STANDARD_CALLBACK_PERMISSION_ID;
+    }
+
+    /// @notice Internal method authorizing the upgrade of the contract via the [upgradeabilty mechanism for UUPS proxies](https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable) (see [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822)).
+    /// @dev The caller must have the 'UPGRADE_DAO_PERMISSION_ID' permission.
+    function _authorizeUpgrade(address) internal virtual override auth(UPGRADE_DAO_PERMISSION_ID) {}
+
+    /// @inheritdoc IDAO
+    function setTrustedForwarder(
+        address _newTrustedForwarder
+    ) external override auth(SET_TRUSTED_FORWARDER_PERMISSION_ID) {
+        _setTrustedForwarder(_newTrustedForwarder);
+    }
+
+    /// @inheritdoc IDAO
+    function getTrustedForwarder() external view virtual override returns (address) {
+        return trustedForwarder;
+    }
+
+    /// @inheritdoc IDAO
+    function hasPermission(
+        address _where,
+        address _who,
+        bytes32 _permissionId,
+        bytes memory _data
+    ) external view override returns (bool) {
+        return isGranted(_where, _who, _permissionId, _data);
+    }
+
+    /// @inheritdoc IDAO
+    function setMetadata(
+        bytes calldata _metadata
+    ) external override auth(SET_METADATA_PERMISSION_ID) {
+        _setMetadata(_metadata);
+    }
+
+    /// @inheritdoc IDAO
+    function execute(
+        bytes32 _callId,
+        Action[] calldata _actions,
+        uint256 _allowFailureMap
+    )
+        external
+        override
+        auth(EXECUTE_PERMISSION_ID)
+        returns (bytes[] memory execResults, uint256 failureMap)
+    {
+        if (_actions.length > MAX_ACTIONS) {
+            revert TooManyActions();
+        }
+
+        execResults = new bytes[](_actions.length);
+
+        uint256 gasBefore;
+        uint256 gasAfter;
+
+        for (uint256 i = 0; i < _actions.length; ) {
+            gasBefore = gasleft();
+
+            (bool success, bytes memory result) = _actions[i].to.call{value: _actions[i].value}(
+                _actions[i].data
+            );
+            gasAfter = gasleft();
+
+            // Check if failure is allowed
+            if (!hasBit(_allowFailureMap, uint8(i))) {
+                // Check if the call failed.
+                if (!success) {
+                    revert ActionFailed(i);
+                }
+            } else {
+                // Check if the call failed.
+                if (!success) {
+                    // Make sure that the action call did not fail because 63/64 of 'gasleft()' was insufficient to execute the external call '.to.call' (see https://eips.ethereum.org/EIPS/eip-150).
+                    // In specific scenarios, i.e. proposal execution where the last action in the action array is allowed to fail, the account calling 'execute' could force-fail this action by setting a gas limit
+                    // where 63/64 is insufficient causing the '.to.call' to fail, but where the remaining 1/64 gas are sufficient to successfully finish the 'execute' call.
+                    if (gasAfter < gasBefore / 64) {
+                        revert InsufficientGas();
+                    }
+
+                    // Store that this action failed.
+                    failureMap = flipBit(failureMap, uint8(i));
+                }
+            }
+
+            execResults[i] = result;
+
+            unchecked {
+                ++i;
+            }
+        }
+
+        emit Executed({
+            actor: msg.sender,
+            callId: _callId,
+            actions: _actions,
+            allowFailureMap: _allowFailureMap,
+            failureMap: failureMap,
+            execResults: execResults
+        });
+    }
+
+    /// @inheritdoc IDAO
+    function deposit(
+        address _token,
+        uint256 _amount,
+        string calldata _reference
+    ) external payable override {
+        if (_amount == 0) revert ZeroAmount();
+
+        if (_token == address(0)) {
+            if (msg.value != _amount)
+                revert NativeTokenDepositAmountMismatch({expected: _amount, actual: msg.value});
+        } else {
+            if (msg.value != 0)
+                revert NativeTokenDepositAmountMismatch({expected: 0, actual: msg.value});
+
+            IERC20Upgradeable(_token).safeTransferFrom(msg.sender, address(this), _amount);
+        }
+
+        emit Deposited(msg.sender, _token, _amount, _reference);
+    }
+
+    /// @inheritdoc IDAO
+    function setSignatureValidator(
+        address _signatureValidator
+    ) external override auth(SET_SIGNATURE_VALIDATOR_PERMISSION_ID) {
+        signatureValidator = IERC1271(_signatureValidator);
+
+        emit SignatureValidatorSet({signatureValidator: _signatureValidator});
+    }
+
+    /// @inheritdoc IDAO
+    function isValidSignature(
+        bytes32 _hash,
+        bytes memory _signature
+    ) external view override(IDAO, IERC1271) returns (bytes4) {
+        if (address(signatureValidator) == address(0)) {
+            // Return the invalid magic number
+            return bytes4(0);
+        }
+        // Forward the call to the set signature validator contract
+        return signatureValidator.isValidSignature(_hash, _signature);
+    }
+
+    /// @notice Emits the 'NativeTokenDeposited' event to track native token deposits that weren't made via the deposit method.
+    /// @dev This call is bound by the gas limitations for 'send'/'transfer' calls introduced by EIP-2929.
+    /// Gas cost increases in future hard forks might break this function. As an alternative, EIP-2930-type transactions using access lists can be employed.
+    receive() external payable {
+        emit NativeTokenDeposited(msg.sender, msg.value);
+    }
+
+    /// @notice Fallback to handle future versions of the [ERC-165](https://eips.ethereum.org/EIPS/eip-165) standard.
+    /// @param _input An alias being equivalent to 'msg.data'. This feature of the fallback function was introduced with the [solidity compiler version 0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6)
+    /// @return The magic number registered for the function selector triggering the fallback.
+    fallback(bytes calldata _input) external returns (bytes memory) {
+        bytes4 magicNumber = _handleCallback(msg.sig, _input);
+        return abi.encode(magicNumber);
+    }
+
+    /// @notice Emits the MetadataSet event if new metadata is set.
+    /// @param _metadata Hash of the IPFS metadata object.
+    function _setMetadata(bytes calldata _metadata) internal {
+        emit MetadataSet(_metadata);
+    }
+
+    /// @notice Sets the trusted forwarder on the DAO and emits the associated event.
+    /// @param _trustedForwarder The trusted forwarder address.
+    function _setTrustedForwarder(address _trustedForwarder) internal {
+        trustedForwarder = _trustedForwarder;
+
+        emit TrustedForwarderSet(_trustedForwarder);
+    }
+
+    /// @notice Registers the ERC721/ERC1155 interfaces and callbacks.
+    function _registerTokenInterfaces() private {
+        _registerInterface(type(IERC721ReceiverUpgradeable).interfaceId);
+        _registerInterface(type(IERC1155ReceiverUpgradeable).interfaceId);
+
+        _registerCallback(
+            IERC721ReceiverUpgradeable.onERC721Received.selector,
+            IERC721ReceiverUpgradeable.onERC721Received.selector
+        );
+        _registerCallback(
+            IERC1155ReceiverUpgradeable.onERC1155Received.selector,
+            IERC1155ReceiverUpgradeable.onERC1155Received.selector
+        );
+        _registerCallback(
+            IERC1155ReceiverUpgradeable.onERC1155BatchReceived.selector,
+            IERC1155ReceiverUpgradeable.onERC1155BatchReceived.selector
+        );
+    }
+
+    /// @inheritdoc IDAO
+    function registerStandardCallback(
+        bytes4 _interfaceId,
+        bytes4 _callbackSelector,
+        bytes4 _magicNumber
+    ) external override auth(REGISTER_STANDARD_CALLBACK_PERMISSION_ID) {
+        _registerInterface(_interfaceId);
+        _registerCallback(_callbackSelector, _magicNumber);
+        emit StandardCallbackRegistered(_interfaceId, _callbackSelector, _magicNumber);
+    }
+
+    /// @inheritdoc IEIP4824
+    function daoURI() external view returns (string memory) {
+        return _daoURI;
+    }
+
+    /// @notice Updates the set DAO uri to a new value.
+    /// @param newDaoURI The new DAO uri to be set.
+    function setDaoURI(string calldata newDaoURI) external auth(SET_METADATA_PERMISSION_ID) {
+        _setDaoURI(newDaoURI);
+    }
+
+    /// @notice Sets the new DAO uri and emits the associated event.
+    /// @param daoURI_ The new DAO uri.
+    function _setDaoURI(string calldata daoURI_) internal {
+        _daoURI = daoURI_;
+
+        emit NewURI(daoURI_);
+    }
+
+    /// @notice This empty reserved space is put in place to allow future versions to add new variables without shifting down storage in the inheritance chain (see [OpenZepplins guide about storage gaps](https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps)).
+    uint256[47] private __gap;
+}
+    `;
+    const nspec = extractNatSpec(source);
+    expect(nspec).toStrictEqual({
+      DAO: {
+        name: 'DAO',
+        superClasses: [
+          'IEIP4824',
+          'Initializable',
+          'IERC1271',
+          'ERC165StorageUpgradeable',
+          'IDAO',
+          'UUPSUpgradeable',
+          'PermissionManager',
+          'CallbackHandler',
+        ],
+        tags: {
+          title: 'DAO',
+          author: 'Aragon Association - 2021-2023',
+          notice:
+            'This contract is the entry point to the Aragon DAO framework and provides our users a simple and easy to use public interface.',
+          dev: 'Public API of the Aragon DAO framework.',
+        },
+        details: {
+          TooManyActions: {
+            keyword: 'error',
+            name: 'TooManyActions',
+            tags: {
+              notice:
+                "Thrown if the action array length is larger than 'MAX_ACTIONS'.",
+            },
+          },
+          ActionFailed: {
+            keyword: 'error',
+            name: 'ActionFailed',
+            tags: {
+              notice: 'Thrown if action execution has failed.',
+              param: {
+                index:
+                  'The index of the action in the action array that failed.',
+              },
+            },
+          },
+          InsufficientGas: {
+            keyword: 'error',
+            name: 'InsufficientGas',
+            tags: {
+              notice: 'Thrown if an action has insufficent gas left.',
+            },
+          },
+          ZeroAmount: {
+            keyword: 'error',
+            name: 'ZeroAmount',
+            tags: {
+              notice: 'Thrown if the deposit amount is zero.',
+            },
+          },
+          NativeTokenDepositAmountMismatch: {
+            keyword: 'error',
+            name: 'NativeTokenDepositAmountMismatch',
+            tags: {
+              notice:
+                'Thrown if there is a mismatch between the expected and actually deposited amount of native tokens.',
+              param: {
+                expected: 'The expected native token amount.',
+                actual: 'The actual native token amount deposited.',
+              },
+            },
+          },
+          NewURI: {
+            keyword: 'event',
+            name: 'NewURI',
+            tags: {
+              notice: 'Emitted when a new DAO uri is set.',
+              param: {
+                daoURI: 'The new uri.',
+              },
+            },
+          },
+          'constructor for DAO': {
+            keyword: 'constructor',
+            name: 'constructor for DAO',
+            tags: {
+              notice:
+                'Disables the initializers on the implementation contract to prevent it from being left uninitialized.',
+            },
+          },
+          initialize: {
+            keyword: 'function',
+            name: 'initialize',
+            tags: {
+              notice:
+                "Initializes the DAO by\n- registering the [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface ID\n- setting the trusted forwarder for meta transactions\n- giving the 'ROOT_PERMISSION_ID' permission to the initial owner (that should be revoked and transferred to the DAO after setup).",
+              dev: 'This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).',
+              param: {
+                _metadata:
+                  'IPFS hash that points to all the metadata (logo, description, tags, etc.) of a DAO.',
+                _initialOwner:
+                  "The initial owner of the DAO having the 'ROOT_PERMISSION_ID' permission.",
+                _trustedForwarder:
+                  'The trusted forwarder responsible for verifying meta transactions.',
+              },
+            },
+          },
+          isPermissionRestrictedForAnyAddr: {
+            keyword: 'function',
+            name: 'isPermissionRestrictedForAnyAddr',
+            tags: {
+              inheritdoc: 'PermissionManager',
+            },
+          },
+          _authorizeUpgrade: {
+            keyword: 'function',
+            name: '_authorizeUpgrade',
+            tags: {
+              notice:
+                'Internal method authorizing the upgrade of the contract via the [upgradeabilty mechanism for UUPS proxies](https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable) (see [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822)).',
+              dev: "The caller must have the 'UPGRADE_DAO_PERMISSION_ID' permission.",
+            },
+          },
+          setTrustedForwarder: {
+            keyword: 'function',
+            name: 'setTrustedForwarder',
+            tags: {
+              inheritdoc: 'IDAO',
+            },
+          },
+          getTrustedForwarder: {
+            keyword: 'function',
+            name: 'getTrustedForwarder',
+            tags: {
+              inheritdoc: 'IDAO',
+            },
+          },
+          hasPermission: {
+            keyword: 'function',
+            name: 'hasPermission',
+            tags: {
+              inheritdoc: 'IDAO',
+            },
+          },
+          setMetadata: {
+            keyword: 'function',
+            name: 'setMetadata',
+            tags: {
+              inheritdoc: 'IDAO',
+            },
+          },
+          execute: {
+            keyword: 'function',
+            name: 'execute',
+            tags: {
+              inheritdoc: 'IDAO',
+            },
+          },
+          deposit: {
+            keyword: 'function',
+            name: 'deposit',
+            tags: {
+              inheritdoc: 'IDAO',
+            },
+          },
+          setSignatureValidator: {
+            keyword: 'function',
+            name: 'setSignatureValidator',
+            tags: {
+              inheritdoc: 'IDAO',
+            },
+          },
+          isValidSignature: {
+            keyword: 'function',
+            name: 'isValidSignature',
+            tags: {
+              inheritdoc: 'IDAO',
+            },
+          },
+          _setMetadata: {
+            keyword: 'function',
+            name: '_setMetadata',
+            tags: {
+              notice: 'Emits the MetadataSet event if new metadata is set.',
+              dev: "This call is bound by the gas limitations for 'send'/'transfer' calls introduced by EIP-2929.\nGas cost increases in future hard forks might break this function. As an alternative, EIP-2930-type transactions using access lists can be employed.",
+              param: {
+                _metadata: 'Hash of the IPFS metadata object.',
+              },
+              return:
+                'The magic number registered for the function selector triggering the fallback.',
+            },
+          },
+          _setTrustedForwarder: {
+            keyword: 'function',
+            name: '_setTrustedForwarder',
+            tags: {
+              notice:
+                'Sets the trusted forwarder on the DAO and emits the associated event.',
+              param: {
+                _trustedForwarder: 'The trusted forwarder address.',
+              },
+            },
+          },
+          _registerTokenInterfaces: {
+            keyword: 'function',
+            name: '_registerTokenInterfaces',
+            tags: {
+              notice: 'Registers the ERC721/ERC1155 interfaces and callbacks.',
+            },
+          },
+          registerStandardCallback: {
+            keyword: 'function',
+            name: 'registerStandardCallback',
+            tags: {
+              inheritdoc: 'IDAO',
+            },
+          },
+          daoURI: {
+            keyword: 'function',
+            name: 'daoURI',
+            tags: {
+              inheritdoc: 'IEIP4824',
+            },
+          },
+          setDaoURI: {
+            keyword: 'function',
+            name: 'setDaoURI',
+            tags: {
+              notice: 'Updates the set DAO uri to a new value.',
+              param: {
+                newDaoURI: 'The new DAO uri to be set.',
+              },
+            },
+          },
+          _setDaoURI: {
+            keyword: 'function',
+            name: '_setDaoURI',
+            tags: {
+              notice: 'Sets the new DAO uri and emits the associated event.',
+              param: {
+                daoURI_: 'The new DAO uri.',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/web-app/src/utils/constants/chains.ts
+++ b/packages/web-app/src/utils/constants/chains.ts
@@ -223,3 +223,10 @@ export const CHAIN_METADATA: ChainList = {
     supportsEns: false,
   },
 };
+
+export const chainExplorerAddressLink = (
+  network: SupportedNetworks,
+  address: string
+) => {
+  return `${CHAIN_METADATA[network].explorer}address/${address}`;
+};

--- a/packages/web-app/src/utils/contract.ts
+++ b/packages/web-app/src/utils/contract.ts
@@ -234,10 +234,8 @@ export function collapseNatspec(
   contract: string
 ): NatspecContract {
   const collapsed = {...natspec[contract]};
-  if (collapsed === undefined) {
-    throw new Error(`Contract ${contract} not found in natspec.`);
-  }
   for (const superClass of collapsed.superClasses) {
+    if (!natspec[superClass]) continue;
     const superNatspec = collapseNatspec(natspec, superClass);
     collapsed.details = Object.fromEntries(
       Object.entries(collapsed.details).map(([name, details]) => {
@@ -343,7 +341,8 @@ export function attachEtherNotice(
 ): SmartContractAction[] {
   const parsedSourceCode = parseSourceCode(SourceCode);
   const EtherNotice = extractNatSpec(parsedSourceCode);
-  const notices = EtherNotice[ContractName]?.details;
+  const collapsedNatspec = collapseNatspec(EtherNotice, ContractName);
+  const notices = collapsedNatspec.details;
 
   return ABI.map(action => {
     if (action.type === 'function' && notices?.[action.name]) {


### PR DESCRIPTION
## Description

Implements using correct inheritance in natspec as in the ticket, also adds showing natspec on parameters in the input form and fixes links to explorer for contract across networks

On Goerli you can use contract 0x772b3237ccA11745427cd78e3851DC2Ba21226B5 for testing, this shows inheritance of parameter natspec

Task: [APP-2216](https://aragonassociation.atlassian.net/browse/APP-2216)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2216]: https://aragonassociation.atlassian.net/browse/APP-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ