### PR TITLE
chore: Update values of global modal context

### DIFF
--- a/src/components/modalBottomSheetSwitcher/index.tsx
+++ b/src/components/modalBottomSheetSwitcher/index.tsx
@@ -3,7 +3,10 @@ import {Modal, ModalProps} from '@aragon/ods';
 import BottomSheet, {BottomSheetProps} from 'components/bottomSheet';
 import useScreen from 'hooks/useScreen';
 
-const ModalBottomSheetSwitcher: React.FC<ModalProps & BottomSheetProps> = ({
+type ModalBottomSheetSwitcherProps = ModalProps &
+  Omit<BottomSheetProps, 'isOpen'>;
+
+const ModalBottomSheetSwitcher: React.FC<ModalBottomSheetSwitcherProps> = ({
   title,
   subtitle,
   isOpen,

--- a/src/components/protectedRoute/index.tsx
+++ b/src/components/protectedRoute/index.tsx
@@ -22,7 +22,7 @@ import {fetchBalance} from 'utils/tokens';
 
 const ProtectedRoute: React.FC = () => {
   const navigate = useNavigate();
-  const {open, close, isGatingOpen} = useGlobalModalContext();
+  const {open, close, isOpen} = useGlobalModalContext('gating');
   const {
     address,
     status,
@@ -95,7 +95,7 @@ const ProtectedRoute: React.FC = () => {
         Number(votingPower) < minProposalThreshold
       ) {
         open('gating');
-      } else close('gating');
+      } else close();
     }
   }, [
     address,
@@ -111,7 +111,7 @@ const ProtectedRoute: React.FC = () => {
 
   const gateMultisigProposal = useCallback(() => {
     if ((votingSettings as MultisigVotingSettings)?.onlyListed === false) {
-      close('gating');
+      close();
     } else if (
       !filteredMembers.some(
         mem => mem.address.toLowerCase() === address?.toLowerCase()
@@ -120,7 +120,7 @@ const ProtectedRoute: React.FC = () => {
     ) {
       open('gating');
     } else {
-      close('gating');
+      close();
     }
   }, [
     membersAreLoading,
@@ -150,7 +150,7 @@ const ProtectedRoute: React.FC = () => {
       setShowLoginModal(true);
     } else {
       if (isOnWrongNetwork) open('network');
-      else close('network');
+      else close();
     }
   }, [address, close, isOnWrongNetwork, open]);
 
@@ -208,7 +208,7 @@ const ProtectedRoute: React.FC = () => {
 
   return (
     <>
-      {!isGatingOpen && userWentThroughLoginFlowRef.current && <Outlet />}
+      {!isOpen && userWentThroughLoginFlowRef.current && <Outlet />}
       <LoginRequired isOpen={showLoginModal} onClose={handleCloseLoginModal} />
     </>
   );

--- a/src/containers/addActionMenu/index.tsx
+++ b/src/containers/addActionMenu/index.tsx
@@ -16,14 +16,14 @@ type AddActionMenuProps = {
 
 const AddActionMenu: React.FC<AddActionMenuProps> = ({actions}) => {
   const {dao: daoAddressOrEns} = useParams();
-  const {isAddActionOpen, close} = useGlobalModalContext();
+  const {isOpen, close} = useGlobalModalContext('addAction');
   const {actions: usedActions, addAction} = useActionsContext();
   const {t} = useTranslation();
 
   return (
     <ModalBottomSheetSwitcher
-      isOpen={isAddActionOpen}
-      onClose={() => close('addAction')}
+      isOpen={isOpen}
+      onClose={close}
       title={t('AddActionModal.title')}
     >
       <Container>
@@ -46,7 +46,7 @@ const AddActionMenu: React.FC<AddActionMenuProps> = ({actions}) => {
               addAction({
                 name: a.type,
               });
-              close('addAction');
+              close();
             }}
           />
         ))}

--- a/src/containers/communityAddressesModal/index.tsx
+++ b/src/containers/communityAddressesModal/index.tsx
@@ -22,7 +22,7 @@ const CommunityAddressesModal: React.FC<CommunityAddressesModalProps> = ({
   const [searchValue, setSearchValue] = useState('');
   const {getValues} = useFormContext();
   const {network} = useNetwork();
-  const {isAddressesOpen, close} = useGlobalModalContext();
+  const {isOpen, close} = useGlobalModalContext('addresses');
   const [wallets, tokenSymbol, multisigWallets] = getValues([
     'wallets',
     'tokenSymbol',
@@ -71,8 +71,8 @@ const CommunityAddressesModal: React.FC<CommunityAddressesModalProps> = ({
    *************************************************/
   return (
     <ModalBottomSheetSwitcher
-      isOpen={isAddressesOpen}
-      onClose={() => close('addresses')}
+      isOpen={isOpen}
+      onClose={close}
       data-testid="communityModal"
     >
       <ModalHeader>

--- a/src/containers/delegateVotingMenu/delegateVotingMenu.tsx
+++ b/src/containers/delegateVotingMenu/delegateVotingMenu.tsx
@@ -35,8 +35,8 @@ type DelegateVotingMenuState = {
 export const DelegateVotingMenu: React.FC = () => {
   const {t} = useTranslation();
   const queryClient = useQueryClient();
-  const {close, open, modalState, isDelegateVotingOpen} =
-    useGlobalModalContext<DelegateVotingMenuState>();
+  const {isOpen, close, open, modalState} =
+    useGlobalModalContext<DelegateVotingMenuState>('delegateVoting');
 
   const formValues = useForm<IDelegateVotingFormValues>(formSettings);
   const {setValue, control} = formValues;
@@ -88,13 +88,13 @@ export const DelegateVotingMenu: React.FC = () => {
       ensName: currentDelegateEns,
     });
     setTxHash(undefined);
-    close('delegateVoting');
+    close();
     resetDelegateProcess();
   };
 
   const handleCloseLogin = () => {
     if (!isWeb3ModalOpen) {
-      close('delegateVoting');
+      close();
     }
   };
 
@@ -167,40 +167,33 @@ export const DelegateVotingMenu: React.FC = () => {
 
   // Open wrong-network menu when user is on the wrong network
   useEffect(() => {
-    if (isConnected && isDelegateVotingOpen && isOnWrongNetwork) {
+    if (isConnected && isOpen && isOnWrongNetwork) {
       open('network');
-      close('delegateVoting');
+      close();
     }
-  }, [isConnected, isDelegateVotingOpen, isOnWrongNetwork, open, close]);
+  }, [isConnected, isOpen, isOnWrongNetwork, open, close]);
 
   // Open gating menu when user has no tokens for this DAO
   useEffect(() => {
     if (
       isConnected &&
-      isDelegateVotingOpen &&
+      isOpen &&
       !isLoadingBalance &&
       tokenBalance?.value === 0n
     ) {
       open('gating');
-      close('delegateVoting');
+      close();
     }
-  }, [
-    isConnected,
-    tokenBalance?.value,
-    isLoadingBalance,
-    isDelegateVotingOpen,
-    close,
-    open,
-  ]);
+  }, [isConnected, tokenBalance?.value, isLoadingBalance, isOpen, close, open]);
 
-  if (!isConnected && isDelegateVotingOpen) {
+  if (!isConnected && isOpen) {
     return <LoginRequired isOpen={true} onClose={handleCloseLogin} />;
   }
 
   return (
     <ModalBottomSheetSwitcher
       onClose={handleCloseMenu}
-      isOpen={isDelegateVotingOpen}
+      isOpen={isOpen}
       title={t('modal.delegation.label')}
     >
       <FormProvider {...formValues}>

--- a/src/containers/delegationGatingMenu/delegationGatingMenu.tsx
+++ b/src/containers/delegationGatingMenu/delegationGatingMenu.tsx
@@ -95,7 +95,7 @@ export const DelegationGatingMenu: React.FC = () => {
             label={t('modal.delegationActive.BtnSecondaryLabel')}
             mode="secondary"
             size="large"
-            onClick={close}
+            onClick={() => close()}
           />
         </ContentGroup>
       </div>

--- a/src/containers/delegationGatingMenu/delegationGatingMenu.tsx
+++ b/src/containers/delegationGatingMenu/delegationGatingMenu.tsx
@@ -15,7 +15,7 @@ import {useWallet} from 'hooks/useWallet';
 
 export const DelegationGatingMenu: React.FC = () => {
   const {t} = useTranslation();
-  const {isDelegationGatingOpen, close, open} = useGlobalModalContext();
+  const {isOpen, close, open} = useGlobalModalContext('delegationGating');
 
   const {network, address} = useWallet();
 
@@ -53,14 +53,14 @@ export const DelegationGatingMenu: React.FC = () => {
     : 'delegationInactive';
 
   const handleReclaimClick = () => {
-    close('delegationGating');
+    close();
     open('delegateVoting', {reclaimMode: true});
   };
 
   return (
     <ModalBottomSheetSwitcher
-      onClose={() => close('delegationGating')}
-      isOpen={isDelegationGatingOpen}
+      onClose={close}
+      isOpen={isOpen}
       title={t('modal.delegationActive.title')}
     >
       <div className="flex flex-col gap-3 py-3 px-2 text-center">
@@ -95,7 +95,7 @@ export const DelegationGatingMenu: React.FC = () => {
             label={t('modal.delegationActive.BtnSecondaryLabel')}
             mode="secondary"
             size="large"
-            onClick={() => close('delegationGating')}
+            onClick={close}
           />
         </ContentGroup>
       </div>

--- a/src/containers/exportCsvModal/ExportCsvModal.tsx
+++ b/src/containers/exportCsvModal/ExportCsvModal.tsx
@@ -44,7 +44,7 @@ const ExportCsvModal: React.FC<ExportCsvModalProps> = ({
   daoDetails,
 }) => {
   const {t} = useTranslation();
-  const {isExportCsvOpen, close} = useGlobalModalContext();
+  const {isOpen, close} = useGlobalModalContext('exportCsv');
 
   const form = useForm({
     mode: 'onChange',
@@ -174,7 +174,7 @@ const ExportCsvModal: React.FC<ExportCsvModalProps> = ({
     setIsCsvGenerationError(false);
     setIsCsvGenerationSuccess(false);
     setIsFlowFinished(false);
-    close('exportCsv');
+    close();
   }, [close]);
 
   const handleFlowFinish = useCallback(() => {
@@ -183,7 +183,7 @@ const ExportCsvModal: React.FC<ExportCsvModalProps> = ({
 
   return (
     <ModalBottomSheetSwitcher
-      isOpen={isExportCsvOpen}
+      isOpen={isOpen}
       onClose={handleClose}
       title={isFlowFinished ? '' : t('finance.modalExport.headerLabel')}
       subtitle={isFlowFinished ? '' : t('finance.modalExport.headerDesc')}

--- a/src/containers/gatingMenu/index.tsx
+++ b/src/containers/gatingMenu/index.tsx
@@ -25,7 +25,7 @@ import {useDaoDetailsQuery} from 'hooks/useDaoDetails';
 import {useDaoToken} from 'hooks/useDaoToken';
 
 export const GatingMenu: React.FC = () => {
-  const {close, isGatingOpen} = useGlobalModalContext();
+  const {close, isOpen} = useGlobalModalContext('gating');
 
   const {t} = useTranslation();
   const navigate = useNavigate();
@@ -43,13 +43,13 @@ export const GatingMenu: React.FC = () => {
   const handleCloseMenu = () => {
     const governancePath = generatePath(Governance, {network, dao: daoName});
     navigate(governancePath);
-    close('gating');
+    close();
   };
 
   const handleWrapTokens = () => {
     const communityPath = generatePath(Community, {network, dao: daoName});
     navigate(communityPath);
-    close('gating');
+    close();
     handleOpenModal();
   };
 
@@ -62,7 +62,7 @@ export const GatingMenu: React.FC = () => {
       ?.symbol || '';
 
   return (
-    <ModalBottomSheetSwitcher isOpen={isGatingOpen} onClose={handleCloseMenu}>
+    <ModalBottomSheetSwitcher isOpen={isOpen} onClose={handleCloseMenu}>
       <ModalBody>
         <StyledImage src={WalletIcon} />
 

--- a/src/containers/manageWalletsModal/index.tsx
+++ b/src/containers/manageWalletsModal/index.tsx
@@ -26,7 +26,7 @@ const ManageWalletsModal: React.FC<ManageWalletsModalProps> = ({
   initialSelections,
 }) => {
   const {t} = useTranslation();
-  const {isManageWalletOpen, close} = useGlobalModalContext();
+  const {isOpen, close} = useGlobalModalContext('manageWallet');
   const [searchValue, setSearchValue] = useState('');
   const [selectedWallets, setSelectedWallets] = useState<SelectableWallets>(
     new Set()
@@ -115,7 +115,7 @@ const ManageWalletsModal: React.FC<ManageWalletsModalProps> = ({
   const handleClose = () => {
     setSearchValue('');
     setSelectedWallets(new Set());
-    close('manageWallet');
+    close();
   };
 
   /*************************************************
@@ -123,7 +123,7 @@ const ManageWalletsModal: React.FC<ManageWalletsModalProps> = ({
    *************************************************/
   return (
     <ModalBottomSheetSwitcher
-      isOpen={isManageWalletOpen}
+      isOpen={isOpen}
       onClose={handleClose}
       data-testid="manageWalletModal"
     >

--- a/src/containers/navbar/daoSelectMenu.tsx
+++ b/src/containers/navbar/daoSelectMenu.tsx
@@ -75,7 +75,7 @@ const DaoSelectMenu: React.FC = () => {
               daoAddress={toDisplayEns(currentDao?.ensDomain)}
               daoName={currentDao?.metadata.name}
               daoLogo={currentDao?.metadata?.avatar}
-              onClick={close}
+              onClick={() => close()}
             />
             {favoriteDaoCache.flatMap(dao => {
               if (

--- a/src/containers/navbar/daoSelectMenu.tsx
+++ b/src/containers/navbar/daoSelectMenu.tsx
@@ -29,7 +29,7 @@ const DaoSelectMenu: React.FC = () => {
   const navigate = useNavigate();
   const currentDao = useReactiveVar(selectedDaoVar);
   const favoriteDaoCache = useReactiveVar(favoriteDaosVar);
-  const {isSelectDaoOpen, close, open} = useGlobalModalContext();
+  const {isOpen, close, open} = useGlobalModalContext('selectDao');
 
   const handleDaoSelect = useCallback(
     (dao: NavigationDao) => {
@@ -40,20 +40,20 @@ const DaoSelectMenu: React.FC = () => {
           dao: toDisplayEns(dao.ensDomain) || dao.address,
         })
       );
-      close('selectDao');
+      close();
     },
     [close, navigate]
   );
 
   const handleBackButtonClick = useCallback(() => {
-    close('selectDao');
+    close();
     if (!isDesktop) open('mobileMenu');
   }, [close, isDesktop, open]);
 
   return (
     <ModalBottomSheetSwitcher
-      isOpen={isSelectDaoOpen}
-      onClose={() => close('selectDao')}
+      isOpen={isOpen}
+      onClose={close}
       onOpenAutoFocus={e => e.preventDefault()}
     >
       <div className="flex flex-col h-full" style={{maxHeight: '75vh'}}>
@@ -75,7 +75,7 @@ const DaoSelectMenu: React.FC = () => {
               daoAddress={toDisplayEns(currentDao?.ensDomain)}
               daoName={currentDao?.metadata.name}
               daoLogo={currentDao?.metadata?.avatar}
-              onClick={() => close('selectDao')}
+              onClick={close}
             />
             {favoriteDaoCache.flatMap(dao => {
               if (
@@ -106,7 +106,7 @@ const DaoSelectMenu: React.FC = () => {
             className="w-full"
             onClick={() => {
               navigate('/');
-              close('selectDao');
+              close();
             }}
           />
         </div>

--- a/src/containers/navbar/mobileMenu.tsx
+++ b/src/containers/navbar/mobileMenu.tsx
@@ -18,13 +18,13 @@ type MobileNavMenuProps = {
 
 const MobileNavMenu = (props: MobileNavMenuProps) => {
   const currentDao = useReactiveVar(selectedDaoVar);
-  const {open, close, isMobileMenuOpen} = useGlobalModalContext();
+  const {open, close, isOpen} = useGlobalModalContext('mobileMenu');
   const {t} = useTranslation();
 
   const {handleWithFunctionalPreferenceMenu} = usePrivacyContext();
 
   return (
-    <BottomSheet isOpen={isMobileMenuOpen} onClose={() => close('mobileMenu')}>
+    <BottomSheet isOpen={Boolean(isOpen)} onClose={close}>
       <div className="tablet:w-50">
         <CardWrapper className="rounded-xl">
           <DaoSelector
@@ -34,13 +34,13 @@ const MobileNavMenu = (props: MobileNavMenuProps) => {
             }
             src={currentDao?.metadata?.avatar}
             onClick={() => {
-              close('mobileMenu');
+              close();
               handleWithFunctionalPreferenceMenu(() => open('selectDao'));
             }}
           />
         </CardWrapper>
         <div className="py-3 px-2 space-y-3">
-          <NavLinks onItemClick={() => close('mobileMenu')} />
+          <NavLinks onItemClick={close} />
 
           <ButtonText
             className="w-full"

--- a/src/containers/networkErrorMenu/index.tsx
+++ b/src/containers/networkErrorMenu/index.tsx
@@ -14,7 +14,7 @@ import {CHAIN_METADATA} from 'utils/constants';
 import {handleClipboardActions, shortenAddress} from 'utils/library';
 
 const NetworkErrorMenu = () => {
-  const {isNetworkOpen, close} = useGlobalModalContext();
+  const {isOpen, close} = useGlobalModalContext('network');
   const {network} = useNetwork();
   const {switchWalletNetwork} = useSwitchNetwork();
   const {address, ensName, ensAvatarUrl, connectorName} = useWallet();
@@ -23,10 +23,7 @@ const NetworkErrorMenu = () => {
   const {alert} = useAlertContext();
 
   return (
-    <ModalBottomSheetSwitcher
-      onClose={() => close('network')}
-      isOpen={isNetworkOpen}
-    >
+    <ModalBottomSheetSwitcher onClose={close} isOpen={isOpen}>
       <ModalHeader>
         <AvatarAddressContainer>
           <Avatar src={ensAvatarUrl || address || ''} size="small" />
@@ -48,7 +45,7 @@ const NetworkErrorMenu = () => {
             mode="ghost"
             icon={<IconClose />}
             size="small"
-            onClick={() => close('network')}
+            onClick={close}
           />
         )}
       </ModalHeader>
@@ -75,7 +72,7 @@ const NetworkErrorMenu = () => {
             })}
             onClick={() => {
               switchWalletNetwork();
-              close('network');
+              close();
             }}
             size="large"
           />

--- a/src/containers/networkErrorMenu/index.tsx
+++ b/src/containers/networkErrorMenu/index.tsx
@@ -45,7 +45,7 @@ const NetworkErrorMenu = () => {
             mode="ghost"
             icon={<IconClose />}
             size="small"
-            onClick={close}
+            onClick={() => close()}
           />
         )}
       </ModalHeader>

--- a/src/containers/poapClaiming/PoapClaimModal.tsx
+++ b/src/containers/poapClaiming/PoapClaimModal.tsx
@@ -8,12 +8,12 @@ import ModalBottomSheetSwitcher from 'components/modalBottomSheetSwitcher';
 
 const PoapClaimModal: React.FC = () => {
   const {t} = useTranslation();
-  const {isPoapClaimOpen, close} = useGlobalModalContext();
+  const {isOpen, close} = useGlobalModalContext('poapClaim');
 
   return (
     <ModalBottomSheetSwitcher
-      isOpen={isPoapClaimOpen}
-      onClose={() => close('poapClaim')}
+      isOpen={isOpen}
+      onClose={close}
       title={t('modal.claimPoap.title')}
     >
       <Container>
@@ -33,7 +33,7 @@ const PoapClaimModal: React.FC = () => {
             iconRight={<IconLinkExternal />}
             onClick={() => {
               window.open(t('modal.claimPoap.ctaURL'), '_blank');
-              close('poapClaim');
+              close();
             }}
           />
         </BodyWrapper>

--- a/src/containers/tokenMenu/index.tsx
+++ b/src/containers/tokenMenu/index.tsx
@@ -35,7 +35,7 @@ const TokenMenu: React.FC<TokenMenuProps> = ({
 }) => {
   const {t} = useTranslation();
   const {data: tokens} = useTokenMetadata(tokenBalances);
-  const {isTokenOpen, close} = useGlobalModalContext();
+  const {isOpen, close} = useGlobalModalContext('token');
   const [searchValue, setSearchValue] = useState('');
 
   /*************************************************
@@ -51,7 +51,7 @@ const TokenMenu: React.FC<TokenMenuProps> = ({
       symbol: token.metadata.symbol,
       decimals: token.metadata.decimals,
     });
-    close('token');
+    close();
   };
 
   const filterValidator = useCallback(
@@ -140,8 +140,8 @@ const TokenMenu: React.FC<TokenMenuProps> = ({
    *************************************************/
   return (
     <ModalBottomSheetSwitcher
-      isOpen={isTokenOpen}
-      onClose={() => close('token')}
+      isOpen={isOpen}
+      onClose={close}
       data-testid="TokenMenu"
     >
       <Container>
@@ -162,7 +162,7 @@ const TokenMenu: React.FC<TokenMenuProps> = ({
           iconLeft={<IconAdd />}
           onClick={() => {
             onTokenSelect({...customToken, symbol: searchValue});
-            close('token');
+            close();
           }}
         />
       </Container>

--- a/src/containers/transactionModals/depositModal.tsx
+++ b/src/containers/transactionModals/depositModal.tsx
@@ -18,7 +18,7 @@ const DepositModal: React.FC = () => {
   const {t} = useTranslation();
   const navigate = useNavigate();
   const {network} = useNetwork();
-  const {isDepositOpen, open, close} = useGlobalModalContext();
+  const {isOpen, open, close} = useGlobalModalContext('deposit');
   const {status, isConnected, isOnWrongNetwork} = useWallet();
 
   const {data: daoDetails} = useDaoDetailsQuery();
@@ -38,7 +38,7 @@ const DepositModal: React.FC = () => {
       if (!isConnected) open('wallet');
       else {
         if (isOnWrongNetwork) open('network');
-        else close('network');
+        else close();
       }
     }
   }, [close, isConnected, isOnWrongNetwork, open]);
@@ -46,7 +46,7 @@ const DepositModal: React.FC = () => {
   // Close the login modal once the status is connecting
   useEffect(() => {
     if (loginFlowTriggeredRef.current) {
-      if (status === 'connecting' || isConnected) close('wallet');
+      if (status === 'connecting' || isConnected) close();
     }
   }, [close, isConnected, isOnWrongNetwork, open, status]);
 
@@ -64,7 +64,7 @@ const DepositModal: React.FC = () => {
    *             Callbacks and Handlers            *
    *************************************************/
   const handleCtaClicked = useCallback(() => {
-    close('deposit');
+    close();
     navigate(
       generatePath(AllTransfers, {
         network,
@@ -75,7 +75,7 @@ const DepositModal: React.FC = () => {
 
   // close modal and initiate the login/wrong network flow
   const handleConnectClick = useCallback(() => {
-    close('deposit');
+    close();
     loginFlowTriggeredRef.current = true;
   }, [close]);
 
@@ -86,8 +86,8 @@ const DepositModal: React.FC = () => {
 
   return (
     <ModalBottomSheetSwitcher
-      isOpen={isDepositOpen}
-      onClose={() => close('deposit')}
+      isOpen={isOpen}
+      onClose={close}
       title={t('modal.deposit.headerTitle')}
       subtitle={t('modal.deposit.headerDescription')}
     >
@@ -139,7 +139,7 @@ const DepositModal: React.FC = () => {
             mode="secondary"
             size="large"
             label={t('modal.deposit.cancelLabel')}
-            onClick={() => close('deposit')}
+            onClick={close}
           />
         </HStack>
       </Container>

--- a/src/containers/transactionModals/depositModal.tsx
+++ b/src/containers/transactionModals/depositModal.tsx
@@ -139,7 +139,7 @@ const DepositModal: React.FC = () => {
             mode="secondary"
             size="large"
             label={t('modal.deposit.cancelLabel')}
-            onClick={close}
+            onClick={() => close()}
           />
         </HStack>
       </Container>

--- a/src/containers/transferMenu/index.tsx
+++ b/src/containers/transferMenu/index.tsx
@@ -13,7 +13,7 @@ import {NewWithDraw} from 'utils/paths';
 type Action = 'deposit_assets' | 'withdraw_assets';
 
 const TransferMenu: React.FC = () => {
-  const {isTransferOpen, close, open} = useGlobalModalContext();
+  const {isOpen, close, open} = useGlobalModalContext('transfer');
   const {t} = useTranslation();
   const {network} = useNetwork();
   const {dao} = useParams();
@@ -30,13 +30,13 @@ const TransferMenu: React.FC = () => {
     } else {
       navigate(generatePath(NewWithDraw, {network: network, dao: dao}));
     }
-    close('transfer');
+    close();
   };
 
   return (
     <ModalBottomSheetSwitcher
-      isOpen={isTransferOpen}
-      onClose={() => close('transfer')}
+      isOpen={isOpen}
+      onClose={close}
       title={t('TransferModal.newTransfer')}
     >
       <Container>

--- a/src/containers/utcMenu/index.tsx
+++ b/src/containers/utcMenu/index.tsx
@@ -12,13 +12,13 @@ type UtcMenuProps = {
 };
 
 const UtcMenu: React.FC<UtcMenuProps> = ({onTimezoneSelect}) => {
-  const {isUtcOpen, close} = useGlobalModalContext();
+  const {isOpen, close} = useGlobalModalContext('utc');
   const [searchTerm, setSearchTerm] = useState<string>('');
   const {t} = useTranslation();
 
   const handleUtcClick = (tz: string) => {
     onTimezoneSelect(tz);
-    close('utc');
+    close();
   };
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -33,8 +33,8 @@ const UtcMenu: React.FC<UtcMenuProps> = ({onTimezoneSelect}) => {
 
   return (
     <ModalBottomSheetSwitcher
-      isOpen={isUtcOpen}
-      onClose={() => close('utc')}
+      isOpen={isOpen}
+      onClose={close}
       title={t('newWithdraw.configureWithdraw.utcMenu.title')}
     >
       <ModalBody>

--- a/src/containers/walletMenu/LoginRequired.tsx
+++ b/src/containers/walletMenu/LoginRequired.tsx
@@ -22,18 +22,18 @@ type Props = {
 };
 
 export const LoginRequired: React.FC<Props> = props => {
-  const {close, isWalletOpen} = useGlobalModalContext();
+  const {close, isOpen} = useGlobalModalContext('wallet');
   const {t} = useTranslation();
   const {isDesktop} = useScreen();
   const {methods} = useWallet();
 
   // allow modal to be used both via global modal context &&
   // as individually controlled component.
-  const showModal = props.isOpen ?? isWalletOpen;
+  const showModal = props.isOpen ?? isOpen;
 
   const handleClose = useCallback(() => {
     if (props.onClose) props.onClose();
-    else close('wallet');
+    else close();
   }, [close, props]);
 
   return (
@@ -60,7 +60,7 @@ export const LoginRequired: React.FC<Props> = props => {
         <ButtonText
           label={t('alert.loginRequired.buttonLabel')}
           onClick={() => {
-            close('wallet');
+            close();
             methods.selectWallet().catch((err: Error) => {
               // To be implemented: maybe add an error message when
               // the error is different from closing the window

--- a/src/containers/walletMenu/index.tsx
+++ b/src/containers/walletMenu/index.tsx
@@ -22,7 +22,7 @@ import {handleClipboardActions, shortenAddress} from 'utils/library';
 import {LoginRequired} from './LoginRequired';
 
 export const WalletMenu = () => {
-  const {close, isWalletOpen} = useGlobalModalContext();
+  const {close, isOpen} = useGlobalModalContext('wallet');
   const {
     address,
     ensName,
@@ -53,7 +53,7 @@ export const WalletMenu = () => {
           wallet_provider: provider?.connection.url,
         });
         localStorage.removeItem('WEB3_CONNECT_CACHED_PROVIDER');
-        close('wallet');
+        close();
         alert(t('alert.chip.walletDisconnected'));
       })
       .catch((e: Error) => {
@@ -75,10 +75,7 @@ export const WalletMenu = () => {
   if (!isConnected) return <LoginRequired />;
 
   return (
-    <ModalBottomSheetSwitcher
-      onClose={() => close('wallet')}
-      isOpen={isWalletOpen}
-    >
+    <ModalBottomSheetSwitcher onClose={close} isOpen={isOpen}>
       <ModalHeader>
         <AvatarAddressContainer>
           <Avatar src={ensAvatarUrl || address || ''} size="small" />
@@ -100,7 +97,7 @@ export const WalletMenu = () => {
             mode="ghost"
             icon={<IconClose />}
             size="small"
-            onClick={() => close('wallet')}
+            onClick={close}
           />
         )}
       </ModalHeader>

--- a/src/containers/walletMenu/index.tsx
+++ b/src/containers/walletMenu/index.tsx
@@ -97,7 +97,7 @@ export const WalletMenu = () => {
             mode="ghost"
             icon={<IconClose />}
             size="small"
-            onClick={close}
+            onClick={() => close()}
           />
         )}
       </ModalHeader>

--- a/src/context/globalModals.tsx
+++ b/src/context/globalModals.tsx
@@ -14,7 +14,7 @@ type GlobalModalsContextType<TState = Record<string, unknown>> = {
   modalState?: TState;
   isOpen?: boolean;
   open: (dialog: DialogType, state?: Record<string, unknown>) => void;
-  close: () => void;
+  close: (onClose?: () => void) => void;
 };
 
 export type DialogType =
@@ -42,9 +42,10 @@ export const GlobalModalsProvider: React.FC<Props> = ({children}) => {
   const [activeDialog, setActiveDialog] = useState<DialogType>();
   const [modalState, setModalState] = useState<Record<string, unknown>>();
 
-  const close = useCallback(() => {
+  const close = useCallback((onClose?: () => void) => {
     setActiveDialog(undefined);
     setModalState(undefined);
+    onClose?.();
   }, []);
 
   const open = useCallback(

--- a/src/context/globalModals.tsx
+++ b/src/context/globalModals.tsx
@@ -10,28 +10,14 @@ import React, {
 const GlobalModalsContext = createContext<GlobalModalsContextType | null>(null);
 
 type GlobalModalsContextType<TState = Record<string, unknown>> = {
-  isTransferOpen: boolean;
-  isTokenOpen: boolean;
-  isUtcOpen: boolean;
-  isSelectDaoOpen: boolean;
-  isAddActionOpen: boolean;
-  isAddressesOpen: boolean;
-  isWalletOpen: boolean;
-  isNetworkOpen: boolean;
-  isMobileMenuOpen: boolean;
-  isManageWalletOpen: boolean;
-  isGatingOpen: boolean;
-  isDepositOpen: boolean;
-  isPoapClaimOpen: boolean;
-  isExportCsvOpen: boolean;
-  isDelegateVotingOpen: boolean;
-  isDelegationGatingOpen: boolean;
+  activeDialog?: DialogType;
   modalState?: TState;
-  open: (menu: MenuTypes, state?: Record<string, unknown>) => void;
-  close: (menu: MenuTypes) => void;
+  isOpen?: boolean;
+  open: (dialog: DialogType, state?: Record<string, unknown>) => void;
+  close: () => void;
 };
 
-export type MenuTypes =
+export type DialogType =
   | 'transfer'
   | 'token'
   | 'utc'
@@ -52,169 +38,31 @@ export type MenuTypes =
 
 type Props = Record<'children', ReactNode>;
 
-/* TODO This should be reworked to have one state that holds the open menu,
-instead of one boolean state for each of the menus. This can be done based on a
-type like MenuType. Then this context can be extended simply by adding a new
-type to MenuTypes. */
 export const GlobalModalsProvider: React.FC<Props> = ({children}) => {
-  const [isTransferOpen, setIsTransferOpen] =
-    useState<GlobalModalsContextType['isTransferOpen']>(false);
-  const [isTokenOpen, setIsTokenOpen] =
-    useState<GlobalModalsContextType['isTokenOpen']>(false);
-  const [isUtcOpen, setIsUtcOpen] =
-    useState<GlobalModalsContextType['isUtcOpen']>(false);
-  const [isAddActionOpen, setIsAddActionOpen] =
-    useState<GlobalModalsContextType['isAddActionOpen']>(false);
-  const [isSelectDaoOpen, setIsSelectDaoOpen] =
-    useState<GlobalModalsContextType['isSelectDaoOpen']>(false);
-  const [isAddressesOpen, setAddressesOpen] =
-    useState<GlobalModalsContextType['isAddressesOpen']>(false);
-  const [isWalletOpen, setWalletOpen] =
-    useState<GlobalModalsContextType['isWalletOpen']>(false);
-  const [isNetworkOpen, setNetworkOpen] =
-    useState<GlobalModalsContextType['isNetworkOpen']>(false);
-  const [isMobileMenuOpen, setMobileMenuOpen] =
-    useState<GlobalModalsContextType['isMobileMenuOpen']>(false);
-  const [isManageWalletOpen, setManageWalletOpen] =
-    useState<GlobalModalsContextType['isManageWalletOpen']>(false);
-  const [isGatingOpen, setIsGatingOpen] =
-    useState<GlobalModalsContextType['isGatingOpen']>(false);
-  const [isDepositOpen, setIsDepositOpen] =
-    useState<GlobalModalsContextType['isDepositOpen']>(false);
-  const [isPoapClaimOpen, setIsPoapClaimOpen] =
-    useState<GlobalModalsContextType['isPoapClaimOpen']>(false);
-  const [isExportCsvOpen, setIsExportCsvOpen] =
-    useState<GlobalModalsContextType['isExportCsvOpen']>(false);
-  const [isDelegateVotingOpen, setIsDelegateVotingOpen] =
-    useState<GlobalModalsContextType['isDelegateVotingOpen']>(false);
-  const [isDelegationGatingOpen, setIsDelegationGatingOpen] =
-    useState<GlobalModalsContextType['isDelegateVotingOpen']>(false);
-
+  const [activeDialog, setActiveDialog] = useState<DialogType>();
   const [modalState, setModalState] = useState<Record<string, unknown>>();
 
-  const toggle = useCallback((type: MenuTypes, isOpen = true) => {
-    switch (type) {
-      case 'token':
-        setIsTokenOpen(isOpen);
-        break;
-      case 'utc':
-        setIsUtcOpen(isOpen);
-        break;
-      case 'addAction':
-        setIsAddActionOpen(isOpen);
-        break;
-      case 'selectDao':
-        setIsSelectDaoOpen(isOpen);
-        break;
-      case 'addresses':
-        setAddressesOpen(isOpen);
-        break;
-      case 'wallet':
-        setWalletOpen(isOpen);
-        break;
-      case 'network':
-        setNetworkOpen(isOpen);
-        break;
-      case 'mobileMenu':
-        setMobileMenuOpen(isOpen);
-        break;
-      case 'manageWallet':
-        setManageWalletOpen(isOpen);
-        break;
-      case 'gating':
-        setIsGatingOpen(isOpen);
-        break;
-      case 'deposit':
-        setIsDepositOpen(isOpen);
-        break;
-      case 'poapClaim':
-        setIsPoapClaimOpen(isOpen);
-        break;
-      case 'delegateVoting':
-        setIsDelegateVotingOpen(isOpen);
-        break;
-      case 'transfer':
-        setIsTransferOpen(isOpen);
-        break;
-      case 'exportCsv':
-        setIsExportCsvOpen(isOpen);
-        break;
-      case 'delegationGating':
-        setIsDelegationGatingOpen(isOpen);
-        break;
-      default:
-        throw new Error(`GlobalModals: modal ${type} unsupported`);
-    }
+  const close = useCallback(() => {
+    setActiveDialog(undefined);
+    setModalState(undefined);
   }, []);
 
-  const close = useCallback(
-    (type: MenuTypes) => {
-      toggle(type, false);
-      setModalState(undefined);
-    },
-    [toggle]
-  );
   const open = useCallback(
-    (type: MenuTypes, state?: Record<string, unknown>) => {
-      toggle(type, true);
+    (dialog: DialogType, state?: Record<string, unknown>) => {
+      setActiveDialog(dialog);
       setModalState(state);
     },
-    [toggle]
+    []
   );
-
-  /**
-   * TODO: ==============================================
-   * I used this context for managing all modals but we should
-   * categories the modal pages and organize it in a better way
-   *====================================================
-   */
-  // Since the modals can not be open at the same time, I actually think this is
-  // a good solution. Keeps the logic in one place and makes it simply to
-  // extend. [VR 10-01-2022]
 
   const value = useMemo(
     (): GlobalModalsContextType => ({
-      isTransferOpen,
-      isTokenOpen,
-      isUtcOpen,
-      isAddActionOpen,
-      isSelectDaoOpen,
-      isAddressesOpen,
-      isWalletOpen,
-      isNetworkOpen,
-      isMobileMenuOpen,
-      isManageWalletOpen,
-      isGatingOpen,
-      isDepositOpen,
-      isPoapClaimOpen,
-      isExportCsvOpen,
-      isDelegateVotingOpen,
-      isDelegationGatingOpen,
+      activeDialog,
       modalState,
       open,
       close,
     }),
-    [
-      isAddActionOpen,
-      isAddressesOpen,
-      isDepositOpen,
-      isExportCsvOpen,
-      isGatingOpen,
-      isManageWalletOpen,
-      isMobileMenuOpen,
-      isNetworkOpen,
-      isPoapClaimOpen,
-      isSelectDaoOpen,
-      isTokenOpen,
-      isTransferOpen,
-      isUtcOpen,
-      isWalletOpen,
-      isDelegateVotingOpen,
-      isDelegationGatingOpen,
-      modalState,
-      open,
-      close,
-    ]
+    [activeDialog, modalState, open, close]
   );
 
   return (
@@ -224,9 +72,9 @@ export const GlobalModalsProvider: React.FC<Props> = ({children}) => {
   );
 };
 
-export const useGlobalModalContext = <
-  TState extends object
->(): GlobalModalsContextType<TState> => {
+export const useGlobalModalContext = <TState extends object>(
+  dialog?: DialogType
+): GlobalModalsContextType<TState> => {
   const values = useContext(GlobalModalsContext);
 
   if (values == null) {
@@ -235,5 +83,9 @@ export const useGlobalModalContext = <
     );
   }
 
-  return {...values, modalState: values.modalState as TState};
+  return {
+    ...values,
+    isOpen: dialog ? values.activeDialog === dialog : undefined,
+    modalState: values.modalState as TState,
+  };
 };


### PR DESCRIPTION
## Description

- As we are only opening one dialog at a time, we don't really need to keep track of every dialog's open/closed state but we can just use one `activeDialog` variable that is going to be set as the name of the current active dialog;
- With this in place, we can either call the `useGlobalModalContext` hook with the dialog name we are handling to check if the current dialog is open or not (e.g. `const { isOpen } = useGlobalModalContext('transfer')`) or we can use the `activeDialog` variable set on the context (e.g. `const { activeDialog } = useGlobalModalContext; const isOpen = activeDialog === 'transfer';`);
- Similarly, for the `close` function, we don't need to specify which dialog we want to close as there will be only one dialog to close;

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.
