### PR TITLE
Chore: APP-2308 - Bump SDK to v 1.9.5

### DIFF
--- a/packages/web-app/package.json
+++ b/packages/web-app/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.5.8",
-    "@aragon/sdk-client": "^1.9.2",
+    "@aragon/sdk-client": "^1.9.5",
     "@aragon/ui-components": "^0.1.0",
     "@elastic/apm-rum-react": "^1.3.1",
     "@radix-ui/react-accordion": "^0.1.6",

--- a/packages/web-app/src/hooks/useDaoToken.tsx
+++ b/packages/web-app/src/hooks/useDaoToken.tsx
@@ -1,9 +1,5 @@
+import {Erc20TokenDetails, Erc20WrapperTokenDetails} from '@aragon/sdk-client';
 import {useEffect, useState} from 'react';
-import {
-  TokenVotingClient,
-  Erc20TokenDetails,
-  Erc20WrapperTokenDetails,
-} from '@aragon/sdk-client';
 
 import {HookData} from 'utils/types';
 import {usePluginClient} from './usePluginClient';
@@ -17,9 +13,7 @@ export function useDaoToken(
   const [error, setError] = useState<Error>();
   const [isLoading, setIsLoading] = useState(false);
 
-  const pluginClient = usePluginClient(
-    'token-voting.plugin.dao.eth'
-  ) as TokenVotingClient;
+  const pluginClient = usePluginClient('token-voting.plugin.dao.eth');
 
   useEffect(() => {
     async function getDaoMetadata() {
@@ -27,22 +21,12 @@ export function useDaoToken(
         setIsLoading(true);
 
         const response = await pluginClient?.methods.getToken(pluginAddress);
+
         if (response) {
-          const underlyingToken = (
-            response as Erc20WrapperTokenDetails | undefined
-          )?.underlyingToken;
-
-          const finalResponse = response as Erc20TokenDetails;
-
-          setData({
-            ...finalResponse,
-            decimals: underlyingToken
-              ? underlyingToken.decimals
-              : finalResponse.decimals,
-          });
+          setData(response as Erc20TokenDetails | Erc20WrapperTokenDetails);
         }
       } catch (err) {
-        console.error(err);
+        console.error('Error fetching DAO token', err);
         setError(err as Error);
       } finally {
         setIsLoading(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,10 +40,10 @@
   dependencies:
     ethers "^5.6.2"
 
-"@aragon/sdk-client-common@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@aragon/sdk-client-common/-/sdk-client-common-1.0.2.tgz#60dff32338f1928b2b635f93104a6053de925966"
-  integrity sha512-UZfOSMdimSlPFS0tzbprG7E5GZ/pwkf83YL15VL78IZXcTjkl7Ivw7WxFP2pZd8tqP3L+B0B3bIojbq9M9l/MQ==
+"@aragon/sdk-client-common@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@aragon/sdk-client-common/-/sdk-client-common-1.1.0.tgz#de2107b54a9fbd0062a2474e79069fae13e7f879"
+  integrity sha512-I85LdR/F6Laat9p0fhmvanDcJcnna60fz1h0Papck9I/N2X6RybhO761K+UDWY0qlF6Tcn+5OWcUWZ0juBaRXQ==
   dependencies:
     "@aragon/osx-ethers" "^1.2.1"
     "@aragon/sdk-common" "^1.5.0"
@@ -57,13 +57,13 @@
     graphql "^16.5.0"
     graphql-request "^4.3.0"
 
-"@aragon/sdk-client@^1.9.2":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@aragon/sdk-client/-/sdk-client-1.9.2.tgz#604bfd1062f3839c3052d504b1ed5cd653a5060f"
-  integrity sha512-cujARZ40gngy4RIvN2mg5QV6GxBQWG7/nawgYHD+fTmHJ6a2Z4wy2pfl9stwG2Y4DPK2Cq8+UO/q7NOojN0hlA==
+"@aragon/sdk-client@^1.9.5":
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/@aragon/sdk-client/-/sdk-client-1.9.5.tgz#be03ccf1d8f6e710dfe984feb03bf9acfe105098"
+  integrity sha512-F/2jtuhcIJYOmvGrSV1aVIDGWTZeOgGw2/FgyQfLvRI6ZNo5BWyiYhu3yXDemaPpnySI8Nuw3X6OdjxYCOY1PQ==
   dependencies:
     "@aragon/osx-ethers" "^1.2.1"
-    "@aragon/sdk-client-common" "^1.0.2"
+    "@aragon/sdk-client-common" "^1.1.0"
     "@aragon/sdk-common" "^1.5.0"
     "@aragon/sdk-ipfs" "^1.1.0"
     "@ethersproject/abstract-signer" "^5.5.0"


### PR DESCRIPTION
## Description
- bumps to latest version of SDK
- removes workaround for adding decimals to a wrapped governance token

Task: [APP-2308](https://aragonassociation.atlassian.net/browse/APP-2308)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2308]: https://aragonassociation.atlassian.net/browse/APP-2308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ