### PR TITLE
Feat: APP-2369 - Add entry points to delegation flow

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -29,6 +29,7 @@ import {DelegateVotingMenu} from 'containers/delegateVotingMenu';
 import '../i18n.config';
 import {ProposalSettingsFormData} from 'utils/types';
 import {GatingMenu} from 'containers/gatingMenu';
+import {DelegationGatingMenu} from 'containers/delegationGatingMenu';
 
 export const App: React.FC = () => {
   // TODO this needs to be inside a Routes component. Will be moved there with
@@ -186,6 +187,7 @@ const DaoWrapper: React.FC = () => {
           <DepositModal />
           <GatingMenu />
           <DelegateVotingMenu />
+          <DelegationGatingMenu />
           {isOpen && <TransactionDetail />}
         </GridLayout>
       </div>

--- a/src/components/protectedRoute/index.tsx
+++ b/src/components/protectedRoute/index.tsx
@@ -75,16 +75,14 @@ const ProtectedRoute: React.FC = () => {
           CHAIN_METADATA[network].nativeCurrency
         );
 
-        const votinPowerWei = await fetchVotingPower({
+        const votingPowerWei = await fetchVotingPower({
           address,
           tokenAddress: daoToken?.address,
         });
-        votingPower = formatUnits(votinPowerWei, daoToken.decimals);
+        votingPower = formatUnits(votingPowerWei, daoToken.decimals);
       } catch (e) {
         console.error(e);
       }
-
-      console.log({balance, votingPower});
 
       const minProposalThreshold = Number(
         formatUnits(

--- a/src/components/stateEmpty/index.tsx
+++ b/src/components/stateEmpty/index.tsx
@@ -17,6 +17,7 @@ type BaseProps = {
   content?: JSX.Element;
   primaryButton?: Omit<ButtonTextProps, 'mode' | 'size'>;
   secondaryButton?: Omit<ButtonTextProps, 'mode' | 'size'>;
+  tertiaryButton?: Omit<ButtonTextProps, 'mode' | 'size'>;
   renderHtml?: boolean;
   actionsColumn?: boolean;
   customCardPaddingClassName?: string;
@@ -81,6 +82,9 @@ export const StateEmpty: React.FC<StateEmptyProps> = props => {
                 size="large"
                 bgWhite={props.secondaryButton.bgWhite ?? true}
               />
+            )}
+            {props.tertiaryButton && (
+              <ButtonText {...props.tertiaryButton} mode="ghost" size="large" />
             )}
           </ActionContainer>
         )}

--- a/src/containers/delegateVotingMenu/delegateVotingForm.tsx
+++ b/src/containers/delegateVotingMenu/delegateVotingForm.tsx
@@ -26,6 +26,7 @@ import {
 } from './delegateVotingUtils';
 
 export interface IDelegateVotingFormProps {
+  initialMode?: 'delegate' | 'reclaim';
   onDelegateTokens: () => void;
   onCancel: () => void;
   status: 'idle' | 'loading' | 'error' | 'success';
@@ -46,7 +47,7 @@ const getDelegateLabel = (
 };
 
 export const DelegateVotingForm: React.FC<IDelegateVotingFormProps> = props => {
-  const {onDelegateTokens, onCancel, status} = props;
+  const {onDelegateTokens, onCancel, initialMode = 'delegate', status} = props;
 
   const {t} = useTranslation();
   const {address, ensName, isOnWrongNetwork} = useWallet();
@@ -58,9 +59,7 @@ export const DelegateVotingForm: React.FC<IDelegateVotingFormProps> = props => {
     name: DelegateVotingFormField.TOKEN_DELEGATE,
     control: control,
   });
-  const [delegateSelection, setDelegateSelection] = useState<
-    'delegate' | 'reclaim'
-  >('delegate');
+  const [delegateSelection, setDelegateSelection] = useState(initialMode);
 
   const {data: daoDetails} = useDaoDetailsQuery();
   const {data: daoToken} = useDaoToken(

--- a/src/containers/delegateVotingMenu/delegateVotingMenu.tsx
+++ b/src/containers/delegateVotingMenu/delegateVotingMenu.tsx
@@ -28,10 +28,15 @@ const formSettings: UseFormProps<IDelegateVotingFormValues> = {
   },
 };
 
+type DelegateVotingMenuState = {
+  reclaimMode?: boolean;
+};
+
 export const DelegateVotingMenu: React.FC = () => {
   const {t} = useTranslation();
   const queryClient = useQueryClient();
-  const {close, open, isDelegateVotingOpen} = useGlobalModalContext();
+  const {close, open, modalState, isDelegateVotingOpen} =
+    useGlobalModalContext<DelegateVotingMenuState>();
 
   const formValues = useForm<IDelegateVotingFormValues>(formSettings);
   const {setValue, control} = formValues;
@@ -45,6 +50,7 @@ export const DelegateVotingMenu: React.FC = () => {
     isModalOpen: isWeb3ModalOpen,
     network,
     address,
+    ensName,
     isOnWrongNetwork,
   } = useWallet();
 
@@ -143,6 +149,17 @@ export const DelegateVotingMenu: React.FC = () => {
     }
   }, [setValue, currentDelegate, currentDelegateEns, address]);
 
+  // Set the token-delegate form field to connected address when the dialog
+  // is opened in reclaim mode
+  useEffect(() => {
+    if (modalState?.reclaimMode && address != null) {
+      setValue(DelegateVotingFormField.TOKEN_DELEGATE, {
+        address,
+        ensName,
+      });
+    }
+  }, [modalState?.reclaimMode, address, ensName, setValue]);
+
   // Open wrong-network menu when user is on the wrong network
   useEffect(() => {
     if (isConnected && isDelegateVotingOpen && isOnWrongNetwork) {
@@ -192,6 +209,7 @@ export const DelegateVotingMenu: React.FC = () => {
             />
           ) : (
             <DelegateVotingForm
+              initialMode={modalState?.reclaimMode ? 'reclaim' : 'delegate'}
               onDelegateTokens={handleDelegateTokens}
               onCancel={handleCloseMenu}
               status={delegationStatus}

--- a/src/containers/delegateVotingMenu/delegateVotingMenu.tsx
+++ b/src/containers/delegateVotingMenu/delegateVotingMenu.tsx
@@ -98,18 +98,18 @@ export const DelegateVotingMenu: React.FC = () => {
     }
   };
 
-  const invalidateDelegateeQuery = () => {
+  const invalidateDelegateQueries = () => {
     const baseParams = {
       address: address as string,
       network: network as SupportedNetworks,
     };
     const params = {tokenAddress: daoToken?.address as string};
-    const queryKey = aragonSdkQueryKeys.delegatee(baseParams, params);
+    const delegateKey = aragonSdkQueryKeys.delegatee(baseParams, params);
     const votingPowerKey = aragonSdkQueryKeys.votingPower({
       address: baseParams.address,
       tokenAddress: daoToken?.address as string,
     });
-    queryClient.invalidateQueries(queryKey);
+    queryClient.invalidateQueries(delegateKey);
     queryClient.invalidateQueries(votingPowerKey);
   };
 
@@ -122,7 +122,7 @@ export const DelegateVotingMenu: React.FC = () => {
       if (step.key === 'delegating') {
         delegateHash = step.txHash;
       } else if (step.key === 'done') {
-        invalidateDelegateeQuery();
+        invalidateDelegateQueries();
         setTxHash(delegateHash);
       }
     }

--- a/src/containers/delegateVotingMenu/delegateVotingMenu.tsx
+++ b/src/containers/delegateVotingMenu/delegateVotingMenu.tsx
@@ -105,7 +105,12 @@ export const DelegateVotingMenu: React.FC = () => {
     };
     const params = {tokenAddress: daoToken?.address as string};
     const queryKey = aragonSdkQueryKeys.delegatee(baseParams, params);
+    const votingPowerKey = aragonSdkQueryKeys.votingPower({
+      address: baseParams.address,
+      tokenAddress: daoToken?.address as string,
+    });
     queryClient.invalidateQueries(queryKey);
+    queryClient.invalidateQueries(votingPowerKey);
   };
 
   const handleDelegateTokensSuccess = async (

--- a/src/containers/delegateVotingMenu/delegateVotingMenu.tsx
+++ b/src/containers/delegateVotingMenu/delegateVotingMenu.tsx
@@ -55,7 +55,7 @@ export const DelegateVotingMenu: React.FC = () => {
     daoDetails?.plugins[0].instanceAddress ?? ''
   );
 
-  const {data: tokenBalance} = useBalance({
+  const {data: tokenBalance, isLoading: isLoadingBalance} = useBalance({
     address: address as Address,
     token: daoToken?.address as Address,
     chainId: CHAIN_METADATA[network as SupportedNetworks].id,
@@ -153,11 +153,23 @@ export const DelegateVotingMenu: React.FC = () => {
 
   // Open gating menu when user has no tokens for this DAO
   useEffect(() => {
-    if (isConnected && isDelegateVotingOpen && tokenBalance?.value === 0n) {
+    if (
+      isConnected &&
+      isDelegateVotingOpen &&
+      !isLoadingBalance &&
+      tokenBalance?.value === 0n
+    ) {
       open('gating');
       close('delegateVoting');
     }
-  }, [isConnected, tokenBalance?.value, isDelegateVotingOpen, close, open]);
+  }, [
+    isConnected,
+    tokenBalance?.value,
+    isLoadingBalance,
+    isDelegateVotingOpen,
+    close,
+    open,
+  ]);
 
   if (!isConnected && isDelegateVotingOpen) {
     return <LoginRequired isOpen={true} onClose={handleCloseLogin} />;

--- a/src/containers/delegateVotingMenu/delegateVotingSuccess.tsx
+++ b/src/containers/delegateVotingMenu/delegateVotingSuccess.tsx
@@ -46,8 +46,8 @@ export const DelegateVotingSuccess: React.FC<IDelegateVotingSuccessProps> =
 
     const tokenAmount = abbreviateTokenAmount(tokenBalance);
 
-    const daoName =
-      toDisplayEns(daoDetails?.ensDomain) ?? (daoDetails?.address as string);
+    const daoEns = toDisplayEns(daoDetails?.ensDomain);
+    const daoName = daoEns !== '' ? daoEns : daoDetails?.address;
 
     const handleCommunityClick = () => {
       const pathParams = {network, dao: daoName};

--- a/src/containers/delegationGatingMenu/delegationGatingMenu.tsx
+++ b/src/containers/delegationGatingMenu/delegationGatingMenu.tsx
@@ -2,7 +2,7 @@ import ModalBottomSheetSwitcher from 'components/modalBottomSheetSwitcher';
 import {useGlobalModalContext} from 'context/globalModals';
 import styled from 'styled-components';
 import React from 'react';
-import {Trans, useTranslation} from 'react-i18next';
+import {useTranslation} from 'react-i18next';
 import {ButtonText, IllustrationHuman, shortenAddress} from '@aragon/ods';
 import {useDaoDetailsQuery} from 'hooks/useDaoDetails';
 import {useDaoToken} from 'hooks/useDaoToken';
@@ -76,17 +76,13 @@ export const DelegationGatingMenu: React.FC = () => {
           <p className="text-xl text-ui-800">
             {t(`modal.${delegationLabel}.title`)}
           </p>
-          <Trans
-            className="text-ui-600"
-            i18nKey={`modal.${delegationLabel}.desc`}
-            components={{b: <strong />}}
-            parent={props => <p {...props} />}
-            values={{
+          <p className="text-ui-600">
+            {t(`modal.${delegationLabel}.desc`, {
               balance: tokenAmount,
               tokenSymbol: daoToken?.symbol,
               walletAddressDelegation: delegateName,
-            }}
-          ></Trans>
+            })}
+          </p>
         </ContentGroup>
         <ContentGroup>
           <ButtonText

--- a/src/containers/delegationGatingMenu/delegationGatingMenu.tsx
+++ b/src/containers/delegationGatingMenu/delegationGatingMenu.tsx
@@ -1,0 +1,110 @@
+import ModalBottomSheetSwitcher from 'components/modalBottomSheetSwitcher';
+import {useGlobalModalContext} from 'context/globalModals';
+import styled from 'styled-components';
+import React from 'react';
+import {Trans, useTranslation} from 'react-i18next';
+import {ButtonText, IllustrationHuman, shortenAddress} from '@aragon/ods';
+import {useDaoDetailsQuery} from 'hooks/useDaoDetails';
+import {useDaoToken} from 'hooks/useDaoToken';
+import {Address, useBalance, useEnsName} from 'wagmi';
+import {CHAIN_METADATA, SupportedNetworks} from 'utils/constants';
+import {useDelegatee} from 'services/aragon-sdk/queries/use-delegatee';
+import {abbreviateTokenAmount} from 'utils/tokens';
+import {useWallet} from 'hooks/useWallet';
+
+export const DelegationGatingMenu: React.FC = () => {
+  const {t} = useTranslation();
+  const {isDelegationGatingOpen, close, open} = useGlobalModalContext();
+
+  const {network, address} = useWallet();
+
+  const {data: daoDetails} = useDaoDetailsQuery();
+  const {data: daoToken} = useDaoToken(
+    daoDetails?.plugins[0].instanceAddress ?? ''
+  );
+
+  const {data: tokenBalance} = useBalance({
+    address: address as Address,
+    token: daoToken?.address as Address,
+    chainId: CHAIN_METADATA[network as SupportedNetworks].id,
+    enabled: address != null && daoToken != null,
+  });
+
+  const tokenAmount = abbreviateTokenAmount(tokenBalance?.formatted ?? '0');
+
+  const {data: delegateData} = useDelegatee(
+    {tokenAddress: daoToken?.address as string},
+    {enabled: daoToken != null}
+  );
+  const isDelegationActive =
+    delegateData !== '0x0000000000000000000000000000000000000000';
+  // The useDelegatee hook returns null when current delegate is connected address
+  const currentDelegate =
+    delegateData === null ? (address as string) : delegateData;
+
+  const {data: delegateEns} = useEnsName({
+    address: currentDelegate as Address,
+    enabled: currentDelegate != null,
+  });
+
+  const delegateName = delegateEns ?? shortenAddress(currentDelegate ?? '');
+  const delegationLabel = isDelegationActive
+    ? 'delegationActive'
+    : 'delegationInactive';
+
+  const handleReclaimClick = () => {
+    close('delegationGating');
+    open('delegateVoting', {reclaimMode: true});
+  };
+
+  return (
+    <ModalBottomSheetSwitcher
+      onClose={() => close('delegationGating')}
+      isOpen={isDelegationGatingOpen}
+      title={t('modal.delegationActive.title')}
+    >
+      <div className="flex flex-col gap-3 py-3 px-2 text-center">
+        <ContentGroup>
+          <IllustrationHuman
+            width={343}
+            height={193}
+            body="elevating"
+            expression="excited"
+            hair="curly"
+            accessory="piercings_tattoo"
+          />
+          <p className="text-xl text-ui-800">
+            {t(`modal.${delegationLabel}.title`)}
+          </p>
+          <Trans
+            className="text-ui-600"
+            i18nKey={`modal.${delegationLabel}.desc`}
+            components={{b: <strong />}}
+            parent={props => <p {...props} />}
+            values={{
+              balance: tokenAmount,
+              tokenSymbol: daoToken?.symbol,
+              walletAddressDelegation: delegateName,
+            }}
+          ></Trans>
+        </ContentGroup>
+        <ContentGroup>
+          <ButtonText
+            label={t('modal.delegationActive.CtaLabel')}
+            mode="primary"
+            size="large"
+            onClick={handleReclaimClick}
+          />
+          <ButtonText
+            label={t('modal.delegationActive.BtnSecondaryLabel')}
+            mode="secondary"
+            size="large"
+            onClick={() => close('delegationGating')}
+          />
+        </ContentGroup>
+      </div>
+    </ModalBottomSheetSwitcher>
+  );
+};
+
+const ContentGroup = styled.div.attrs({className: 'flex flex-col gap-1.5'})``;

--- a/src/containers/delegationGatingMenu/delegationGatingMenu.tsx
+++ b/src/containers/delegationGatingMenu/delegationGatingMenu.tsx
@@ -2,6 +2,7 @@ import ModalBottomSheetSwitcher from 'components/modalBottomSheetSwitcher';
 import {useGlobalModalContext} from 'context/globalModals';
 import styled from 'styled-components';
 import React from 'react';
+import {constants} from 'ethers';
 import {useTranslation} from 'react-i18next';
 import {ButtonText, IllustrationHuman, shortenAddress} from '@aragon/ods';
 import {useDaoDetailsQuery} from 'hooks/useDaoDetails';
@@ -36,8 +37,7 @@ export const DelegationGatingMenu: React.FC = () => {
     {tokenAddress: daoToken?.address as string},
     {enabled: daoToken != null}
   );
-  const isDelegationActive =
-    delegateData !== '0x0000000000000000000000000000000000000000';
+  const isDelegationActive = delegateData !== constants.AddressZero;
   // The useDelegatee hook returns null when current delegate is connected address
   const currentDelegate =
     delegateData === null ? (address as string) : delegateData;

--- a/src/containers/delegationGatingMenu/index.ts
+++ b/src/containers/delegationGatingMenu/index.ts
@@ -1,0 +1,1 @@
+export {DelegationGatingMenu} from './delegationGatingMenu';

--- a/src/containers/gatingMenu/index.tsx
+++ b/src/containers/gatingMenu/index.tsx
@@ -34,7 +34,8 @@ export const GatingMenu: React.FC = () => {
 
   const {data: daoDetails} = useDaoDetailsQuery();
   const {plugins, ensDomain, address} = daoDetails ?? {};
-  const daoName = toDisplayEns(ensDomain) ?? address;
+  const daoName =
+    toDisplayEns(ensDomain) !== '' ? toDisplayEns(ensDomain) : address;
 
   const {data: daoToken} = useDaoToken(plugins?.[0].instanceAddress);
   const {isDAOTokenWrapped} = useExistingToken({daoDetails, daoToken});

--- a/src/containers/govTokensWrappingModal/GovTokensWrappingModal.tsx
+++ b/src/containers/govTokensWrappingModal/GovTokensWrappingModal.tsx
@@ -216,7 +216,7 @@ const GovTokensWrappingModal: FC<GovTokensWrappingModalProps> = ({
               ? t('modal.wrapToken.successCtaLabel')
               : t('modal.unwrapToken.successCtaLabel'),
             className: 'w-full',
-            onClick: onClose,
+            onClick: () => onClose(),
           }}
           secondaryButton={
             isWrapMode
@@ -425,7 +425,7 @@ const GovTokensWrappingModal: FC<GovTokensWrappingModalProps> = ({
                     size="large"
                     label={t('modal.wrapToken.footerWrappedCancelLabel')}
                     className="w-full"
-                    onClick={onClose}
+                    onClick={() => onClose()}
                   />
                 </>
               )}

--- a/src/containers/govTokensWrappingModal/GovTokensWrappingModal.tsx
+++ b/src/containers/govTokensWrappingModal/GovTokensWrappingModal.tsx
@@ -24,10 +24,11 @@ import {StateEmpty} from 'components/stateEmpty';
 import {Erc20TokenDetails} from '@aragon/sdk-client';
 import numeral from 'numeral';
 import {TokensWrappingFormData} from 'utils/types';
+import {useGlobalModalContext} from 'context/globalModals';
 
 interface GovTokensWrappingModalProps {
   isOpen: boolean;
-  onClose: () => void;
+  onClose: (redirectPage?: boolean) => void;
   isLoading: boolean;
   daoToken: Erc20TokenDetails | undefined;
   wrappedDaoToken: Erc20TokenDetails | undefined;
@@ -64,8 +65,8 @@ const GovTokensWrappingModal: FC<GovTokensWrappingModalProps> = ({
   handleUnwrap,
 }) => {
   const {t} = useTranslation();
-
   const {isValid, dirtyFields} = useFormState({control: form.control});
+  const {open} = useGlobalModalContext();
 
   const [mode, amount] = useWatch({
     name: ['mode', 'amount'],
@@ -178,6 +179,11 @@ const GovTokensWrappingModal: FC<GovTokensWrappingModalProps> = ({
     [modeData.tokenBalance]
   );
 
+  const handleDelegateClick = () => {
+    onClose(false);
+    open('delegateVoting');
+  };
+
   return (
     <ModalBottomSheetSwitcher
       isOpen={isOpen}
@@ -204,6 +210,7 @@ const GovTokensWrappingModal: FC<GovTokensWrappingModalProps> = ({
           accessory="buddha"
           title={modeData.finishedTitle}
           description={modeData.finishedDescription}
+          actionsColumn={isWrapMode}
           primaryButton={{
             label: isWrapMode
               ? t('modal.wrapToken.successCtaLabel')
@@ -217,6 +224,15 @@ const GovTokensWrappingModal: FC<GovTokensWrappingModalProps> = ({
                   label: t('modal.wrapToken.successBtnSecondaryLabel'),
                   className: 'w-full',
                   onClick: handleAddWrappedTokenToWallet,
+                }
+              : undefined
+          }
+          tertiaryButton={
+            isWrapMode
+              ? {
+                  label: t('modal.wrapToken.successBtnGhostLabel'),
+                  className: 'w-full',
+                  onClick: handleDelegateClick,
                 }
               : undefined
           }

--- a/src/context/govTokensWrapping.tsx
+++ b/src/context/govTokensWrapping.tsx
@@ -6,7 +6,6 @@ import {
   UnwrapTokensStep,
   WrapTokensStep,
 } from '@aragon/sdk-client';
-import {useQueryClient} from '@tanstack/react-query';
 import GovTokensWrappingModal from 'containers/govTokensWrappingModal/GovTokensWrappingModal';
 import {useNetwork} from 'context/network';
 import {useProviders} from 'context/providers';
@@ -32,6 +31,7 @@ import {toDisplayEns} from 'utils/library';
 import {Community} from 'utils/paths';
 import {fetchBalance} from 'utils/tokens';
 import {TokensWrappingFormData} from 'utils/types';
+import {useQueryClient} from 'wagmi';
 
 interface IGovTokensWrappingContextType {
   handleOpenModal: () => void;
@@ -45,7 +45,7 @@ const GovTokensWrappingProvider: FC<{children: ReactNode}> = ({children}) => {
   const {address: userAddress} = useWallet();
   const {network} = useNetwork();
   const loc = useLocation();
-  const queryClient = useQueryClient();
+  const wagmiQueryClient = useQueryClient();
   const {api: provider} = useProviders();
 
   const {data: daoDetails, isLoading: isDaoDetailsLoading} =
@@ -181,21 +181,21 @@ const GovTokensWrappingProvider: FC<{children: ReactNode}> = ({children}) => {
   // Invalidate wagmi balance cache to display the correct token balances after
   // the wrap / unwrap processes
   const invalidateDaoTokenBalanceCache = useCallback(() => {
-    queryClient.invalidateQueries([
+    wagmiQueryClient.invalidateQueries([
       {
         entity: 'balance',
         address: userAddress,
         token: wrappedDaoToken?.address,
       },
     ]);
-    queryClient.invalidateQueries([
+    wagmiQueryClient.invalidateQueries([
       {
         entity: 'balance',
         address: userAddress,
         token: daoTokenData?.address,
       },
     ]);
-  }, [queryClient, userAddress, wrappedDaoToken, daoTokenData]);
+  }, [wagmiQueryClient, userAddress, wrappedDaoToken, daoTokenData]);
 
   const handleApprove = useCallback(async () => {
     if (isTxLoading || !wrappedDaoToken || !underlyingToken) return;

--- a/src/context/govTokensWrapping.tsx
+++ b/src/context/govTokensWrapping.tsx
@@ -229,14 +229,7 @@ const GovTokensWrappingProvider: FC<{children: ReactNode}> = ({children}) => {
     } finally {
       setIsTxLoading(false);
     }
-  }, [
-    amount,
-    client,
-    underlyingToken,
-    isTxLoading,
-    wrappedDaoToken,
-    invalidateDaoTokenBalanceCache,
-  ]);
+  }, [amount, client, underlyingToken, isTxLoading, wrappedDaoToken]);
 
   const handleWrap = useCallback(async () => {
     if (isTxLoading || !wrappedDaoToken || !pluginClient) return;

--- a/src/context/govTokensWrapping.tsx
+++ b/src/context/govTokensWrapping.tsx
@@ -178,6 +178,8 @@ const GovTokensWrappingProvider: FC<{children: ReactNode}> = ({children}) => {
     [isTxLoading, reset, isFlowFinished, daoDetails, network, loc, navigate]
   );
 
+  // Invalidate wagmi balance cache to display the correct token balances after
+  // the wrap / unwrap processes
   const invalidateDaoTokenBalanceCache = useCallback(() => {
     queryClient.invalidateQueries([
       {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,19 +37,6 @@ const {publicClient} = configureChains(chains, [
   infuraProvider({apiKey: infuraApiKey}),
 ]);
 
-// React-Query client
-export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      cacheTime: 1000 * 60 * 5, // 5min
-      staleTime: 1000 * 60 * 2, // 2min
-      retry: 0,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: true,
-    },
-  },
-});
-
 const wagmiConfig = createConfig({
   autoConnect: true,
   connectors: [
@@ -73,6 +60,19 @@ const wagmiConfig = createConfig({
 
 // Web3Modal Ethereum Client
 const ethereumClient = new EthereumClient(wagmiConfig, chains);
+
+// React-Query client
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      cacheTime: 1000 * 60 * 5, // 5min
+      staleTime: 1000 * 60 * 2, // 2min
+      retry: 0,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: true,
+    },
+  },
+});
 
 const CACHE_VERSION = 1;
 const onLoad = () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,8 +37,22 @@ const {publicClient} = configureChains(chains, [
   infuraProvider({apiKey: infuraApiKey}),
 ]);
 
+// React-Query client
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      cacheTime: 1000 * 60 * 5, // 5min
+      staleTime: 1000 * 60 * 2, // 2min
+      retry: 0,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: true,
+    },
+  },
+});
+
 const wagmiConfig = createConfig({
   autoConnect: true,
+  queryClient,
   connectors: [
     ...w3mConnectors({
       projectId: walletConnectProjectID,
@@ -60,19 +74,6 @@ const wagmiConfig = createConfig({
 
 // Web3Modal Ethereum Client
 const ethereumClient = new EthereumClient(wagmiConfig, chains);
-
-// React-Query client
-export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      cacheTime: 1000 * 60 * 5, // 5min
-      staleTime: 1000 * 60 * 2, // 2min
-      retry: 0,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: true,
-    },
-  },
-});
 
 const CACHE_VERSION = 1;
 const onLoad = () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -52,7 +52,6 @@ export const queryClient = new QueryClient({
 
 const wagmiConfig = createConfig({
   autoConnect: true,
-  queryClient,
   connectors: [
     ...w3mConnectors({
       projectId: walletConnectProjectID,

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1138,7 +1138,7 @@
       "BtnSecondaryLabel": "No, I’m good",
       "label": "Delegation",
       "title": "You have no voting power",
-      "desc": "You are delegating your voting power of {{balance}} {{tokenSymbol}} to the {{walletAddressDelegation}}.\nIf you want to participate in future proposals, you have to claim your voting power. "
+      "desc": "You are delegating your voting power of {{balance}} {{tokenSymbol}} to {{walletAddressDelegation}}. If you want to participate in future proposals, you have to claim your voting power. "
     },
     "delegation": {
       "label": "Delegation",
@@ -1161,7 +1161,8 @@
       "successCtaLabel": "See community",
       "successBtnSecondaryLabel": "See transaction",
       "successDelegateTitle": "Voting power successfully delegated",
-      "successDelegateDesc": "You have delegated all your voting power of {{balance}} {{tokenSymbol}} to the <b>{{delegateEns}}</b>. You have the option to revoke this at any time.",
+      "successDelegateDesc": "You have delegated all your voting power of {{balance}} {{tokenSymbol}} to {{delegateEns}}. You have the option to revoke this at any time.",
+      "successReclaimTitle": "Claimed your voting power successfully",
       "successReclaimDesc": "You have claimed your voting power of {{balance}} {{tokenSymbol}}. Your voting power will be available in future proposals, but not for those that are already active.",
       "alertCriticalDelegate": "Delegating went wrong. Try again.",
       "alertCriticalReclaim": "Claiming went wrong. Try again.",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1162,11 +1162,11 @@
       "successBtnSecondaryLabel": "See transaction",
       "successDelegateTitle": "Voting power successfully delegated",
       "successDelegateDesc": "You have delegated all your voting power of {{balance}} {{tokenSymbol}} to {{delegateEns}}. You have the option to revoke this at any time.",
-      "successReclaimTitle": "Claimed your voting power successfully",
       "successReclaimDesc": "You have claimed your voting power of {{balance}} {{tokenSymbol}}. Your voting power will be available in future proposals, but not for those that are already active.",
       "alertCriticalDelegate": "Delegating went wrong. Try again.",
       "alertCriticalReclaim": "Claiming went wrong. Try again.",
-      "ctaLabelRetry": "Retry"
+      "ctaLabelRetry": "Retry",
+      "successReclaimTitle": "Claimed your voting power successfully"
     },
     "delegationInactive": {
       "title": "You have no voting power",

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -77,7 +77,7 @@ import {
 import {Action, ProposalId} from 'utils/types';
 import {useDaoToken} from 'hooks/useDaoToken';
 import {BigNumber} from 'ethers';
-import {getVotingPower} from 'utils/tokens';
+import {useVotingPower} from 'services/aragon-sdk/queries/use-voting-power';
 
 // TODO: @Sepehr Please assign proper tags on action decoding
 // const PROPOSAL_TAGS = ['Finance', 'Withdraw'];
@@ -132,7 +132,6 @@ export const Proposal: React.FC = () => {
   const {address, isConnected, isOnWrongNetwork} = useWallet();
 
   const [voteStatus, setVoteStatus] = useState('');
-  const [votingPower, setVoginPower] = useState(BigNumber.from('0'));
   const [intervalInMills, setIntervalInMills] = useState(0);
   const [decodedActions, setDecodedActions] =
     useState<(Action | undefined)[]>();
@@ -166,6 +165,14 @@ export const Proposal: React.FC = () => {
     pluginAddress,
     pluginType,
     proposal?.status as string
+  );
+
+  const {data: votingPower = BigNumber.from('0')} = useVotingPower(
+    {
+      address: address as string,
+      tokenAddress: daoToken?.address as string,
+    },
+    {enabled: address != null && daoToken != null}
   );
 
   const pluginClient = usePluginClient(pluginType);
@@ -212,23 +219,6 @@ export const Proposal: React.FC = () => {
       );
     }
   }, [editor, proposal]);
-
-  useEffect(() => {
-    const fetchVotingPower = async () => {
-      if (daoToken != null && address != null) {
-        const result = await getVotingPower(
-          daoToken.address,
-          address,
-          provider
-        );
-        setVoginPower(result);
-      }
-    };
-
-    if (!multisigDAO) {
-      fetchVotingPower();
-    }
-  }, [daoToken, address, provider, multisigDAO]);
 
   useEffect(() => {
     if (proposal?.status) {

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -77,7 +77,7 @@ import {
 import {Action, ProposalId} from 'utils/types';
 import {useDaoToken} from 'hooks/useDaoToken';
 import {BigNumber} from 'ethers';
-import {useVotingPower} from 'services/aragon-sdk/queries/use-voting-power';
+import {usePastVotingPower} from 'services/aragon-sdk/queries/use-past-voting-power';
 
 // TODO: @Sepehr Please assign proper tags on action decoding
 // const PROPOSAL_TAGS = ['Finance', 'Withdraw'];
@@ -167,12 +167,13 @@ export const Proposal: React.FC = () => {
     proposal?.status as string
   );
 
-  const {data: votingPower = BigNumber.from('0')} = useVotingPower(
+  const {data: votingPower = BigNumber.from('0')} = usePastVotingPower(
     {
       address: address as string,
       tokenAddress: daoToken?.address as string,
+      blockNumber: proposal?.creationBlockNumber as number,
     },
-    {enabled: address != null && daoToken != null}
+    {enabled: address != null && daoToken != null && proposal != null}
   );
 
   const pluginClient = usePluginClient(pluginType);

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -49,7 +49,7 @@ import useScreen from 'hooks/useScreen';
 import {useWallet} from 'hooks/useWallet';
 import {useWalletCanVote} from 'hooks/useWalletCanVote';
 import {useTokenAsync} from 'services/token/queries/use-token';
-import {CHAIN_METADATA, SupportedNetworks} from 'utils/constants';
+import {CHAIN_METADATA} from 'utils/constants';
 import {
   decodeAddMembersToAction,
   decodeMetadataToAction,
@@ -78,7 +78,6 @@ import {Action, ProposalId} from 'utils/types';
 import {useDaoToken} from 'hooks/useDaoToken';
 import {BigNumber} from 'ethers';
 import {getVotingPower} from 'utils/tokens';
-import {Address, useBalance} from 'wagmi';
 
 // TODO: @Sepehr Please assign proper tags on action decoding
 // const PROPOSAL_TAGS = ['Finance', 'Withdraw'];

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -180,9 +180,10 @@ export const Proposal: React.FC = () => {
   const [votingInProcess, setVotingInProcess] = useState(false);
   const [expandedProposal, setExpandedProposal] = useState(false);
 
-  // Display the voting-power gating dialog when user has can vote but has no voting
+  // Display the voting-power gating dialog when user can vote but has no voting
   // power, meaning that the user delegated his voting power to another address
-  const displayVotingGate = canVote && votingPower.lte(BigNumber.from('0'));
+  const displayVotingGate =
+    !multisigDAO && canVote && votingPower.lte(BigNumber.from('0'));
 
   const editor = useEditor({
     editable: false,
@@ -224,8 +225,10 @@ export const Proposal: React.FC = () => {
       }
     };
 
-    fetchVotingPower();
-  }, [daoToken, address, provider]);
+    if (!multisigDAO) {
+      fetchVotingPower();
+    }
+  }, [daoToken, address, provider, multisigDAO]);
 
   useEffect(() => {
     if (proposal?.status) {
@@ -527,7 +530,7 @@ export const Proposal: React.FC = () => {
     }
 
     // needs voting power
-    else if (!multisigDAO && displayVotingGate) {
+    else if (displayVotingGate) {
       return {
         voteNowDisabled: false,
         onClick: () => open('delegationGating'),

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -167,7 +167,7 @@ export const Proposal: React.FC = () => {
     proposal?.status as string
   );
 
-  const {data: votingPower = BigNumber.from('0')} = usePastVotingPower(
+  const {data: pastVotingPower = BigNumber.from('0')} = usePastVotingPower(
     {
       address: address as string,
       tokenAddress: daoToken?.address as string,
@@ -188,10 +188,10 @@ export const Proposal: React.FC = () => {
   const [votingInProcess, setVotingInProcess] = useState(false);
   const [expandedProposal, setExpandedProposal] = useState(false);
 
-  // Display the voting-power gating dialog when user can vote but has no voting
-  // power, meaning that the user delegated his voting power to another address
+  // Display the voting-power gating dialog when user can vote but had no
+  // voting power at the proposal creation
   const displayVotingGate =
-    !multisigDAO && canVote && votingPower.lte(BigNumber.from('0'));
+    !multisigDAO && canVote && pastVotingPower.lte(BigNumber.from('0'));
 
   const editor = useEditor({
     editable: false,

--- a/src/services/aragon-sdk/aragon-sdk-service.api.ts
+++ b/src/services/aragon-sdk/aragon-sdk-service.api.ts
@@ -2,6 +2,11 @@ export interface IFetchDelegateeParams {
   tokenAddress: string;
 }
 
+export interface IFetchVotingPowerParams {
+  tokenAddress: string;
+  address: string;
+}
+
 export interface IDelegateTokensParams {
   tokenAddress: string;
   delegatee: string;

--- a/src/services/aragon-sdk/aragon-sdk-service.api.ts
+++ b/src/services/aragon-sdk/aragon-sdk-service.api.ts
@@ -2,6 +2,12 @@ export interface IFetchDelegateeParams {
   tokenAddress: string;
 }
 
+export interface IFetchPastVotingPowerParams {
+  tokenAddress: string;
+  address: string;
+  blockNumber: number;
+}
+
 export interface IFetchVotingPowerParams {
   tokenAddress: string;
   address: string;

--- a/src/services/aragon-sdk/queries/use-delegatee.ts
+++ b/src/services/aragon-sdk/queries/use-delegatee.ts
@@ -32,10 +32,11 @@ export const useDelegatee = (
     options.enabled = false;
   }
 
+  // Make sure that the signer is set on the client before
+  // querying and caching the result
   try {
-    if (client != null) {
-      client?.web3.getSigner();
-    }
+    const signer = client?.web3.getSigner();
+    options.enabled = signer != null;
   } catch (error: unknown) {
     options.enabled = false;
   }

--- a/src/services/aragon-sdk/queries/use-delegatee.ts
+++ b/src/services/aragon-sdk/queries/use-delegatee.ts
@@ -32,6 +32,14 @@ export const useDelegatee = (
     options.enabled = false;
   }
 
+  try {
+    if (client != null) {
+      client?.web3.getSigner();
+    }
+  } catch (error: unknown) {
+    options.enabled = false;
+  }
+
   return useQuery(
     aragonSdkQueryKeys.delegatee(baseParams, params),
     () => fetchDelegatee(params, client),

--- a/src/services/aragon-sdk/queries/use-past-voting-power.ts
+++ b/src/services/aragon-sdk/queries/use-past-voting-power.ts
@@ -1,0 +1,25 @@
+import {UseQueryOptions, useQuery} from '@tanstack/react-query';
+import {aragonSdkQueryKeys} from '../query-keys';
+import type {IFetchPastVotingPowerParams} from '../aragon-sdk-service.api';
+import {getPastVotingPower} from 'utils/tokens';
+import {useProviders} from 'context/providers';
+import {BigNumber} from 'ethers';
+
+export const usePastVotingPower = (
+  params: IFetchPastVotingPowerParams,
+  options?: UseQueryOptions<BigNumber>
+) => {
+  const {api: provider} = useProviders();
+
+  return useQuery(
+    aragonSdkQueryKeys.pastVotingPower(params),
+    () =>
+      getPastVotingPower(
+        params.tokenAddress,
+        params.address,
+        params.blockNumber,
+        provider
+      ),
+    options
+  );
+};

--- a/src/services/aragon-sdk/queries/use-voting-power.ts
+++ b/src/services/aragon-sdk/queries/use-voting-power.ts
@@ -1,9 +1,10 @@
-import {UseQueryOptions, useQuery} from '@tanstack/react-query';
+import {UseQueryOptions, useQuery, useQueryClient} from '@tanstack/react-query';
 import {aragonSdkQueryKeys} from '../query-keys';
 import type {IFetchVotingPowerParams} from '../aragon-sdk-service.api';
 import {getVotingPower} from 'utils/tokens';
 import {useProviders} from 'context/providers';
 import {BigNumber} from 'ethers';
+import {useCallback} from 'react';
 
 export const useVotingPower = (
   params: IFetchVotingPowerParams,
@@ -16,4 +17,21 @@ export const useVotingPower = (
     () => getVotingPower(params.tokenAddress, params.address, provider),
     options
   );
+};
+
+export const useVotingPowerAsync = () => {
+  const queryClient = useQueryClient();
+  const {api: provider} = useProviders();
+
+  const fetchVotingPowerAsync = useCallback(
+    (params: IFetchVotingPowerParams) =>
+      queryClient.fetchQuery({
+        queryKey: aragonSdkQueryKeys.votingPower(params),
+        queryFn: () =>
+          getVotingPower(params.tokenAddress, params.address, provider),
+      }),
+    [queryClient, provider]
+  );
+
+  return fetchVotingPowerAsync;
 };

--- a/src/services/aragon-sdk/queries/use-voting-power.ts
+++ b/src/services/aragon-sdk/queries/use-voting-power.ts
@@ -1,0 +1,19 @@
+import {UseQueryOptions, useQuery} from '@tanstack/react-query';
+import {aragonSdkQueryKeys} from '../query-keys';
+import type {IFetchVotingPowerParams} from '../aragon-sdk-service.api';
+import {getVotingPower} from 'utils/tokens';
+import {useProviders} from 'context/providers';
+import {BigNumber} from 'ethers';
+
+export const useVotingPower = (
+  params: IFetchVotingPowerParams,
+  options?: UseQueryOptions<BigNumber>
+) => {
+  const {api: provider} = useProviders();
+
+  return useQuery(
+    aragonSdkQueryKeys.votingPower(params),
+    () => getVotingPower(params.tokenAddress, params.address, provider),
+    options
+  );
+};

--- a/src/services/aragon-sdk/query-keys.ts
+++ b/src/services/aragon-sdk/query-keys.ts
@@ -1,10 +1,14 @@
 import type {QueryKey} from '@tanstack/query-core';
 
-import type {IFetchDelegateeParams} from './aragon-sdk-service.api';
+import type {
+  IFetchDelegateeParams,
+  IFetchVotingPowerParams,
+} from './aragon-sdk-service.api';
 import {SupportedNetworks} from 'utils/constants';
 
 export enum AragonSdkQueryItem {
   DELEGATEE = 'DELEGATEE',
+  VOTING_POWER = 'VOTING_POWER',
 }
 
 // Add address and network parameters to all query keys to use the most updated DAO plugin client
@@ -18,4 +22,8 @@ export const aragonSdkQueryKeys = {
     baseParams: IAragonSdkBaseParams,
     params: IFetchDelegateeParams
   ): QueryKey => [AragonSdkQueryItem.DELEGATEE, baseParams, params],
+  votingPower: (params: IFetchVotingPowerParams): QueryKey => [
+    AragonSdkQueryItem.VOTING_POWER,
+    params,
+  ],
 };

--- a/src/services/aragon-sdk/query-keys.ts
+++ b/src/services/aragon-sdk/query-keys.ts
@@ -2,6 +2,7 @@ import type {QueryKey} from '@tanstack/query-core';
 
 import type {
   IFetchDelegateeParams,
+  IFetchPastVotingPowerParams,
   IFetchVotingPowerParams,
 } from './aragon-sdk-service.api';
 import {SupportedNetworks} from 'utils/constants';
@@ -9,6 +10,7 @@ import {SupportedNetworks} from 'utils/constants';
 export enum AragonSdkQueryItem {
   DELEGATEE = 'DELEGATEE',
   VOTING_POWER = 'VOTING_POWER',
+  PAST_VOTING_POWER = 'PAST_VOTING_POWER',
 }
 
 // Add address and network parameters to all query keys to use the most updated DAO plugin client
@@ -22,6 +24,10 @@ export const aragonSdkQueryKeys = {
     baseParams: IAragonSdkBaseParams,
     params: IFetchDelegateeParams
   ): QueryKey => [AragonSdkQueryItem.DELEGATEE, baseParams, params],
+  pastVotingPower: (params: IFetchPastVotingPowerParams): QueryKey => [
+    AragonSdkQueryItem.PAST_VOTING_POWER,
+    params,
+  ],
   votingPower: (params: IFetchVotingPowerParams): QueryKey => [
     AragonSdkQueryItem.VOTING_POWER,
     params,

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -332,40 +332,6 @@ export const fetchBalance = async (
 };
 
 /**
- * @param tokenAddress address of token contract
- * @param ownerAddress owner address / wallet address
- * @param provider interface to node
- * @param nativeCurrency native currency of active chain
- * @param shouldFormat whether value is returned in human readable format
- * @returns a promise that will return a voting power
- */
-export const fetchVotingPower = async (
-  tokenAddress: string,
-  ownerAddress: string,
-  provider: EthersProviders.Provider,
-  nativeCurrency: NativeTokenData,
-  shouldFormat = true
-) => {
-  const contract = new ethers.Contract(
-    tokenAddress,
-    votesUpgradeableABI,
-    provider
-  );
-  const votes = await contract.getVotes(ownerAddress);
-
-  if (shouldFormat) {
-    const {decimals} = await getTokenInfo(
-      tokenAddress,
-      provider,
-      nativeCurrency
-    );
-    return formatUnits(votes, decimals);
-  }
-
-  return votes;
-};
-
-/**
  * Check if token is the chain native token; the distinction is made
  * especially in terms of whether the contract address
  * is that of an ERC20 token

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,7 +1,12 @@
 /* eslint-disable no-empty */
 import {erc20TokenABI} from 'abis/erc20TokenABI';
 import {TokenWithMetadata} from './types';
-import {constants, ethers, providers as EthersProviders} from 'ethers';
+import {
+  BigNumber,
+  constants,
+  ethers,
+  providers as EthersProviders,
+} from 'ethers';
 
 import {formatUnits} from 'utils/library';
 import {NativeTokenData, TimeFilter, TOKEN_AMOUNT_REGEX} from './constants';
@@ -87,6 +92,26 @@ export async function getOwner(
     return (await contract.owner()) as string;
   } catch (err) {
     return null;
+  }
+}
+
+/**
+ * Returns the voting power for the specified address
+ * @param address Address of the contract
+ * @param account Address to check the voting power
+ * @param provider Ethers provider to use
+ * @returns voting power of the account or 0
+ */
+export async function getVotingPower(
+  address: string,
+  account: string,
+  provider: EthersProviders.Provider
+) {
+  const contract = new ethers.Contract(address, votesUpgradeableABI, provider);
+  try {
+    return (await contract.getVotes(account)) as BigNumber;
+  } catch (err) {
+    return BigNumber.from('0');
   }
 }
 

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -96,7 +96,29 @@ export async function getOwner(
 }
 
 /**
- * Returns the voting power for the specified address
+ * Returns the voting power for the specified address at the specified block number
+ * @param address Address of the contract
+ * @param account Address to check the voting power
+ * @param blockNumber Block number to check for voting power
+ * @param provider Ethers provider to use
+ * @returns voting power of the account or 0
+ */
+export async function getPastVotingPower(
+  address: string,
+  account: string,
+  blockNumber: number,
+  provider: EthersProviders.Provider
+) {
+  const contract = new ethers.Contract(address, votesUpgradeableABI, provider);
+  try {
+    return (await contract.getPastVotes(account, blockNumber)) as BigNumber;
+  } catch (err) {
+    return BigNumber.from('0');
+  }
+}
+
+/**
+ * Returns the voting power for the specified address at the current time
  * @param address Address of the contract
  * @param account Address to check the voting power
  * @param provider Ethers provider to use


### PR DESCRIPTION
## Description

- Display a delegate now button after successfully wrapping the ERC20 tokens to the government tokens;
- Display a voting-power-gating menu if the user has balance but cannot vote because he delegated his voting power
- Add `getVotingPower` / `getPastVotingPower` and relative hooks (`useVotingPower` / `usePastVotingPower`) to check for current and past voting power
- Make sure that the `wagmi` cache is updated after wrapping / unwrapping the tokens to display the correct dialog when opening the "delegateTokens" dialog (if query is not invalidated, the "no-tokens" view will be displayed intstead)

Task: [APP-2369](https://aragonassociation.atlassian.net/browse/APP-2369)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2369]: https://aragonassociation.atlassian.net/browse/APP-2369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ