### PR TITLE
chore: APP-2055 added loaders to useDaoVault

### DIFF
--- a/src/hooks/useDaoVault.tsx
+++ b/src/hooks/useDaoVault.tsx
@@ -22,14 +22,33 @@ import {useTokenMetadata} from './useTokenMetadata';
 export const useDaoVault = (
   options: PollTokenOptions = {filter: TimeFilter.day, interval: 300000}
 ) => {
-  const {data: daoDetails} = useDaoDetailsQuery();
+  const {data: daoDetails, isLoading: isDaoDetailsLoading} =
+    useDaoDetailsQuery();
 
-  const {data: balances} = useDaoBalances(daoDetails?.address ?? '');
-  const {data: tokensWithMetadata} = useTokenMetadata(balances);
-  const {data: tokenPrices} = usePollTokenPrices(tokensWithMetadata, options);
+  const {data: balances, isLoading: isBalancesLoading} = useDaoBalances(
+    daoDetails?.address ?? ''
+  );
+  const {data: tokensWithMetadata, isLoading: isTokensMetadataLoading} =
+    useTokenMetadata(balances);
+  const {data: tokenPrices, isLoading: isTokensPricesLoading} =
+    usePollTokenPrices(tokensWithMetadata, options);
 
-  const {data: transfers} = useDaoTransfers(daoDetails?.address ?? '');
-  const {data: transferPrices} = usePollTransfersPrices(transfers);
+  const {data: transfers, isLoading: isCoreTransfersLoading} = useDaoTransfers(
+    daoDetails?.address ?? ''
+  );
+  const {data: transferPrices, isLoading: isTransferPricesLoading} =
+    usePollTransfersPrices(transfers);
+
+  const isTransfersLoading =
+    isDaoDetailsLoading || isCoreTransfersLoading || isTransferPricesLoading;
+
+  const isCumulativeStatsLoading =
+    isDaoDetailsLoading ||
+    isBalancesLoading ||
+    isTokensMetadataLoading ||
+    isTokensPricesLoading;
+
+  const isTokensLoading = isCumulativeStatsLoading || isTransfersLoading;
 
   const tokens: VaultToken[] = useMemo(() => {
     if (tokenPrices?.tokens?.length === 0) {
@@ -86,5 +105,8 @@ export const useDaoVault = (
     totalAssetValue: tokenPrices.totalAssetValue,
     totalAssetChange: tokenPrices.totalAssetChange,
     transfers: transferPrices.transfers,
+    isTokensLoading,
+    isTransfersLoading,
+    isCumulativeStatsLoading,
   };
 };


### PR DESCRIPTION
## Description

Refactor finance related hooks.

After talk with Fabrice, we came to following objectives which were desirable to achieve within context of this ticket:
- (DONE) Add loading state to use `useDaoVault` at least, so we can properly set up loading behavior in future
- (DONE) Ensure all the hooks are using `useQuery`. I checked the underlying implementations of: `useDaoBalances`, `useDaoTransfers`, `usePollTokenPrices`, `usePollTransfersPrices`, `useTokenMetadata`, `useTokenList` - all of them either employ the hooks which use `useQuery` or use `useQuery` themselves.

- (NOT DONE) Remove `useDaoVault` hook. **Reason:** I attempted to find the solution on how we could remove transfers from equation but didn't manage achieve it preserving the application working as expected. Thing is we are using `historicalTokenBalances` for calculating stats data for `tokens` and without it things doesn't fit together. Also `usePollTransfersPrices` requires initial transfers to be passed in order to return enhanced ones. All in all, `useDaoVault` doesn't seem like a bad abstraction with the  current implementations.

- (NOT DONE) Remove `useTokenMetadata` hook. I also attempted to find the way on how we could potentially eliminate this one but unfortunately it is still very important to get tokens details data. Especially with integration of `Base` network since we not only using `Coingecko` now but also `Covalent`.  It's also tightly coupled with `usePollTokenPrices` since we need to supply tokens with meta-data only there.

Overall this task took me a lot of exploration, code-reading and experimentation, but the above report is the closest I managed to get to in terms of optimizing finance-related hooks.

Task: [APP-2055](https://aragonassociation.atlassian.net/browse/APP-2055)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2055]: https://aragonassociation.atlassian.net/browse/APP-2055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ