### PR TITLE
Feat: APP-2147 Remove search input from Transfers page

### DIFF
--- a/packages/web-app/.eslintrc
+++ b/packages/web-app/.eslintrc
@@ -26,7 +26,13 @@
     "plugin:prettier/recommended",
     "plugin:tailwindcss/recommended"
   ],
-  "plugins": ["react", "react-hooks", "@typescript-eslint", "tailwindcss", "prettier"],
+  "plugins": [
+    "react",
+    "react-hooks",
+    "@typescript-eslint",
+    "tailwindcss",
+    "prettier"
+  ],
   "rules": {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
@@ -37,7 +43,7 @@
     "tailwindcss/no-contradicting-classname": "error",
     "prettier/prettier": "error",
     "block-scoped-var": "error",
-    "eqeqeq": "error",
+    "eqeqeq": ["error", "always", {"null": "ignore"}],
     "no-var": "error",
     "prefer-const": "error",
     "eol-last": "error",

--- a/packages/web-app/src/components/verificationCard/index.tsx
+++ b/packages/web-app/src/components/verificationCard/index.tsx
@@ -159,7 +159,7 @@ const VerificationCard: React.FC<TransferListProps> = ({tokenAddress}) => {
                   <Dd>{tokenTotalHolders}</Dd>
                 ) : (
                   <dd className="flex items-center" style={{width: '70%'}}>
-                    <IconSpinner className="w-1.5 desktop:w-2 h-1.5 desktop:h-2 animate-spin text-primary-500" />
+                    <IconSpinner className="w-1.5 desktop:w-2 h-1.5 desktop:h-2 text-primary-500 animate-spin" />
                   </dd>
                 )}
               </Dl>

--- a/packages/web-app/src/locales/en-US/common.json
+++ b/packages/web-app/src/locales/en-US/common.json
@@ -144,7 +144,6 @@
     "selectToken": "Select a Token ...",
     "walletOrEns": "Type wallet address or ENS ...",
     "searchTokens": "Type to search ...",
-    "searchTransfers": "Type to filter ...",
     "daoName": "Type your DAOs name ...",
     "daoDescription": "Type your summary ..."
   },

--- a/packages/web-app/src/locales/en/common.json
+++ b/packages/web-app/src/locales/en/common.json
@@ -241,7 +241,6 @@
     "selectToken": "Select a token …",
     "walletOrEns": "Type wallet address or ENS …",
     "searchTokens": "Type to search …",
-    "searchTransfers": "Type to filter …",
     "daoName": "Type your DAO's name …",
     "ensName": "aragon",
     "daoDescription": "Type your summary …",

--- a/packages/web-app/src/locales/es-ES/common.json
+++ b/packages/web-app/src/locales/es-ES/common.json
@@ -178,7 +178,6 @@
     "selectToken": "Select a Token ...",
     "walletOrEns": "Type wallet address or ENS ...",
     "searchTokens": "Type to search ...",
-    "searchTransfers": "Type to filter ...",
     "daoName": "Type your DAOs name ...",
     "daoDescription": "Type your summary ...",
     "addResource": "e.g. Website, Discord, etc"

--- a/packages/web-app/src/locales/pt-BR/common.json
+++ b/packages/web-app/src/locales/pt-BR/common.json
@@ -178,7 +178,6 @@
     "selectToken": "Select a Token ...",
     "walletOrEns": "Type wallet address or ENS ...",
     "searchTokens": "Type to search ...",
-    "searchTransfers": "Type to filter ...",
     "daoName": "Type your DAOs name ...",
     "daoDescription": "Type your summary ...",
     "addResource": "e.g. Website, Discord, etc"

--- a/packages/web-app/src/locales/ru-UA/common.json
+++ b/packages/web-app/src/locales/ru-UA/common.json
@@ -226,7 +226,6 @@
     "selectToken": "Select a token …",
     "walletOrEns": "Type wallet address or ENS …",
     "searchTokens": "Type to search …",
-    "searchTransfers": "Type to filter …",
     "daoName": "Type your DAO's name …",
     "ensName": "aragon",
     "daoDescription": "Type your summary …",

--- a/packages/web-app/src/pages/transfers.tsx
+++ b/packages/web-app/src/pages/transfers.tsx
@@ -1,4 +1,4 @@
-import {ButtonGroup, IconAdd, Option, SearchInput} from '@aragon/ui-components';
+import {ButtonGroup, IconAdd, Option} from '@aragon/ui-components';
 import {withTransaction} from '@elastic/apm-rum-react';
 import {Locale, format} from 'date-fns';
 import * as Locales from 'date-fns/locale';
@@ -26,37 +26,20 @@ const Transfers: React.FC = () => {
     daoDetails?.address ?? ''
   );
 
-  const [filterValue, setFilterValue] = useState('');
-  const [searchValue, setSearchValue] = useState('');
+  const [filterValue, setFilterValue] = useState<string>();
 
   /*************************************************
    *             Callbacks and Handlers            *
    *************************************************/
   const handleButtonGroupChange = (selected: string) => {
-    const val = selected === 'all' ? '' : selected;
+    const val = selected === 'all' ? undefined : selected;
     setFilterValue(val);
   };
 
   const filterValidator = useCallback(
-    (transfer: Transfer) => {
-      let returnValue = true;
-      let matchesFilter = true;
-      let matchesSearch = true;
-      if (filterValue !== '') {
-        matchesFilter = Boolean(transfer.transferType === filterValue);
-      }
-      if (searchValue !== '') {
-        const re = new RegExp(searchValue, 'i');
-        matchesSearch = Boolean(
-          transfer?.title.match(re) ||
-            transfer.tokenSymbol.match(re) ||
-            transfer.tokenAmount.match(re)
-        );
-      }
-      returnValue = matchesFilter && matchesSearch;
-      return returnValue;
-    },
-    [searchValue, filterValue]
+    (transfer: Transfer) =>
+      filterValue == null || transfer.transferType === filterValue,
+    [filterValue]
   );
 
   const displayedTransfers = useMemo(
@@ -105,13 +88,6 @@ const Transfers: React.FC = () => {
       >
         <div className="mt-3 desktop:mt-8">
           <div className="space-y-1.5">
-            <SearchInput
-              value={searchValue}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setSearchValue(e.target.value)
-              }
-              placeholder={t('placeHolders.searchTransfers')}
-            />
             <div className="flex">
               <ButtonGroup
                 bgWhite


### PR DESCRIPTION
## Description

- Remove the `SearchInput` component from the Transfer page
- Remove now unused `searchTransfers` localisation key
- Update `eqeqeq` eslint rules to allow null check
  - Eslint reference: [allow-null](https://eslint.org/docs/latest/rules/eqeqeq#allow-null)
  - I find the expression `x == null` valuable to check if a variable is null or undefined

Task: [APP-2147](https://aragonassociation.atlassian.net/browse/APP-2147)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2147]: https://aragonassociation.atlassian.net/browse/APP-2147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ