### PR TITLE
fix: fixed transfers page crashing bug

### DIFF
--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -432,6 +432,8 @@ export function shortenStr(
   endSymbols = 0,
   separation = '...'
 ): string {
+  if (!str) return str;
+
   if (str.length < startSymbols + endSymbols) return str;
 
   const openingLetters = str.slice(0, startSymbols);


### PR DESCRIPTION
## Description

Fixed transfers page crashing bug.
When you enter: [this page](https://app.aragon.org/#/daos/polygon/0x0762b99d6afdace71f7745caa603d88f177e994f/finance/transfers) the app goes blank.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.
