### PR TITLE
Fix: APP-2359 - Improve stability of DAO WalletConnect connections

### DIFF
--- a/src/containers/walletConnect/actionListenerModal/index.tsx
+++ b/src/containers/walletConnect/actionListenerModal/index.tsx
@@ -54,9 +54,7 @@ const ActionListenerModal: React.FC<Props> = ({
     [actionsReceived]
   );
 
-  const {wcDisconnect} = useWalletConnectInterceptor({
-    onActionRequest,
-  });
+  const {wcDisconnect} = useWalletConnectInterceptor({onActionRequest});
 
   /*************************************************
    *             Callbacks and Handlers            *

--- a/src/containers/walletConnect/actionListenerModal/index.tsx
+++ b/src/containers/walletConnect/actionListenerModal/index.tsx
@@ -1,6 +1,6 @@
 import {AvatarDao, ButtonText, Spinner, Tag} from '@aragon/ods';
 import {SessionTypes} from '@walletconnect/types';
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useState} from 'react';
 import {useFormContext} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
@@ -54,7 +54,7 @@ const ActionListenerModal: React.FC<Props> = ({
     [actionsReceived]
   );
 
-  const {wcDisconnect, activeSessions} = useWalletConnectInterceptor({
+  const {wcDisconnect} = useWalletConnectInterceptor({
     onActionRequest,
   });
 
@@ -176,16 +176,6 @@ const ActionListenerModal: React.FC<Props> = ({
     setValue,
     t,
   ]);
-
-  // Go to previous step if session is terminated on the dApp
-  useEffect(() => {
-    const isSelectedSessionActive =
-      activeSessions.find(({topic}) => topic === selectedSession.topic) != null;
-
-    if (!isSelectedSessionActive && isOpen) {
-      onBackButtonClicked();
-    }
-  }, [activeSessions, selectedSession, onBackButtonClicked, isOpen]);
 
   /*************************************************
    *                     Render                    *

--- a/src/containers/walletConnect/actionListenerModal/index.tsx
+++ b/src/containers/walletConnect/actionListenerModal/index.tsx
@@ -1,6 +1,6 @@
 import {AvatarDao, ButtonText, Spinner, Tag} from '@aragon/ods';
 import {SessionTypes} from '@walletconnect/types';
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {useFormContext} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
@@ -54,7 +54,9 @@ const ActionListenerModal: React.FC<Props> = ({
     [actionsReceived]
   );
 
-  const {wcDisconnect} = useWalletConnectInterceptor({onActionRequest});
+  const {wcDisconnect, activeSessions} = useWalletConnectInterceptor({
+    onActionRequest,
+  });
 
   /*************************************************
    *             Callbacks and Handlers            *
@@ -174,6 +176,16 @@ const ActionListenerModal: React.FC<Props> = ({
     setValue,
     t,
   ]);
+
+  // Go to previous step if session is terminated on the dApp
+  useEffect(() => {
+    const isSelectedSessionActive =
+      activeSessions.find(({topic}) => topic === selectedSession.topic) != null;
+
+    if (!isSelectedSessionActive && isOpen) {
+      onBackButtonClicked();
+    }
+  }, [activeSessions, selectedSession, onBackButtonClicked, isOpen]);
 
   /*************************************************
    *                     Render                    *

--- a/src/containers/walletConnect/dAppValidationModal/index.tsx
+++ b/src/containers/walletConnect/dAppValidationModal/index.tsx
@@ -129,20 +129,22 @@ const WCdAppValidation: React.FC<Props> = props => {
     }
   }, [uri, wcConnect]);
 
-  // Update connectionStatus to SUCCESS as soon as the connection is established and the session
-  // with the connection topic is returned as active session
+  // Update connectionStatus to SUCCESS when the session is active and acknowledged or reset
+  // the connection state if the session has been terminated on the dApp
   useEffect(() => {
-    if (
-      connectionStatus === ConnectionState.LOADING &&
-      currentSession != null
-    ) {
+    const isLoading = connectionStatus === ConnectionState.LOADING;
+    const isSuccess = connectionStatus === ConnectionState.SUCCESS;
+
+    if (isLoading && currentSession != null) {
       setConnectionStatus(
         currentSession.acknowledged
           ? ConnectionState.SUCCESS
           : ConnectionState.ERROR
       );
+    } else if (isSuccess && currentSession == null) {
+      resetConnectionState();
     }
-  }, [connectionStatus, currentSession]);
+  }, [connectionStatus, currentSession, resetConnectionState]);
 
   const disableCta =
     uri == null ||

--- a/src/containers/walletConnect/dAppValidationModal/index.tsx
+++ b/src/containers/walletConnect/dAppValidationModal/index.tsx
@@ -185,7 +185,7 @@ const WCdAppValidation: React.FC<Props> = props => {
                 name={name}
                 onBlur={onBlur}
                 onChange={onChange}
-                value={value}
+                value={value ?? ''}
                 placeholder={t('wc.validation.codeInputPlaceholder')}
                 adornmentText={adornmentText}
                 onAdornmentClick={() => handleAdornmentClick(value, onChange)}

--- a/src/containers/walletConnect/index.tsx
+++ b/src/containers/walletConnect/index.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {useFormContext} from 'react-hook-form';
 import {SessionTypes} from '@walletconnect/types';
 
@@ -83,6 +83,21 @@ const WalletConnect: React.FC<WalletConnectProps> = ({actionIndex}) => {
     },
     [resetField]
   );
+
+  // Close listeningActions modal when session is terminated on the dApp
+  useEffect(() => {
+    if (!selectedSession) {
+      return;
+    }
+
+    const isSelectedSessionActive =
+      activeSessions.find(({topic}) => topic === selectedSession.topic) != null;
+
+    if (!isSelectedSessionActive) {
+      setSelectedSession(undefined);
+      setListeningActionsIsOpen(false);
+    }
+  }, [activeSessions, selectedSession]);
 
   /*************************************************
    *                     Render                    *

--- a/src/hooks/useWalletConnectInterceptor.ts
+++ b/src/hooks/useWalletConnectInterceptor.ts
@@ -92,7 +92,7 @@ export function useWalletConnectInterceptor({
     if (activeSessionsListeners.size > 0) {
       return;
     }
-    console.log('add listeners');
+
     walletConnectInterceptor.subscribeConnectProposal(handleApprove);
     walletConnectInterceptor.subscribeRequest(handleRequest);
     walletConnectInterceptor.subscribeDisconnect(updateActiveSessions);
@@ -102,7 +102,7 @@ export function useWalletConnectInterceptor({
     if (activeSessionsListeners.size > 0) {
       return;
     }
-    console.log('remove listeners');
+
     walletConnectInterceptor.unsubscribeConnectProposal(handleApprove);
     walletConnectInterceptor.unsubscribeRequest(handleRequest);
     walletConnectInterceptor.unsubscribeDisconnect(updateActiveSessions);

--- a/src/hooks/useWalletConnectInterceptor.ts
+++ b/src/hooks/useWalletConnectInterceptor.ts
@@ -30,8 +30,9 @@ export function useWalletConnectInterceptor({
   const prevNetwork = usePrevious(network);
 
   const {data: daoDetails} = useDaoDetailsQuery();
-
-  const [sessions, setSessions] = useState<WcSession[]>([]);
+  const [sessions, setSessions] = useState<WcSession[]>(
+    walletConnectInterceptor.getActiveSessions(daoDetails?.address)
+  );
   const activeSessions = sessions.filter(session => session.acknowledged);
 
   const updateActiveSessions = useCallback(() => {
@@ -41,7 +42,7 @@ export function useWalletConnectInterceptor({
 
     // Update active-sessions for all hook instances
     activeSessionsListeners.forEach(listener => listener(newSessions));
-  }, [daoDetails]);
+  }, [daoDetails?.address]);
 
   const wcConnect = useCallback(async ({onError, uri}: WcConnectOptions) => {
     try {
@@ -75,12 +76,7 @@ export function useWalletConnectInterceptor({
 
       updateActiveSessions();
     },
-    [daoDetails, updateActiveSessions]
-  );
-
-  const handleConnectProposal = useCallback(
-    async (event: Web3WalletTypes.SessionProposal) => handleApprove(event),
-    [handleApprove]
+    [daoDetails?.address, updateActiveSessions]
   );
 
   const handleRequest = useCallback(
@@ -92,45 +88,36 @@ export function useWalletConnectInterceptor({
     [network, onActionRequest]
   );
 
-  const handleDisconnect = useCallback(
-    (event: Web3WalletTypes.SessionDelete) => wcDisconnect(event.topic),
-    [wcDisconnect]
-  );
+  const addListeners = useCallback(() => {
+    if (activeSessionsListeners.size > 0) {
+      return;
+    }
+    console.log('add listeners');
+    walletConnectInterceptor.subscribeConnectProposal(handleApprove);
+    walletConnectInterceptor.subscribeRequest(handleRequest);
+    walletConnectInterceptor.subscribeDisconnect(updateActiveSessions);
+  }, [handleApprove, handleRequest, updateActiveSessions]);
 
+  const removeListeners = useCallback(() => {
+    if (activeSessionsListeners.size > 0) {
+      return;
+    }
+    console.log('remove listeners');
+    walletConnectInterceptor.unsubscribeConnectProposal(handleApprove);
+    walletConnectInterceptor.unsubscribeRequest(handleRequest);
+    walletConnectInterceptor.unsubscribeDisconnect(updateActiveSessions);
+  }, [handleApprove, handleRequest, updateActiveSessions]);
+
+  // Listen for active-session changes and subscribe / unsubscribe to client changes
   useEffect(() => {
+    addListeners();
     activeSessionsListeners.add(setSessions);
 
     return () => {
       activeSessionsListeners.delete(setSessions);
+      removeListeners();
     };
-  }, []);
-
-  // Initialize active sessions
-  useEffect(() => {
-    updateActiveSessions();
-  }, [updateActiveSessions]);
-
-  useEffect(() => {
-    walletConnectInterceptor.subscribeConnectProposal(handleConnectProposal);
-
-    return () =>
-      walletConnectInterceptor.unsubscribeConnectProposal(
-        handleConnectProposal
-      );
-  }, [handleConnectProposal]);
-
-  useEffect(() => {
-    walletConnectInterceptor.subscribeRequest(handleRequest);
-
-    return () => walletConnectInterceptor.unsubscribeRequest(handleRequest);
-  }, [handleRequest]);
-
-  useEffect(() => {
-    walletConnectInterceptor.subscribeDisconnect(handleDisconnect);
-
-    return () =>
-      walletConnectInterceptor.unsubscribeDisconnect(handleDisconnect);
-  }, [handleDisconnect]);
+  }, [addListeners, removeListeners]);
 
   useEffect(() => {
     if (prevNetwork === network) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,7 +48,17 @@ const wagmiConfig = createConfig({
 const ethereumClient = new EthereumClient(wagmiConfig, chains);
 
 // React-Query client
-export const queryClient = new QueryClient();
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      cacheTime: 1000 * 60 * 5, // 5min
+      staleTime: 1000 * 30, // 30sec
+      retry: 0,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: true,
+    },
+  },
+});
 
 const CACHE_VERSION = 1;
 const onLoad = () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -52,7 +52,7 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       cacheTime: 1000 * 60 * 5, // 5min
-      staleTime: 1000 * 30, // 30sec
+      staleTime: 1000 * 60 * 2, // 2min
       retry: 0,
       refetchOnWindowFocus: false,
       refetchOnReconnect: true,


### PR DESCRIPTION
## Description
 
- Handle session being terminated from the dApp on the dApp-validation modal
- Fix warning of wc-input field switching from controlled to uncontrolled state
- Handle session being terminated from the dApp on the listening-action modal
- Only add one instance of wc-client listeners to avoid multiple connection approvals
- Update query-client options to avoid redundant query refetch and re-renders

Task: [APP-2359](https://aragonassociation.atlassian.net/browse/APP-2359)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.

[APP-2359]: https://aragonassociation.atlassian.net/browse/APP-2359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ