### PR TITLE
Fix: APP-2254 - Allow login modal to be closed

### DIFF
--- a/packages/web-app/src/components/protectedRoute/index.tsx
+++ b/packages/web-app/src/components/protectedRoute/index.tsx
@@ -20,7 +20,7 @@ import {fetchBalance} from 'utils/tokens';
 const ProtectedRoute: React.FC = () => {
   const navigate = useNavigate();
   const {open, close, isGatingOpen} = useGlobalModalContext();
-  const {address, status, isOnWrongNetwork, isModalOpen} = useWallet();
+  const {address, status, isOnWrongNetwork} = useWallet();
   const {data: daoDetails, isLoading: detailsAreLoading} = useDaoDetailsQuery();
 
   const [showLoginModal, setShowLoginModal] = useState(false);
@@ -113,26 +113,23 @@ const ProtectedRoute: React.FC = () => {
     // no lasting consequences considering status will be checked upon proposal creation
     // If we want to keep user logged in (I'm in favor of), remove ref throughout component
     // Fabrice F. - [12/07/2022]
-    if (
-      (!address && isModalOpen === false) ||
-      (!address && userWentThroughLoginFlow.current === false)
-    )
-      open('wallet');
+    if (!address && userWentThroughLoginFlow.current === false)
+      setShowLoginModal(true);
     else {
       if (isOnWrongNetwork) open('network');
       else close('network');
     }
-  }, [address, close, isModalOpen, isOnWrongNetwork, open, status]);
+  }, [address, close, isOnWrongNetwork, open, status]);
 
   // close the wallet modal when the wallet is connected
   useEffect(() => {
     if (
-      ((status === 'connecting' && isModalOpen === true) || address) &&
+      (status === 'connecting' || address) &&
       userWentThroughLoginFlow.current === false
     ) {
       setShowLoginModal(false);
     }
-  }, [address, close, isModalOpen, isOnWrongNetwork, status]);
+  }, [address, close, isOnWrongNetwork, status]);
 
   // wallet connected and on right network, authenticate
   useEffect(() => {


### PR DESCRIPTION
## Description

- Allows the login modal to be closed on protected routes

Task: [APP-2254](https://aragonassociation.atlassian.net/browse/APP-2254)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2254]: https://aragonassociation.atlassian.net/browse/APP-2254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ