### PR TITLE
Chore: APP-APP-2276 - Revert to production IPFS node

### DIFF
--- a/packages/web-app/src/utils/constants/chains.ts
+++ b/packages/web-app/src/utils/constants/chains.ts
@@ -126,9 +126,7 @@ export const CHAIN_METADATA: ChainList = {
     covalentApi: 'https://api.covalenthq.com/v1/eth-mainnet',
     alchemyApi: 'https://eth-mainnet.g.alchemy.com/v2',
     supportsEns: true,
-    //TODO: revert back when issue is fixed
-    // ipfs: 'https://prod.ipfs.aragon.network',
-    ipfs: 'https://test.ipfs.aragon.network',
+    ipfs: 'https://prod.ipfs.aragon.network',
   },
   polygon: {
     id: 137,
@@ -151,9 +149,7 @@ export const CHAIN_METADATA: ChainList = {
     covalentApi: 'https://api.covalenthq.com/v1/matic-mainnet',
     alchemyApi: 'https://polygon-mainnet.g.alchemy.com/v2',
     supportsEns: false,
-    //TODO: revert back when issue is fixed
-    // ipfs: 'https://prod.ipfs.aragon.network',
-    ipfs: 'https://test.ipfs.aragon.network',
+    ipfs: 'https://prod.ipfs.aragon.network',
   },
   'arbitrum-test': {
     id: 421613,


### PR DESCRIPTION
## Description

- reverts the previous change of routing Mainnet and Polygon traffic to the testing IPFS node

Task: [APP-2276](https://aragonassociation.atlassian.net/browse/APP-2276)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2276]: https://aragonassociation.atlassian.net/browse/APP-2276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ