### PR TITLE
fix: APP-2277 fixed multisig dao manage members add addresses empty f…

### DIFF
--- a/packages/web-app/src/utils/proposals.ts
+++ b/packages/web-app/src/utils/proposals.ts
@@ -961,10 +961,18 @@ export function getNonEmptyActions(
       // minimum approval changed: return action or don't include
       return action.inputs.minApprovals !== minApprovals ? action : [];
     } else if (action.name === 'add_address') {
-      // address added to the list: return action or don't include
-      return action.inputs.memberWallets.some(w => w.address === '')
-        ? []
-        : action;
+      // strip empty inputs off
+
+      const finalAction = {
+        ...action,
+        inputs: {
+          memberWallets: action.inputs.memberWallets.filter(
+            item => !!item.address
+          ),
+        },
+      };
+
+      return finalAction.inputs.memberWallets.length > 0 ? finalAction : [];
     } else if (action.name === 'remove_address') {
       // address removed from the list: return action or don't include
       return action.inputs.memberWallets.length > 0 ? action : [];


### PR DESCRIPTION
## Description

Add Members Multisig DAO - An empty "add wallet" field results in the action not being added to the proposal.

Task: [APP-2277](https://aragonassociation.atlassian.net/browse/APP-2277)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2277]: https://aragonassociation.atlassian.net/browse/APP-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ