### PR TITLE
fix: APP-2253 removed scroll from modals and bottom sheet components

### DIFF
--- a/packages/ui-components/src/components/backdrop/backdrop.tsx
+++ b/packages/ui-components/src/components/backdrop/backdrop.tsx
@@ -29,13 +29,6 @@ export const Backdrop: React.FC<BackdropProps> = ({
 
   useEffect(() => {
     const html = document.querySelector('html');
-    return () => {
-      if (html) html.style.overflow = 'auto';
-    };
-  }, []);
-
-  useEffect(() => {
-    const html = document.querySelector('html');
     if (!html) return;
     html.style.overflow = visible ? 'hidden' : 'auto';
   }, [visible]);
@@ -70,11 +63,12 @@ type StyledBackdropProps = {
   visible: boolean;
 };
 
-const StyledBackdrop = styled.div.attrs(({visible}: StyledBackdropProps) => {
+export const BackdropStyles = ({visible}: {visible: boolean}) => {
   const className: string = visible
     ? 'visible opacity-100 z-20'
     : 'invisible opacity-0';
-  const style: CSSProperties = {
+
+  const css: CSSProperties = {
     position: 'fixed',
     top: 0,
     left: 0,
@@ -88,5 +82,10 @@ const StyledBackdrop = styled.div.attrs(({visible}: StyledBackdropProps) => {
     marginTop: 0,
   };
 
-  return {className, style};
+  return {className, css};
+};
+
+const StyledBackdrop = styled.div.attrs(({visible}: StyledBackdropProps) => {
+  const {className, css} = BackdropStyles({visible});
+  return {className, style: css};
 })<StyledBackdropProps>``;

--- a/packages/ui-components/src/components/backdrop/backdrop.tsx
+++ b/packages/ui-components/src/components/backdrop/backdrop.tsx
@@ -1,4 +1,4 @@
-import React, {ReactNode} from 'react';
+import React, {ReactNode, useEffect} from 'react';
 import styled, {CSSProperties} from 'styled-components';
 
 export interface BackdropProps {
@@ -26,6 +26,34 @@ export const Backdrop: React.FC<BackdropProps> = ({
   ...props
 }) => {
   // TODO:Implement Backdrop to use as wrapper
+
+  useEffect(() => {
+    const html = document.querySelector('html');
+    return () => {
+      if (html) html.style.overflow = 'auto';
+    };
+  }, []);
+
+  useEffect(() => {
+    const html = document.querySelector('html');
+    if (!html) return;
+    html.style.overflow = visible ? 'hidden' : 'auto';
+  }, [visible]);
+
+  useEffect(() => {
+    function lockScrollOnResize() {
+      const html = document.querySelector('html');
+      if (!visible || !html) return;
+      html.style.overflow = 'hidden';
+    }
+
+    window?.addEventListener?.('resize', lockScrollOnResize);
+
+    return () => {
+      window?.removeEventListener?.('resize', lockScrollOnResize);
+    };
+  }, [visible]);
+
   return (
     <StyledBackdrop
       data-testid="backdrop-container"

--- a/packages/ui-components/src/components/modal/modal.tsx
+++ b/packages/ui-components/src/components/modal/modal.tsx
@@ -1,7 +1,14 @@
 import React, {ReactNode, CSSProperties} from 'react';
 import styled from 'styled-components';
-import {Root, Title, Content, Close, Portal} from '@radix-ui/react-dialog';
-import {Backdrop} from '../backdrop';
+import {
+  Root,
+  Title,
+  Content,
+  Close,
+  Portal,
+  Overlay,
+} from '@radix-ui/react-dialog';
+import {BackdropStyles} from '../backdrop';
 import {IconClose} from '../icons';
 
 export interface ModalProps {
@@ -52,7 +59,7 @@ export const Modal: React.FC<ModalProps> = ({
     <>
       <Root open={isOpen}>
         <Portal>
-          <Backdrop visible={isOpen} />
+          <ModalOverlay />
           <ModalContainer
             data-testid="modal-content"
             onInteractOutside={onInteractOutside}
@@ -124,4 +131,9 @@ const ModalSubtitle = styled.div.attrs({
 const ModalClose = styled(Close).attrs({
   className:
     'flex-shrink-0 text-ui-500 w-4 h-4 rounded-lg bg-ui-50 outline:none',
+})``;
+
+const ModalOverlay = styled(Overlay).attrs(() => {
+  const {className, css} = BackdropStyles({visible: true});
+  return {className, style: css};
 })``;


### PR DESCRIPTION
## Description

When popup modals are displayed, background page is still scrollable.

Task: [APP-2253](https://aragonassociation.atlassian.net/browse/APP-2253)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2253]: https://aragonassociation.atlassian.net/browse/APP-2253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ