### PR TITLE
fix: native tokens withdrawal action display on proposal page

### DIFF
--- a/packages/web-app/src/pages/proposal.tsx
+++ b/packages/web-app/src/pages/proposal.tsx
@@ -230,6 +230,18 @@ const Proposal: React.FC = () => {
           client?.decoding.findInterface(action.data) ||
           pluginClient?.decoding.findInterface(action.data);
 
+        if (!functionParams && action.to && action.value) {
+          return decodeWithdrawToAction(
+            action.data,
+            client,
+            apolloClient,
+            provider,
+            network,
+            action.to,
+            action.value
+          );
+        }
+
         switch (functionParams?.functionName) {
           case 'transfer':
             return decodeWithdrawToAction(


### PR DESCRIPTION
## Description

**Note for reviewer:**
This might seem like a bit of a hacky fix but the main point - it works. We need better support from `findInterface` of SDK function to eliminate the work-around introduced in this PR.

The withdrawal action of Native tokens such as ETH was not visible on proposal page.

Task: [APP-2200](https://aragonassociation.atlassian.net/browse/APP-2200)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2200]: https://aragonassociation.atlassian.net/browse/APP-2200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ