### PR TITLE
Feature: APP-2264 - Action Builder & Execution Widget

### DIFF
--- a/packages/web-app/src/components/executionWidget/actions/walletConnectActionCard.tsx
+++ b/packages/web-app/src/components/executionWidget/actions/walletConnectActionCard.tsx
@@ -25,10 +25,15 @@ export const WCActionCard: React.FC<WCActionCardActionCardProps> = ({
   const {t} = useTranslation();
 
   const showTimeSensitiveWarning = useMemo(() => {
-    for (const i of action.inputs) {
-      if (POTENTIALLY_TIME_SENSITIVE_FIELDS.has(i.name.toLowerCase()))
-        return true;
+    // Note: need to check whether the inputs exist because the decoding
+    // and form setting might take a while
+    if (action.inputs) {
+      for (const i of action.inputs) {
+        if (POTENTIALLY_TIME_SENSITIVE_FIELDS.has(i.name.toLowerCase()))
+          return true;
+      }
     }
+    return false;
   }, [action.inputs]);
 
   return (

--- a/packages/web-app/src/components/executionWidget/actions/walletConnectActionCard.tsx
+++ b/packages/web-app/src/components/executionWidget/actions/walletConnectActionCard.tsx
@@ -1,0 +1,71 @@
+import {useTranslation} from 'react-i18next';
+import React from 'react';
+
+import {AccordionMethod, AccordionMethodType} from 'components/accordionMethod';
+import {ActionWC, Input} from 'utils/types';
+import styled from 'styled-components';
+import {AlertCard} from '@aragon/ui-components';
+import {DisplayComponentForType} from 'containers/smartContractComposer/components/inputForm';
+
+type WCActionCardActionCardProps = Pick<AccordionMethodType, 'type'> & {
+  action: ActionWC;
+  methodActions?: Array<{
+    component: React.ReactNode;
+    callback: () => void;
+  }>;
+};
+
+export const WCActionCard: React.FC<WCActionCardActionCardProps> = ({
+  action,
+  methodActions,
+  type,
+}) => {
+  const {t} = useTranslation();
+
+  return (
+    <AccordionMethod
+      type={type}
+      methodName={action.functionName}
+      dropdownItems={methodActions}
+      smartContractName={action.contractName}
+      verified={!!action.verified}
+      //   methodDescription={action.notice}
+    >
+      <Content>
+        {action.inputs?.length > 0 ? (
+          <div className="pb-1.5 space-y-2">
+            {(action.inputs as Input[]).map(input => (
+              <div key={input.name}>
+                <InputName>{input.name}</InputName>
+                <div className="mt-0.5 mb-1.5">
+                  <span className="text-ui-600 ft-text-sm">{input.notice}</span>
+                </div>
+                <DisplayComponentForType
+                  disabled
+                  key={input.name}
+                  input={input}
+                />
+              </div>
+            ))}
+          </div>
+        ) : null}
+        {!action.decoded && (
+          <AlertCard
+            title={t('newProposal.configureActions.actionAlertWarning.title')}
+            helpText={t('newProposal.configureActions.actionAlertWarning.desc')}
+            mode="warning"
+          />
+        )}
+      </Content>
+    </AccordionMethod>
+  );
+};
+
+const Content = styled.div.attrs({
+  className:
+    'p-3 bg-ui-0 border border-ui-100 border-t-0 space-y-3 rounded-b-xl',
+})``;
+
+const InputName = styled.div.attrs({
+  className: 'text-base font-bold text-ui-800 capitalize',
+})``;

--- a/packages/web-app/src/components/executionWidget/actions/walletConnectActionCard.tsx
+++ b/packages/web-app/src/components/executionWidget/actions/walletConnectActionCard.tsx
@@ -1,5 +1,5 @@
 import {useTranslation} from 'react-i18next';
-import React from 'react';
+import React, {useMemo} from 'react';
 
 import {AccordionMethod, AccordionMethodType} from 'components/accordionMethod';
 import {ActionWC, Input} from 'utils/types';
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import {AlertCard} from '@aragon/ui-components';
 import {DisplayComponentForType} from 'containers/smartContractComposer/components/inputForm';
 import {shortenAddress} from 'utils/library';
+import {POTENTIALLY_TIME_SENSITIVE_FIELDS} from 'utils/constants/misc';
 
 type WCActionCardActionCardProps = Pick<AccordionMethodType, 'type'> & {
   action: ActionWC;
@@ -22,6 +23,17 @@ export const WCActionCard: React.FC<WCActionCardActionCardProps> = ({
   type,
 }) => {
   const {t} = useTranslation();
+
+  const showTimeSensitiveWarning = useMemo(() => {
+    for (let i = 0; i < action.inputs.length; i++) {
+      if (
+        POTENTIALLY_TIME_SENSITIVE_FIELDS.has(
+          action.inputs[i].name.toLowerCase()
+        )
+      )
+        return true;
+    }
+  }, [action.inputs]);
 
   return (
     <AccordionMethod
@@ -55,6 +67,15 @@ export const WCActionCard: React.FC<WCActionCardActionCardProps> = ({
             title={t('newProposal.configureActions.actionAlertWarning.title')}
             helpText={t('newProposal.configureActions.actionAlertWarning.desc')}
             mode="warning"
+          />
+        )}
+        {showTimeSensitiveWarning && (
+          <AlertCard
+            title={t('newProposal.configureActions.actionAlertCritical.title')}
+            helpText={t(
+              'newProposal.configureActions.actionAlertCritical.desc'
+            )}
+            mode="critical"
           />
         )}
       </Content>

--- a/packages/web-app/src/components/executionWidget/actions/walletConnectActionCard.tsx
+++ b/packages/web-app/src/components/executionWidget/actions/walletConnectActionCard.tsx
@@ -6,6 +6,7 @@ import {ActionWC, Input} from 'utils/types';
 import styled from 'styled-components';
 import {AlertCard} from '@aragon/ui-components';
 import {DisplayComponentForType} from 'containers/smartContractComposer/components/inputForm';
+import {shortenAddress} from 'utils/library';
 
 type WCActionCardActionCardProps = Pick<AccordionMethodType, 'type'> & {
   action: ActionWC;
@@ -27,9 +28,9 @@ export const WCActionCard: React.FC<WCActionCardActionCardProps> = ({
       type={type}
       methodName={action.functionName}
       dropdownItems={methodActions}
-      smartContractName={action.contractName}
+      smartContractName={shortenAddress(action.contractName)}
       verified={!!action.verified}
-      //   methodDescription={action.notice}
+      methodDescription={action.notice}
     >
       <Content>
         {action.inputs?.length > 0 ? (

--- a/packages/web-app/src/components/executionWidget/actions/walletConnectActionCard.tsx
+++ b/packages/web-app/src/components/executionWidget/actions/walletConnectActionCard.tsx
@@ -1,13 +1,13 @@
-import {useTranslation} from 'react-i18next';
+import {AlertCard} from '@aragon/ui-components';
 import React, {useMemo} from 'react';
+import {useTranslation} from 'react-i18next';
+import styled from 'styled-components';
 
 import {AccordionMethod, AccordionMethodType} from 'components/accordionMethod';
-import {ActionWC, Input} from 'utils/types';
-import styled from 'styled-components';
-import {AlertCard} from '@aragon/ui-components';
-import {DisplayComponentForType} from 'containers/smartContractComposer/components/inputForm';
-import {shortenAddress} from 'utils/library';
+import {FormlessComponentForType} from 'containers/smartContractComposer/components/inputForm';
 import {POTENTIALLY_TIME_SENSITIVE_FIELDS} from 'utils/constants/misc';
+import {shortenAddress} from 'utils/library';
+import {ActionWC, Input} from 'utils/types';
 
 type WCActionCardActionCardProps = Pick<AccordionMethodType, 'type'> & {
   action: ActionWC;
@@ -25,12 +25,8 @@ export const WCActionCard: React.FC<WCActionCardActionCardProps> = ({
   const {t} = useTranslation();
 
   const showTimeSensitiveWarning = useMemo(() => {
-    for (let i = 0; i < action.inputs.length; i++) {
-      if (
-        POTENTIALLY_TIME_SENSITIVE_FIELDS.has(
-          action.inputs[i].name.toLowerCase()
-        )
-      )
+    for (const i of action.inputs) {
+      if (POTENTIALLY_TIME_SENSITIVE_FIELDS.has(i.name.toLowerCase()))
         return true;
     }
   }, [action.inputs]);
@@ -53,7 +49,7 @@ export const WCActionCard: React.FC<WCActionCardActionCardProps> = ({
                 <div className="mt-0.5 mb-1.5">
                   <span className="text-ui-600 ft-text-sm">{input.notice}</span>
                 </div>
-                <DisplayComponentForType
+                <FormlessComponentForType
                   disabled
                   key={input.name}
                   input={input}

--- a/packages/web-app/src/components/executionWidget/actions/walletConnectActionCard.tsx
+++ b/packages/web-app/src/components/executionWidget/actions/walletConnectActionCard.tsx
@@ -44,7 +44,7 @@ export const WCActionCard: React.FC<WCActionCardActionCardProps> = ({
       verified={!!action.verified}
       methodDescription={action.notice}
     >
-      <Content>
+      <Content type={type}>
         {action.inputs?.length > 0 ? (
           <div className="pb-1.5 space-y-2">
             {(action.inputs as Input[]).map(input => (
@@ -83,10 +83,13 @@ export const WCActionCard: React.FC<WCActionCardActionCardProps> = ({
   );
 };
 
-const Content = styled.div.attrs({
-  className:
-    'p-3 bg-ui-0 border border-ui-100 border-t-0 space-y-3 rounded-b-xl',
-})``;
+type ContentProps = Pick<WCActionCardActionCardProps, 'type'>;
+
+const Content = styled.div.attrs(({type}: ContentProps) => ({
+  className: `p-3 border border-ui-100 border-t-0 space-y-3 rounded-b-xl ${
+    type === 'action-builder' ? 'bg-ui-0' : 'bg-ui-50'
+  }`,
+}))<ContentProps>``;
 
 const InputName = styled.div.attrs({
   className: 'text-base font-bold text-ui-800 capitalize',

--- a/packages/web-app/src/components/executionWidget/actions/walletConnectActionCard.tsx
+++ b/packages/web-app/src/components/executionWidget/actions/walletConnectActionCard.tsx
@@ -1,4 +1,4 @@
-import {AlertCard} from '@aragon/ui-components';
+import {AlertCard, Label} from '@aragon/ui-components';
 import React, {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import {AccordionMethod, AccordionMethodType} from 'components/accordionMethod';
 import {FormlessComponentForType} from 'containers/smartContractComposer/components/inputForm';
 import {POTENTIALLY_TIME_SENSITIVE_FIELDS} from 'utils/constants/misc';
-import {shortenAddress} from 'utils/library';
+import {capitalizeFirstLetter, shortenAddress} from 'utils/library';
 import {ActionWC, Input} from 'utils/types';
 
 type WCActionCardActionCardProps = Pick<AccordionMethodType, 'type'> & {
@@ -47,21 +47,24 @@ export const WCActionCard: React.FC<WCActionCardActionCardProps> = ({
     >
       <Content type={type}>
         {action.inputs?.length > 0 ? (
-          <div className="pb-1.5 space-y-2">
-            {(action.inputs as Input[]).map(input => (
-              <div key={input.name}>
-                <InputName>{input.name}</InputName>
-                <div className="mt-0.5 mb-1.5">
-                  <span className="text-ui-600 ft-text-sm">{input.notice}</span>
-                </div>
-                <FormlessComponentForType
-                  disabled
-                  key={input.name}
-                  input={input}
-                />
-              </div>
-            ))}
-          </div>
+          <FormGroup>
+            {action.inputs.map(input => {
+              if (!input.name) return null;
+              return (
+                <FormItem key={input.name}>
+                  <Label
+                    label={capitalizeFirstLetter(input.name)}
+                    helpText={input.notice}
+                  />
+                  <FormlessComponentForType
+                    disabled
+                    key={input.name}
+                    input={input as Input}
+                  />
+                </FormItem>
+              );
+            })}
+          </FormGroup>
         ) : null}
         {!action.decoded && (
           <AlertCard
@@ -87,11 +90,15 @@ export const WCActionCard: React.FC<WCActionCardActionCardProps> = ({
 type ContentProps = Pick<WCActionCardActionCardProps, 'type'>;
 
 const Content = styled.div.attrs(({type}: ContentProps) => ({
-  className: `p-3 border border-ui-100 border-t-0 space-y-3 rounded-b-xl ${
+  className: `px-2 desktop:px-3 p-3 border border-ui-100 border-t-0 space-y-2 desktop:space-y-3 rounded-b-xl ${
     type === 'action-builder' ? 'bg-ui-0' : 'bg-ui-50'
   }`,
 }))<ContentProps>``;
 
-const InputName = styled.div.attrs({
-  className: 'text-base font-bold text-ui-800 capitalize',
+const FormGroup = styled.div.attrs({
+  className: 'space-y-2 desktop:space-y-3',
+})``;
+
+const FormItem = styled.div.attrs({
+  className: 'space-y-1.5',
 })``;

--- a/packages/web-app/src/components/executionWidget/actionsFilter.tsx
+++ b/packages/web-app/src/components/executionWidget/actionsFilter.tsx
@@ -8,8 +8,9 @@ import {ModifyMetadataCard} from './actions/modifyMetadataCard';
 import {ModifyMultisigSettingsCard} from './actions/modifyMultisigSettingsCard';
 import {ModifyMvSettingsCard} from './actions/modifySettingsCard';
 import {RemoveAddressCard} from './actions/removeAddressCard';
-import {WithdrawCard} from './actions/withdrawCard';
 import {SCCExecutionCard} from './actions/sccExecutionWidget';
+import {WCActionCard} from './actions/walletConnectActionCard';
+import {WithdrawCard} from './actions/withdrawCard';
 
 type ActionsFilterProps = {
   action: Action;
@@ -38,6 +39,8 @@ export const ActionsFilter: React.FC<ActionsFilterProps> = ({action}) => {
       return <ModifyMultisigSettingsCard action={action} />;
     case 'external_contract_action':
       return <SCCExecutionCard action={action} />;
+    case 'wallet_connect_action':
+      return <WCActionCard action={action} type="execution-widget" />;
     default:
       return <></>;
   }

--- a/packages/web-app/src/components/modalHeader/searchHeader.tsx
+++ b/packages/web-app/src/components/modalHeader/searchHeader.tsx
@@ -6,20 +6,19 @@ import {
   IconType,
 } from '@aragon/ui-components';
 import React from 'react';
-import {useFormContext} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
 
-type DesktopModalHeaderProps = {
+type SearchHeader = {
   onClose?: () => void;
-  selectedContract?: string; // Note: may come from form, not set in stone
+  selectedValue?: string;
   onSearch?: (search: string) => void;
   buttonIcon?: React.FunctionComponentElement<IconType>;
+  onHomeButtonClick?: () => void;
 };
 
-const DesktopModalHeader: React.FC<DesktopModalHeaderProps> = props => {
+const SearchHeader: React.FC<SearchHeader> = props => {
   const {t} = useTranslation();
-  const {setValue} = useFormContext();
 
   return (
     <Container>
@@ -28,15 +27,12 @@ const DesktopModalHeader: React.FC<DesktopModalHeaderProps> = props => {
           icon={props.buttonIcon || <IconHome />}
           mode="secondary"
           bgWhite
-          onClick={() => {
-            setValue('selectedSC', null);
-            setValue('selectedAction', null);
-          }}
+          onClick={props.onHomeButtonClick}
         />
         <IconChevronRight />
-        {props.selectedContract && (
+        {props.selectedValue && (
           <>
-            <SelectedContract>{props.selectedContract}</SelectedContract>
+            <SelectedValue>{props.selectedValue}</SelectedValue>
             <IconChevronRight />
           </>
         )}
@@ -57,7 +53,7 @@ const DesktopModalHeader: React.FC<DesktopModalHeaderProps> = props => {
   );
 };
 
-export default DesktopModalHeader;
+export default SearchHeader;
 
 const Container = styled.div.attrs({
   className:
@@ -68,7 +64,7 @@ const LeftContent = styled.div.attrs({
   className: 'flex gap-x-1 items-center text-ui-300 ft-text-base',
 })``;
 
-const SelectedContract = styled.p.attrs({
+const SelectedValue = styled.p.attrs({
   className: 'font-bold text-ui-600 ft-text-base',
 })``;
 

--- a/packages/web-app/src/containers/actionBuilder/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/index.tsx
@@ -26,6 +26,7 @@ import MintTokens from './mintTokens';
 import RemoveAddresses from './removeAddresses';
 import SCCAction from './scc';
 import UpdateMinimumApproval from './updateMinimumApproval';
+import WalletConnectAction from './walletConnect';
 import WithdrawAction from './withdraw/withdrawAction';
 
 /**
@@ -99,8 +100,12 @@ const Action: React.FC<ActionsComponentProps> = ({
     case 'wallet_connect_modal':
       return <WalletConnect actionIndex={actionIndex} />;
     case 'wallet_connect_action':
-      //TODO: Create a separate action-builder accordion for Wallet Connect Actions to handle the non-decodable flow and AlertCards
-      return <SCCAction actionIndex={actionIndex} allowRemove={allowRemove} />;
+      return (
+        <WalletConnectAction
+          actionIndex={actionIndex}
+          allowRemove={allowRemove}
+        />
+      );
     default:
       throw Error('Action not found');
   }

--- a/packages/web-app/src/containers/actionBuilder/walletConnect/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/walletConnect/index.tsx
@@ -1,14 +1,12 @@
-import {AlertCard, ListItemAction} from '@aragon/ui-components';
+import {ListItemAction} from '@aragon/ui-components';
 import React from 'react';
 import {useWatch} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
-import styled from 'styled-components';
 
-import {AccordionMethod, AccordionMethodType} from 'components/accordionMethod';
-import {ComponentForType} from 'containers/smartContractComposer/components/inputForm';
+import {WCActionCard} from 'components/executionWidget/actions/walletConnectActionCard';
 import {useActionsContext} from 'context/actions';
 import {useAlertContext} from 'context/alert';
-import {ActionIndex, ActionWC, Input} from 'utils/types';
+import {ActionIndex} from 'utils/types';
 
 const WalletConnectAction: React.FC<ActionIndex & {allowRemove?: boolean}> = ({
   actionIndex,
@@ -41,10 +39,9 @@ const WalletConnectAction: React.FC<ActionIndex & {allowRemove?: boolean}> = ({
   if (actionData) {
     return (
       <>
-        <WalletConnectActionCard
+        <WCActionCard
           type="action-builder"
           action={actionData}
-          actionIndex={actionIndex}
           methodActions={methodActions}
         />
       </>
@@ -55,69 +52,3 @@ const WalletConnectAction: React.FC<ActionIndex & {allowRemove?: boolean}> = ({
 };
 
 export default WalletConnectAction;
-
-const InputName = styled.div.attrs({
-  className: 'text-base font-bold text-ui-800 capitalize',
-})``;
-
-const Content = styled.div.attrs({
-  className:
-    'p-3 bg-ui-0 border border-ui-100 border-t-0 space-y-3 rounded-b-xl',
-})``;
-
-type WalletConnectActionCardProps = Pick<AccordionMethodType, 'type'> & {
-  action: ActionWC;
-  actionIndex?: number;
-  methodActions?: Array<{
-    component: React.ReactNode;
-    callback: () => void;
-  }>;
-};
-
-export const WalletConnectActionCard: React.FC<WalletConnectActionCardProps> =
-  ({action, actionIndex, methodActions, type}) => {
-    const {t} = useTranslation();
-
-    return (
-      <AccordionMethod
-        type={type}
-        methodName={action.functionName}
-        dropdownItems={methodActions}
-        smartContractName={action.contractName}
-        verified={!!action.verified}
-        methodDescription={action.notice}
-      >
-        <Content>
-          {action.inputs?.length > 0 ? (
-            <div className="pb-1.5 space-y-2">
-              {(action.inputs as Input[]).map((input, index) => (
-                <div key={input.name}>
-                  <InputName>{input.name}</InputName>
-                  <div className="mt-0.5 mb-1.5">
-                    <span className="text-ui-600 ft-text-sm">
-                      {input.notice}
-                    </span>
-                  </div>
-                  <ComponentForType
-                    disabled
-                    key={input.name}
-                    input={input}
-                    formHandleName={`actions.${actionIndex}.inputs.${index}.value`}
-                  />
-                </div>
-              ))}
-            </div>
-          ) : null}
-          {!action.decoded && (
-            <AlertCard
-              title={t('newProposal.configureActions.actionAlertWarning.title')}
-              helpText={t(
-                'newProposal.configureActions.actionAlertWarning.desc'
-              )}
-              mode="warning"
-            />
-          )}
-        </Content>
-      </AccordionMethod>
-    );
-  };

--- a/packages/web-app/src/containers/actionBuilder/walletConnect/index.tsx
+++ b/packages/web-app/src/containers/actionBuilder/walletConnect/index.tsx
@@ -1,0 +1,123 @@
+import {AlertCard, ListItemAction} from '@aragon/ui-components';
+import React from 'react';
+import {useWatch} from 'react-hook-form';
+import {useTranslation} from 'react-i18next';
+import styled from 'styled-components';
+
+import {AccordionMethod, AccordionMethodType} from 'components/accordionMethod';
+import {ComponentForType} from 'containers/smartContractComposer/components/inputForm';
+import {useActionsContext} from 'context/actions';
+import {useAlertContext} from 'context/alert';
+import {ActionIndex, ActionWC, Input} from 'utils/types';
+
+const WalletConnectAction: React.FC<ActionIndex & {allowRemove?: boolean}> = ({
+  actionIndex,
+  allowRemove = true,
+}) => {
+  const {t} = useTranslation();
+  const {alert} = useAlertContext();
+
+  const [actionData] = useWatch({name: [`actions.${actionIndex}`]});
+  const {removeAction} = useActionsContext();
+
+  const methodActions = (() => {
+    const result = [];
+
+    if (allowRemove) {
+      result.push({
+        component: (
+          <ListItemAction title={t('labels.removeEntireAction')} bgWhite />
+        ),
+        callback: () => {
+          removeAction(actionIndex);
+          alert(t('alert.chip.removedAction'));
+        },
+      });
+    }
+
+    return result;
+  })();
+
+  if (actionData) {
+    return (
+      <>
+        <WalletConnectActionCard
+          type="action-builder"
+          action={actionData}
+          actionIndex={actionIndex}
+          methodActions={methodActions}
+        />
+      </>
+    );
+  }
+
+  return null;
+};
+
+export default WalletConnectAction;
+
+const InputName = styled.div.attrs({
+  className: 'text-base font-bold text-ui-800 capitalize',
+})``;
+
+const Content = styled.div.attrs({
+  className:
+    'p-3 bg-ui-0 border border-ui-100 border-t-0 space-y-3 rounded-b-xl',
+})``;
+
+type WalletConnectActionCardProps = Pick<AccordionMethodType, 'type'> & {
+  action: ActionWC;
+  actionIndex?: number;
+  methodActions?: Array<{
+    component: React.ReactNode;
+    callback: () => void;
+  }>;
+};
+
+export const WalletConnectActionCard: React.FC<WalletConnectActionCardProps> =
+  ({action, actionIndex, methodActions, type}) => {
+    const {t} = useTranslation();
+
+    return (
+      <AccordionMethod
+        type={type}
+        methodName={action.functionName}
+        dropdownItems={methodActions}
+        smartContractName={action.contractName}
+        verified={!!action.verified}
+        methodDescription={action.notice}
+      >
+        <Content>
+          {action.inputs?.length > 0 ? (
+            <div className="pb-1.5 space-y-2">
+              {(action.inputs as Input[]).map((input, index) => (
+                <div key={input.name}>
+                  <InputName>{input.name}</InputName>
+                  <div className="mt-0.5 mb-1.5">
+                    <span className="text-ui-600 ft-text-sm">
+                      {input.notice}
+                    </span>
+                  </div>
+                  <ComponentForType
+                    disabled
+                    key={input.name}
+                    input={input}
+                    formHandleName={`actions.${actionIndex}.inputs.${index}.value`}
+                  />
+                </div>
+              ))}
+            </div>
+          ) : null}
+          {!action.decoded && (
+            <AlertCard
+              title={t('newProposal.configureActions.actionAlertWarning.title')}
+              helpText={t(
+                'newProposal.configureActions.actionAlertWarning.desc'
+              )}
+              mode="warning"
+            />
+          )}
+        </Content>
+      </AccordionMethod>
+    );
+  };

--- a/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
@@ -1,7 +1,7 @@
 import {
   ButtonText,
-  IconSuccess,
   CheckboxListItem,
+  IconSuccess,
   NumberInput,
   TextInput,
   WalletInputLegacy,
@@ -299,6 +299,7 @@ export const ComponentForType: React.FC<ComponentForTypeProps> = ({
   // Check if we need to add "index" kind of variable to the "name"
   switch (classifyInputType(input.type)) {
     case 'address':
+    case 'encodedData':
       return (
         <Controller
           defaultValue=""
@@ -418,24 +419,23 @@ export const ComponentForType: React.FC<ComponentForTypeProps> = ({
   }
 };
 
-export const ComponentForTypeWithFormProvider: React.FC<
-  ComponentForTypeProps
-> = ({input, functionName, formHandleName, defaultValue, disabled = false}) => {
-  const methods = useForm({mode: 'onChange'});
+export const ComponentForTypeWithFormProvider: React.FC<ComponentForTypeProps> =
+  ({input, functionName, formHandleName, defaultValue, disabled = false}) => {
+    const methods = useForm({mode: 'onChange'});
 
-  return (
-    <FormProvider {...methods}>
-      <ComponentForType
-        key={input.name}
-        input={input}
-        functionName={functionName}
-        disabled={disabled}
-        defaultValue={defaultValue}
-        formHandleName={formHandleName}
-      />
-    </FormProvider>
-  );
-};
+    return (
+      <FormProvider {...methods}>
+        <ComponentForType
+          key={input.name}
+          input={input}
+          functionName={functionName}
+          disabled={disabled}
+          defaultValue={defaultValue}
+          formHandleName={formHandleName}
+        />
+      </FormProvider>
+    );
+  };
 
 const ActionName = styled.p.attrs({
   className: 'text-lg font-bold text-ui-800 capitalize truncate',

--- a/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
@@ -420,10 +420,15 @@ export const ComponentForType: React.FC<ComponentForTypeProps> = ({
 };
 
 /** This version of the component returns uncontrolled inputs */
-export const DisplayComponentForType: React.FC<{
+type FormlessComponentForTypeProps = {
   input: Input;
   disabled?: boolean;
-}> = ({input, disabled}) => {
+};
+
+export function FormlessComponentForType({
+  input,
+  disabled,
+}: FormlessComponentForTypeProps) {
   const {alert} = useAlertContext();
 
   // Check if we need to add "index" kind of variable to the "name"
@@ -468,7 +473,7 @@ export const DisplayComponentForType: React.FC<{
               <div className="mb-1.5 text-base font-bold text-ui-800 capitalize">
                 {input.name}
               </div>
-              <DisplayComponentForType
+              <FormlessComponentForType
                 key={component.name}
                 input={component}
                 disabled={disabled}
@@ -487,25 +492,30 @@ export const DisplayComponentForType: React.FC<{
         />
       );
   }
-};
+}
 
-export const ComponentForTypeWithFormProvider: React.FC<ComponentForTypeProps> =
-  ({input, functionName, formHandleName, defaultValue, disabled = false}) => {
-    const methods = useForm({mode: 'onChange'});
+export function ComponentForTypeWithFormProvider({
+  input,
+  functionName,
+  formHandleName,
+  defaultValue,
+  disabled = false,
+}: ComponentForTypeProps) {
+  const methods = useForm({mode: 'onChange'});
 
-    return (
-      <FormProvider {...methods}>
-        <ComponentForType
-          key={input.name}
-          input={input}
-          functionName={functionName}
-          disabled={disabled}
-          defaultValue={defaultValue}
-          formHandleName={formHandleName}
-        />
-      </FormProvider>
-    );
-  };
+  return (
+    <FormProvider {...methods}>
+      <ComponentForType
+        key={input.name}
+        input={input}
+        functionName={functionName}
+        disabled={disabled}
+        defaultValue={defaultValue}
+        formHandleName={formHandleName}
+      />
+    </FormProvider>
+  );
+}
 
 const ActionName = styled.p.attrs({
   className: 'text-lg font-bold text-ui-800 capitalize truncate',

--- a/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/components/inputForm.tsx
@@ -419,6 +419,76 @@ export const ComponentForType: React.FC<ComponentForTypeProps> = ({
   }
 };
 
+/** This version of the component returns uncontrolled inputs */
+export const DisplayComponentForType: React.FC<{
+  input: Input;
+  disabled?: boolean;
+}> = ({input, disabled}) => {
+  const {alert} = useAlertContext();
+
+  // Check if we need to add "index" kind of variable to the "name"
+  switch (classifyInputType(input.type)) {
+    case 'address':
+    case 'encodedData': // custom type for the data field which is encoded bytes
+      return (
+        <WalletInputLegacy
+          name={input.name}
+          value={input.value}
+          onChange={() => {}}
+          placeholder="0x"
+          adornmentText={t('labels.copy')}
+          disabledFilled={disabled}
+          onAdornmentClick={() =>
+            handleClipboardActions(input.value as string, () => {}, alert)
+          }
+        />
+      );
+
+    case 'int':
+    case 'uint8':
+    case 'int8':
+    case 'uint32':
+    case 'int32':
+    case 'uint256':
+      return (
+        <NumberInput
+          name={input.name}
+          placeholder="0"
+          includeDecimal
+          disabled={disabled}
+          value={input.value as string}
+        />
+      );
+
+    case 'tuple':
+      return (
+        <>
+          {input.components?.map(component => (
+            <div key={component.name}>
+              <div className="mb-1.5 text-base font-bold text-ui-800 capitalize">
+                {input.name}
+              </div>
+              <DisplayComponentForType
+                key={component.name}
+                input={component}
+                disabled={disabled}
+              />
+            </div>
+          ))}
+        </>
+      );
+    default:
+      return (
+        <TextInput
+          name={input.name}
+          placeholder={`${input.name} (${input.type})`}
+          value={input.value}
+          disabled={disabled}
+        />
+      );
+  }
+};
+
 export const ComponentForTypeWithFormProvider: React.FC<ComponentForTypeProps> =
   ({input, functionName, formHandleName, defaultValue, disabled = false}) => {
     const methods = useForm({mode: 'onChange'});

--- a/packages/web-app/src/containers/smartContractComposer/desktopModal/index.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/desktopModal/index.tsx
@@ -4,17 +4,17 @@ import {useFormContext, useWatch} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
 
+import Header from 'components/modalHeader/searchHeader';
 import {StateEmpty} from 'components/stateEmpty';
-import {SmartContract} from 'utils/types';
-import ActionListGroup from '../components/actionListGroup';
-import SmartContractListGroup from '../components/smartContractListGroup';
-import Header from './header';
-import InputForm from '../components/inputForm';
-import {trackEvent} from 'services/analytics';
 import {useParams} from 'react-router-dom';
+import {trackEvent} from 'services/analytics';
 import {actionsFilter} from 'utils/contract';
-import {ListHeaderContract} from '../components/listHeaderContract';
+import {SmartContract} from 'utils/types';
 import {SccFormData} from '..';
+import ActionListGroup from '../components/actionListGroup';
+import InputForm from '../components/inputForm';
+import {ListHeaderContract} from '../components/listHeaderContract';
+import SmartContractListGroup from '../components/smartContractListGroup';
 
 type DesktopModalProps = {
   isOpen: boolean;
@@ -33,7 +33,7 @@ const DesktopModal: React.FC<DesktopModalProps> = props => {
     name: ['selectedSC'],
   });
   const [search, setSearch] = useState('');
-  const {getValues, setValue} = useFormContext<SccFormData>();
+  const {getValues, setValue, resetField} = useFormContext<SccFormData>();
   const [isActionSelected, setIsActionSelected] = useState(false);
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -57,8 +57,12 @@ const DesktopModal: React.FC<DesktopModalProps> = props => {
     >
       <Header
         onClose={props.onClose}
-        selectedContract={selectedSC?.name}
+        selectedValue={selectedSC?.name}
         onSearch={setSearch}
+        onHomeButtonClick={() => {
+          resetField('selectedSC');
+          resetField('selectedAction');
+        }}
       />
       <Wrapper>
         <Aside>

--- a/packages/web-app/src/containers/smartContractComposer/mobileModal/index.tsx
+++ b/packages/web-app/src/containers/smartContractComposer/mobileModal/index.tsx
@@ -10,20 +10,19 @@ import {
 import React, {useEffect, useState} from 'react';
 import {useFormContext, useWatch} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
+import {useParams} from 'react-router-dom';
 import styled from 'styled-components';
 
 import BottomSheet from 'components/bottomSheet';
-import {SmartContract} from 'utils/types';
-import ActionListGroup from '../components/actionListGroup';
-import SmartContractListGroup from '../components/smartContractListGroup';
-import {ActionSearchInput} from '../desktopModal/header';
-import {trackEvent} from 'services/analytics';
-import {useParams} from 'react-router-dom';
-import InputForm from '../components/inputForm';
-import {SccFormData} from '..';
-import {ListHeaderContract} from '../components/listHeaderContract';
-import {actionsFilter} from 'utils/contract';
 import {StateEmpty} from 'components/stateEmpty';
+import {trackEvent} from 'services/analytics';
+import {actionsFilter} from 'utils/contract';
+import {SmartContract} from 'utils/types';
+import {SccFormData} from '..';
+import ActionListGroup from '../components/actionListGroup';
+import InputForm from '../components/inputForm';
+import {ListHeaderContract} from '../components/listHeaderContract';
+import SmartContractListGroup from '../components/smartContractListGroup';
 
 type Props = {
   isOpen: boolean;
@@ -206,3 +205,7 @@ const Content = styled.div.attrs({
 })`
   max-height: 70vh;
 `;
+
+const ActionSearchInput = styled.input.attrs({
+  className: 'flex-1 text-ui-300 bg-ui-0 ft-text-base focus:outline-none',
+})``;

--- a/packages/web-app/src/containers/walletConnect/actionListenerModal/index.tsx
+++ b/packages/web-app/src/containers/walletConnect/actionListenerModal/index.tsx
@@ -53,9 +53,17 @@ const ActionListenerModal: React.FC<Props> = ({
   /*************************************************
    *             Callbacks and Handlers            *
    *************************************************/
-  const handleAddActions = () => {
+  const handleAddActions = useCallback(() => {
     resetField(`actions.${actionIndex}`);
 
+    // NOTE: this is slightly inefficient and can be optimized
+    // by wrapping the map in a Promise.all, but as of now,
+    // I am unsure if the getEtherscanVerifiedContract will always
+    // be ran with the same parameters given each batch of actions
+    // will be coming from only one dApp at a time. If that is indeed
+    // the case, then both the Etherscan data and notices can be fetched
+    // and parsed outside of the map, getting rid of the unnecessary
+    // async requests.
     actionsReceived.map(async (action, currentIndex) => {
       // verify and decode
       const etherscanData = await getEtherscanVerifiedContract(
@@ -144,7 +152,16 @@ const ActionListenerModal: React.FC<Props> = ({
     });
 
     removeAction(actionIndex);
-  };
+  }, [
+    actionIndex,
+    actionsReceived,
+    addAction,
+    network,
+    removeAction,
+    resetField,
+    setValue,
+    t,
+  ]);
 
   /*************************************************
    *                     Render                    *

--- a/packages/web-app/src/containers/walletConnect/actionListenerModal/index.tsx
+++ b/packages/web-app/src/containers/walletConnect/actionListenerModal/index.tsx
@@ -57,13 +57,13 @@ const ActionListenerModal: React.FC<Props> = ({
     resetField(`actions.${actionIndex}`);
 
     // NOTE: this is slightly inefficient and can be optimized
-    // by wrapping the map in a Promise.all, but as of now,
-    // I am unsure if the getEtherscanVerifiedContract will always
-    // be ran with the same parameters given each batch of actions
+    // by wrapping the map in a Promise.all, but there might be an
+    // even better solution. I am unsure if the getEtherscanVerifiedContract
+    // will always be ran with the same parameters given each batch of actions
     // will be coming from only one dApp at a time. If that is indeed
     // the case, then both the Etherscan data and notices can be fetched
     // and parsed outside of the map, getting rid of the unnecessary
-    // async requests.
+    // async requests. F.F. - [07-10-2023]
     actionsReceived.map(async (action, currentIndex) => {
       // verify and decode
       const etherscanData = await getEtherscanVerifiedContract(

--- a/packages/web-app/src/containers/walletConnect/actionListenerModal/index.tsx
+++ b/packages/web-app/src/containers/walletConnect/actionListenerModal/index.tsx
@@ -76,7 +76,7 @@ const ActionListenerModal: React.FC<Props> = ({
 
       // name, raw action and contract address set on every action
       addAction({name: 'wallet_connect_action'});
-      setValue(`actions.${actionIndex}.name`, 'wallet_connect_action');
+      setValue(`actions.${index}.name`, 'wallet_connect_action');
       setValue(`actions.${index}.raw`, action.params[0]);
       setValue(`actions.${index}.contractAddress`, action.params[0].to);
 

--- a/packages/web-app/src/containers/walletConnect/connectedAppsModal/index.tsx
+++ b/packages/web-app/src/containers/walletConnect/connectedAppsModal/index.tsx
@@ -1,6 +1,3 @@
-import React, {useState} from 'react';
-import styled from 'styled-components';
-import {SessionTypes} from '@walletconnect/types';
 import {
   ButtonText,
   IconChevronRight,
@@ -10,10 +7,13 @@ import {
   Link,
   ListItemAction,
 } from '@aragon/ui-components';
+import {SessionTypes} from '@walletconnect/types';
+import React, {useState} from 'react';
 import {useTranslation} from 'react-i18next';
+import styled from 'styled-components';
 
 import ModalBottomSheetSwitcher from 'components/modalBottomSheetSwitcher';
-import Header from 'containers/smartContractComposer/desktopModal/header';
+import Header from 'components/modalHeader/searchHeader';
 import {StateEmpty} from 'components/stateEmpty';
 
 type Props = {

--- a/packages/web-app/src/context/createProposal.tsx
+++ b/packages/web-app/src/context/createProposal.tsx
@@ -11,8 +11,8 @@ import {
 } from '@aragon/sdk-client';
 import {
   DaoAction,
-  TokenType,
   ProposalMetadata,
+  TokenType,
 } from '@aragon/sdk-client-common';
 import {hexToBytes} from '@aragon/sdk-common';
 import {ethers} from 'ethers';
@@ -268,6 +268,17 @@ const CreateProposalProvider: React.FC<Props> = ({
           }
           break;
         }
+        case 'wallet_connect_action':
+          // wallet connect actions come with a raw field
+          // which is just the data passed by wc itself
+          actions.push(
+            Promise.resolve({
+              // include value in case action does not
+              value: BigInt(0),
+              ...action.raw,
+            })
+          );
+          break;
       }
     }
 

--- a/packages/web-app/src/pages/proposal.tsx
+++ b/packages/web-app/src/pages/proposal.tsx
@@ -694,7 +694,6 @@ const Proposal: React.FC = () => {
             onExecuteClicked={handleExecuteNowClicked}
             txhash={transactionHash || proposal?.executionTxHash || undefined}
           />
-          <ButtonText label={'execute'} onClick={handleExecuteNowClicked} />
         </ProposalContainer>
         <AdditionalInfoContainer>
           <ResourceList links={proposal?.metadata.resources} />

--- a/packages/web-app/src/pages/proposal.tsx
+++ b/packages/web-app/src/pages/proposal.tsx
@@ -58,7 +58,7 @@ import {
   decodeMultisigSettingsToAction,
   decodePluginSettingsToAction,
   decodeRemoveMembersToAction,
-  decodeSCCToAction,
+  decodeToExternalAction,
   decodeWithdrawToAction,
   shortenAddress,
   toDisplayEns,
@@ -286,7 +286,7 @@ const Proposal: React.FC = () => {
             const isPossiblyWithdrawAction =
               !functionParams && action.to && action.value;
 
-            return decodeSCCToAction(action, network, t)
+            return decodeToExternalAction(action, network, t)
               .then(result => {
                 if (!result && isPossiblyWithdrawAction) {
                   return withdrawAction as unknown as Action;
@@ -694,6 +694,7 @@ const Proposal: React.FC = () => {
             onExecuteClicked={handleExecuteNowClicked}
             txhash={transactionHash || proposal?.executionTxHash || undefined}
           />
+          <ButtonText label={'execute'} onClick={handleExecuteNowClicked} />
         </ProposalContainer>
         <AdditionalInfoContainer>
           <ResourceList links={proposal?.metadata.resources} />

--- a/packages/web-app/src/utils/constants/misc.ts
+++ b/packages/web-app/src/utils/constants/misc.ts
@@ -141,3 +141,19 @@ export const PENDING_DAOS_KEY = 'pendingDaos';
 export const PENDING_EXECUTION_KEY = 'pendingExecution';
 export const PENDING_MULTISIG_EXECUTION_KEY = 'pendingMultisigExecution';
 export const VERIFIED_CONTRACTS_KEY = 'verifiedContracts';
+
+// TODO: build more
+// Time sensitive fields (intentionally lowercasing)
+export const POTENTIALLY_TIME_SENSITIVE_FIELDS = new Set<string>([
+  'cliffperiod',
+  'deadline',
+  'endtime',
+  'expirydate',
+  'freezeperiod',
+  'lockduration',
+  'lockexpiration',
+  'timelock',
+  'timerestriction',
+  'unlocktime',
+  'vestingduration',
+]);

--- a/packages/web-app/src/utils/library.ts
+++ b/packages/web-app/src/utils/library.ts
@@ -441,7 +441,7 @@ export async function decodeToExternalAction(
           name: 'wallet_connect_action',
           contractAddress: action.to,
           contractName: etherscanData.result[0].ContractName,
-          functionName: t('Unknown'),
+          functionName: 'Unable to decode function name', // FIXME: crowdin key,
           inputs: getEncodedActionInputs(action, network, t),
           verified: true,
           decoded: false,
@@ -452,7 +452,7 @@ export async function decodeToExternalAction(
         name: 'wallet_connect_action',
         contractAddress: action.to,
         contractName: action.to,
-        functionName: t('Unknown'),
+        functionName: 'Unable to decode function name', // FIXME: crowdin key,
         verified: false,
         decoded: false,
         inputs: getEncodedActionInputs(action, network, t),
@@ -693,9 +693,9 @@ export function getWCPayableAmount(
   network: SupportedNetworks
 ) {
   return {
-    name: t('Raw Amount'),
+    name: 'Raw Amount', // FIXME: crowdin key
     type: 'string',
-    notice: t('The number of the tokens to transfer'),
+    notice: 'The number of the tokens to transfer', // FIXME: crowdin key,
     value: `${formatUnits(
       BigNumber.from(value),
       CHAIN_METADATA[network].nativeCurrency.decimals
@@ -714,16 +714,16 @@ export function getEncodedActionInputs(
         return getWCPayableAmount(t, action.value.toString(), network);
       case 'to':
         return {
-          name: t('Dst'),
+          name: 'Dst', // FIXME: crowdin key,
           type: 'address',
-          notice: t('The address of the destination account'),
+          notice: 'The address of the destination account', // FIXME: crowdin key,
           value: action[fieldName],
         };
       case 'data':
         return {
-          name: t('Data'),
+          name: 'Data', // t('Data'),
           type: 'encodedData',
-          notice: t('Encoded EVM call to the smart contract'),
+          notice: 'Encoded EVM call to the smart contract', // FIXME: crowdin key,
           value: action[fieldName],
         };
       default:

--- a/packages/web-app/src/utils/library.ts
+++ b/packages/web-app/src/utils/library.ts
@@ -40,6 +40,7 @@ import {
   ActionUpdateMultisigPluginSettings,
   ActionUpdatePluginSettings,
   ActionWithdraw,
+  ExternalActionInput,
   Input,
 } from 'utils/types';
 import {i18n} from '../../i18n.config';
@@ -403,7 +404,7 @@ export async function decodeToExternalAction(
           JSON.parse(etherscanData.result[0].ABI)
         ).find(notice => notice.name === decodedData.name);
 
-        const inputs = decodedData.params.map(param => {
+        const inputs: ExternalActionInput[] = decodedData.params.map(param => {
           return {
             ...param,
             notice: notices?.inputs.find(
@@ -421,7 +422,7 @@ export async function decodeToExternalAction(
               BigNumber.from(action.value),
               CHAIN_METADATA[network].nativeCurrency.decimals
             )} ${CHAIN_METADATA[network].nativeCurrency.symbol}`,
-          });
+          } as ExternalActionInput);
         }
 
         return {

--- a/packages/web-app/src/utils/library.ts
+++ b/packages/web-app/src/utils/library.ts
@@ -872,3 +872,11 @@ export function shortenAddress(address: string | null) {
     );
   else return address;
 }
+
+export function capitalizeFirstLetter(str: string) {
+  if (typeof str !== 'string' || str.length === 0) {
+    return str; // Return the input if it's not a string or an empty string
+  }
+
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/packages/web-app/src/utils/types.ts
+++ b/packages/web-app/src/utils/types.ts
@@ -309,17 +309,18 @@ export type ActionSCC = {
   contractName: string;
   contractAddress: string;
   functionName: string;
-  inputs: Array<{
-    name: string;
-    type: string;
-    notice?: string;
-    value: object | string | BigNumber;
-  }>;
+  inputs: Array<ExternalActionInput>;
   value?: string;
 };
 
 // Alias
 export type ActionExternalContract = ActionWC;
+export type ExternalActionInput = {
+  name: string;
+  type: string;
+  notice?: string;
+  value: object | string | BigNumber;
+};
 
 export type ActionWC = Omit<ActionSCC, 'name'> & {
   name: 'wallet_connect_action';

--- a/packages/web-app/src/utils/types.ts
+++ b/packages/web-app/src/utils/types.ts
@@ -318,20 +318,14 @@ export type ActionSCC = {
   value?: string;
 };
 
-export type ActionWC = {
+// Alias
+export type ActionExternalContract = ActionWC;
+
+export type ActionWC = Omit<ActionSCC, 'name'> & {
   name: 'wallet_connect_action';
-  contractName: string;
-  contractAddress: string;
-  functionName: string;
+  notice?: string;
   verified: boolean;
   decoded: boolean;
-  inputs: Array<{
-    name: string;
-    type: string;
-    notice?: string;
-    value: object | string | BigNumber;
-  }>;
-  value?: string;
   // considering we have the raw action directly from WC, there
   // is no need to decode it, re-encode it, only to decode it again
   // when displaying on the proposal details page

--- a/packages/web-app/src/utils/types.ts
+++ b/packages/web-app/src/utils/types.ts
@@ -323,6 +323,8 @@ export type ActionWC = {
   contractName: string;
   contractAddress: string;
   functionName: string;
+  verified: boolean;
+  decoded: boolean;
   inputs: Array<{
     name: string;
     type: string;
@@ -330,6 +332,11 @@ export type ActionWC = {
     value: object | string | BigNumber;
   }>;
   value?: string;
+  // considering we have the raw action directly from WC, there
+  // is no need to decode it, re-encode it, only to decode it again
+  // when displaying on the proposal details page
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  raw?: any;
 };
 
 // TODO: Consider making this a generic type that take other types of the form
@@ -444,6 +451,7 @@ export interface Input {
   components?: Input[];
   internalType?: string;
   notice?: string;
+  value?: string;
 }
 
 export type SmartContract = {


### PR DESCRIPTION
## Description

- Adds an Action Builder card for the WC action
- Reuses card in Execution Widget for WC action
- Allows proposal creation with WC action
- Decodes WC action

NOTE: Can use Uniswap or AAVE app for testing

~~This PR's branched off of #908 and will rebased once that has been merged~~

TODO: 
- [x] Merge SCC and WC decoding and Execution Widget Card 
- [ ] Missing translation strings

 
Task: [APP-2264](https://aragonassociation.atlassian.net/browse/APP-2264)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2264]: https://aragonassociation.atlassian.net/browse/APP-2264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ