### PR TITLE
Fix: APP-2417 - Correctly display WalletConnect actions

### DIFF
--- a/src/containers/actionBuilder/walletConnect/index.tsx
+++ b/src/containers/actionBuilder/walletConnect/index.tsx
@@ -1,6 +1,6 @@
 import {ListItemAction} from '@aragon/ods';
 import React from 'react';
-import {useWatch} from 'react-hook-form';
+import {useFormContext} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 
 import {WCActionCard} from 'components/executionWidget/actions/walletConnectActionCard';
@@ -14,8 +14,9 @@ const WalletConnectAction: React.FC<ActionIndex & {allowRemove?: boolean}> = ({
 }) => {
   const {t} = useTranslation();
   const {alert} = useAlertContext();
+  const {watch} = useFormContext();
 
-  const [actionData] = useWatch({name: [`actions.${actionIndex}`]});
+  const actionData = watch(`actions.${actionIndex}`);
   const {removeAction} = useActionsContext();
 
   const methodActions = (() => {

--- a/src/containers/walletConnect/actionListenerModal/index.tsx
+++ b/src/containers/walletConnect/actionListenerModal/index.tsx
@@ -84,7 +84,7 @@ const ActionListenerModal: React.FC<Props> = ({
       );
 
       // increment the index so multiple actions can be added at once
-      const index = actionIndex + currentIndex;
+      const index = actionIndex + (currentIndex + 1);
 
       // name, raw action and contract address set on every action
       addAction({name: 'wallet_connect_action'});

--- a/src/context/actions.tsx
+++ b/src/context/actions.tsx
@@ -53,36 +53,36 @@ const ActionsProvider: React.FC<ActionsProviderProps> = ({daoId, children}) => {
 
   const removeAction = useCallback(
     (index: number) => {
-      let newActions = actions.filter((_, oldIndex) => oldIndex !== index);
+      setActions(current => {
+        let newActions = current.filter((_, oldIndex) => oldIndex !== index);
 
-      if (
-        // check if there is an update settings with min approval
-        newActions.some(a => a.name === 'modify_multisig_voting_settings') &&
-        // and no add or remove action is present
-        !newActions.some(
-          a => a.name === 'remove_address' || a.name === 'add_address'
-        )
-      ) {
-        const indexOfMinApproval = newActions.findIndex(
-          a => a.name === 'modify_multisig_voting_settings'
-        );
+        if (
+          // check if there is an update settings with min approval
+          newActions.some(a => a.name === 'modify_multisig_voting_settings') &&
+          // and no add or remove action is present
+          !newActions.some(
+            a => a.name === 'remove_address' || a.name === 'add_address'
+          )
+        ) {
+          const indexOfMinApproval = newActions.findIndex(
+            a => a.name === 'modify_multisig_voting_settings'
+          );
 
-        // remove from local context
-        newActions = newActions.filter(
-          (_, oldIndex) => oldIndex !== indexOfMinApproval
-        );
+          // remove from local context
+          newActions = newActions.filter(
+            (_, oldIndex) => oldIndex !== indexOfMinApproval
+          );
 
-        // remove from form
-        remove(indexOfMinApproval);
-      }
+          // remove from form
+          remove(indexOfMinApproval);
+        }
 
-      // update local context
-      setActions(newActions);
+        remove(index);
 
-      // update form actions
-      remove(index);
+        return newActions;
+      });
     },
-    [actions, remove]
+    [remove]
   );
 
   const duplicateAction = useCallback((index: number) => {


### PR DESCRIPTION
## Description

- Use `watch` instead of `useWatch` on `walletConnect/index.tsx` as `useWatch` does not correctly handle dynamic form field names (see [issue](https://github.com/react-hook-form/react-hook-form/issues/9507)) 
- Correctly calculate action index when confirming actions. At the moment of confirming the actions, the `actionIndex` might be for instance `2` and `actionIndex[2] = "wallet_connect_modal"`. When adding one or more wallet connect actions. we need to increate the index by one, so that:
```
actionIndex[2] = "wallet_connect_modal"

{add action 1}
actionIndex[3] = [new action 1]

{add action 2}
actionIndex[4] = [new action 2]

{remove actionIndex}
actionIndex[2] = null
```
- Update `removeAction` callback on `context/actions.tsx` to make sure it uses the most updated actions. As we add and remove actions on the `handleAddActions` async function, when calling the `removeAction` function it will use the outdated actions if we are not using the `setState` through the callback notation.

Task: [APP-2417](https://aragonassociation.atlassian.net/browse/APP-2417)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2417]: https://aragonassociation.atlassian.net/browse/APP-2417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ