### PR TITLE
chore: Remove unused Apollo cache persistor configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@walletconnect/web3wallet": "^1.8.2",
     "@web3modal/ethereum": "^2.4.7",
     "@web3modal/react": "^2.4.7",
-    "apollo3-cache-persist": "^0.14.0",
     "big.js": "^6.2.1",
     "date-fns": "^2.28.0",
     "date-fns-tz": "^2.0.0",

--- a/src/context/apolloClient.tsx
+++ b/src/context/apolloClient.tsx
@@ -1,4 +1,4 @@
-import {InMemoryCache, makeVar} from '@apollo/client';
+import {makeVar} from '@apollo/client';
 import {
   DaoListItem,
   Deposit,
@@ -8,7 +8,6 @@ import {
   VotingMode,
 } from '@aragon/sdk-client';
 import {PluginInstallItem} from '@aragon/sdk-client-common';
-import {CachePersistor, LocalStorageWrapper} from 'apollo3-cache-persist';
 
 import {
   FAVORITE_DAOS_KEY,
@@ -25,68 +24,6 @@ import {
 } from 'utils/constants';
 import {customJSONReviver} from 'utils/library';
 import {DetailedProposal, Erc20ProposalVote} from 'utils/types';
-import {PRIVACY_KEY} from './privacyContext';
-
-const cache = new InMemoryCache();
-
-// add the REST API's typename you want to persist here
-const entitiesToPersist = ['tokenData'];
-
-// check if cache should be persisted or restored based on user preferences
-const value = localStorage.getItem(PRIVACY_KEY);
-if (value && JSON.parse(value).functional) {
-  const persistor = new CachePersistor({
-    cache,
-    // TODO: Check and update the size needed for the cache
-    maxSize: 5242880, // 5 MiB
-    storage: new LocalStorageWrapper(window.localStorage),
-    debug: process.env.NODE_ENV === 'development',
-    persistenceMapper: async (data: string) => {
-      const parsed = JSON.parse(data);
-
-      const mapped: Record<string, unknown> = {};
-      const persistEntities: string[] = [];
-      const rootQuery = parsed['ROOT_QUERY'];
-
-      mapped['ROOT_QUERY'] = Object.keys(rootQuery).reduce(
-        (obj: Record<string, unknown>, key: string) => {
-          if (key === '__typename') return obj;
-
-          const keyWithoutArgs = key.substring(0, key.indexOf('('));
-          if (entitiesToPersist.includes(keyWithoutArgs)) {
-            obj[key] = rootQuery[key];
-
-            if (Array.isArray(rootQuery[key])) {
-              const entities = rootQuery[key].map(
-                (item: Record<string, unknown>) => item.__ref
-              );
-              persistEntities.push(...entities);
-            } else {
-              const entity = rootQuery[key].__ref;
-              persistEntities.push(entity);
-            }
-          }
-
-          return obj;
-        },
-        {__typename: 'Query'}
-      );
-
-      persistEntities.reduce((obj, key) => {
-        obj[key] = parsed[key];
-        return obj;
-      }, mapped);
-
-      return JSON.stringify(mapped);
-    },
-  });
-
-  const restoreApolloCache = async () => {
-    await persistor.restore();
-  };
-
-  restoreApolloCache();
-}
 
 /*************************************************
  *            FAVORITE & SELECTED DAOS           *

--- a/yarn.lock
+++ b/yarn.lock
@@ -5989,11 +5989,6 @@ apollo-utilities@^1.3.4:
     ts-invariant "^0.4.0"
     tslib "^1.10.0"
 
-apollo3-cache-persist@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/apollo3-cache-persist/-/apollo3-cache-persist-0.14.0.tgz#457519f548698fb1e70f99d81e59652fc289ab19"
-  integrity sha512-jT3wkB3IJGNyK1XTtS2WbaAyD/Z9Z4HuFEsU0kIpYceqdtT8gV1kNSX+4YMBt0XgS954zMKY6cs8Q4zt7NNPeQ==
-
 append-transform@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-2.0.0.tgz#99d9d29c7b38391e6f428d28ce136551f0b77e12"


### PR DESCRIPTION
## Description

- This configuration was used when the application was fetching the tokens through Apollo client. We now use React Query to fetch such data and this configuration has currently no effect.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.
