### PR TITLE
Add wizard skip step feature

### DIFF
--- a/src/components/fullScreenStepper/fullScreenStepper.tsx
+++ b/src/components/fullScreenStepper/fullScreenStepper.tsx
@@ -50,9 +50,7 @@ export const FullScreenStepper: React.FC<FullScreenStepperProps> = ({
   navLabel,
   returnPath,
 }) => {
-  const skipSteps = useMemo(() => {
-    return children.filter(child => child.props.skipStep !== true);
-  }, [children]);
+  const skipSteps = children.filter(child => child.props.skipStep !== true);
 
   const {t} = useTranslation();
   const navigate = useNavigate();

--- a/src/components/fullScreenStepper/fullScreenStepper.tsx
+++ b/src/components/fullScreenStepper/fullScreenStepper.tsx
@@ -50,11 +50,15 @@ export const FullScreenStepper: React.FC<FullScreenStepperProps> = ({
   navLabel,
   returnPath,
 }) => {
+  const skipSteps = useMemo(() => {
+    return children.filter(child => child.props.skipStep !== true);
+  }, [children]);
+
   const {t} = useTranslation();
   const navigate = useNavigate();
 
   const [showExitProcessMenu, setShowExitProcessMenu] = useState(false);
-  const {currentStep, prev, next, setStep} = useStepper(children.length);
+  const {currentStep, prev, next, setStep} = useStepper(skipSteps.length);
 
   const currentIndex = currentStep - 1;
   const {
@@ -71,23 +75,23 @@ export const FullScreenStepper: React.FC<FullScreenStepperProps> = ({
     onBackButtonClicked,
     onNextButtonClicked,
     onNextButtonDisabledClicked,
-  } = children[currentIndex].props;
+  } = skipSteps[currentIndex].props;
 
   const totalSteps = useMemo(() => {
     let total = 0;
-    children.forEach((_, index) => {
-      if (!children[index].props.hideWizard) total++;
+    skipSteps.forEach((_, index) => {
+      if (!skipSteps[index].props.hideWizard) total++;
     });
     return total;
-  }, [children]);
+  }, [skipSteps]);
 
   const previousHideWizards = useMemo(() => {
     let total = 0;
     for (let i = 0; i < currentStep; i++) {
-      children[i].props.hideWizard && total++;
+      skipSteps[i].props.hideWizard && total++;
     }
     return total;
-  }, [children, currentStep]);
+  }, [skipSteps, currentStep]);
 
   const value = {currentStep, setStep, prev, next};
 
@@ -156,7 +160,7 @@ export const FullScreenStepper: React.FC<FullScreenStepperProps> = ({
             })}
         </div>
         <FormLayout fullWidth={fullWidth || false}>
-          {children[currentIndex]}
+          {skipSteps[currentIndex]}
           {customFooter ? (
             <>{customFooter}</>
           ) : (

--- a/src/components/fullScreenStepper/step.tsx
+++ b/src/components/fullScreenStepper/step.tsx
@@ -5,6 +5,7 @@ export type StepProps = {
   wizardTitle?: string;
   wizardDescription?: string | React.ReactNode;
   hideWizard?: boolean;
+  skipStep?: boolean;
   fullWidth?: boolean;
   customHeader?: ReactElement;
   customFooter?: ReactElement;


### PR DESCRIPTION
## Description

It adds a `skipStep` feature on the wizard. 

This is due to the necessity to have conditional steps. For example, a step that is shown depending of previous choices on precedent steps. 

The `Step` `hideWizard` attribute doesn't fit this necessity because the step was not count on the total steps top bar, but is shown anyway when next button clicked. This is because the `hideWizard` property objective is to not to count a step but show it anyway, for example, when the last step is used to review all form data. 

Now, if you add the `skipStep={true}` the step won't be count and neither will be shown. 

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the test network.
