### PR TITLE
fix: APP-2437 - Fix re-renders on create proposal step

### DIFF
--- a/src/containers/votingTerminal/index.tsx
+++ b/src/containers/votingTerminal/index.tsx
@@ -119,10 +119,13 @@ export const VotingTerminal: React.FC<VotingTerminalProps> = ({
           };
         })
       );
+
       setDisplayedVoters(response);
     }
 
-    fetchEns();
+    if (voters.length) {
+      fetchEns();
+    }
   }, [provider, voters]);
 
   const filteredVoters = useMemo(() => {

--- a/src/containers/votingTerminal/index.tsx
+++ b/src/containers/votingTerminal/index.tsx
@@ -119,7 +119,6 @@ export const VotingTerminal: React.FC<VotingTerminalProps> = ({
           };
         })
       );
-
       setDisplayedVoters(response);
     }
 


### PR DESCRIPTION
## Description

- The `fetchEns` function is called in a loop when the voters list is empty

Task: [APP-2437](https://aragonassociation.atlassian.net/browse/APP-2437)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2437]: https://aragonassociation.atlassian.net/browse/APP-2437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ