### PR TITLE
Fix: FL-2279 - Fix Docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,5 @@ Dockerfile
 .dockerignore
 node_modules
 npm-debug.log
-dist
 .next
 build


### PR DESCRIPTION
## Description

Update the `.dockerignore` file to fix the Docker image build (see failed action [here](https://github.com/aragon/app/actions/runs/5576100161/jobs/10186901652)).   

As the `dist` folder is currently under the `.dockerignore` file, it is not visible by the docker file. This also means that the `.dockerignore` file has been pretty useless so far, I would remove it to avoid such issues in the future.

Task: [APP-2279](https://aragonassociation.atlassian.net/browse/APP-2279)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2279]: https://aragonassociation.atlassian.net/browse/APP-2279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ