### PR TITLE
fix: APP-2366 - Do not enable fetch-delegate call when params are not valid

### DIFF
--- a/src/services/aragon-sdk/queries/use-delegatee.ts
+++ b/src/services/aragon-sdk/queries/use-delegatee.ts
@@ -35,8 +35,10 @@ export const useDelegatee = (
   // Make sure that the signer is set on the client before
   // querying and caching the result
   try {
-    const signer = client?.web3.getSigner();
-    options.enabled = signer != null;
+    if (options.enabled !== false) {
+      const signer = client?.web3.getSigner();
+      options.enabled = signer != null;
+    }
   } catch (error: unknown) {
     options.enabled = false;
   }


### PR DESCRIPTION
## Description

- When the parameters for the `useDelegatee` are not valid (e.g. `address`), the check on the `client.web3.getSigner` is overriding the `options.enabled` previously set. Only check the client signer if the previous check is valid.

Task: [APP-2366](https://aragonassociation.atlassian.net/browse/APP-2366)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2366]: https://aragonassociation.atlassian.net/browse/APP-2366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ