### PR TITLE
Fix: APP-2222 Clicking Outside of SCC Makes it Disappear

### DIFF
--- a/packages/ui-components/src/components/modal/modal.tsx
+++ b/packages/ui-components/src/components/modal/modal.tsx
@@ -31,6 +31,8 @@ export interface ModalProps {
   onClose?: () => void;
 
   onOpenAutoFocus?: (e: Event) => void;
+
+  onInteractOutside?: () => void;
 }
 
 /**
@@ -43,6 +45,7 @@ export const Modal: React.FC<ModalProps> = ({
   isOpen = true,
   onClose,
   onOpenAutoFocus = e => e.preventDefault(),
+  onInteractOutside = onClose,
   ...props
 }) => {
   return (
@@ -52,7 +55,7 @@ export const Modal: React.FC<ModalProps> = ({
           <Backdrop visible={isOpen} />
           <ModalContainer
             data-testid="modal-content"
-            onInteractOutside={onClose}
+            onInteractOutside={onInteractOutside}
             onEscapeKeyDown={onClose}
             onOpenAutoFocus={onOpenAutoFocus}
             {...props}

--- a/packages/web-app/src/containers/smartContractComposer/desktopModal/index.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/desktopModal/index.tsx
@@ -41,12 +41,20 @@ const DesktopModal: React.FC<DesktopModalProps> = props => {
   const contracts = getValues('contracts') || [];
   const autoSelectedContract = contracts.length === 1 ? contracts[0] : null;
 
+  const handleInteractOutside = () => {
+    // Do nothing when interacting outside the modal
+  };
+
   useEffect(() => {
     setValue('selectedSC', autoSelectedContract);
   }, [autoSelectedContract, setValue]);
 
   return (
-    <StyledModal isOpen={props.isOpen} onClose={props.onClose}>
+    <StyledModal
+      isOpen={props.isOpen}
+      onClose={props.onClose}
+      onInteractOutside={handleInteractOutside}
+    >
       <Header
         onClose={props.onClose}
         selectedContract={selectedSC?.name}


### PR DESCRIPTION
## Description

SCC modal does not close when (accidentally) clicking outside of it on Desktop anymore.

Task: [APP-2225](https://aragonassociation.atlassian.net/browse/APP-2225)

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2225]: https://aragonassociation.atlassian.net/browse/APP-2225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ