### PR TITLE
fix: APP-2369 - Fix entry point to delegation flow on voting terminal

### DIFF
--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -49,8 +49,7 @@ import useScreen from 'hooks/useScreen';
 import {useWallet} from 'hooks/useWallet';
 import {useWalletCanVote} from 'hooks/useWalletCanVote';
 import {useTokenAsync} from 'services/token/queries/use-token';
-import {CHAIN_METADATA, SupportedNetworks} from 'utils/constants';
-import {constants} from 'ethers';
+import {CHAIN_METADATA} from 'utils/constants';
 import {
   decodeAddMembersToAction,
   decodeMetadataToAction,
@@ -77,10 +76,7 @@ import {
 } from 'utils/proposals';
 import {Action, ProposalId} from 'utils/types';
 import {useDaoToken} from 'hooks/useDaoToken';
-import {BigNumber} from 'ethers';
-import {usePastVotingPower} from 'services/aragon-sdk/queries/use-past-voting-power';
-import {Address} from 'viem';
-import {useBalance} from 'wagmi';
+import {useDelegatee} from 'services/aragon-sdk/queries/use-delegatee';
 
 // TODO: @Sepehr Please assign proper tags on action decoding
 // const PROPOSAL_TAGS = ['Finance', 'Withdraw'];
@@ -170,22 +166,11 @@ export const Proposal: React.FC = () => {
     proposal?.status as string
   );
 
-  const {data: tokenBalanceData} = useBalance({
-    address: address as Address,
-    token: daoToken?.address as Address,
-    chainId: CHAIN_METADATA[network as SupportedNetworks].id,
-    enabled: address != null && daoToken != null,
-  });
-  const tokenBalance = BigNumber.from(tokenBalanceData?.value ?? 0);
-
-  const {data: pastVotingPower = constants.Zero} = usePastVotingPower(
-    {
-      address: address as string,
-      tokenAddress: daoToken?.address as string,
-      blockNumber: proposal?.creationBlockNumber as number,
-    },
-    {enabled: address != null && daoToken != null && proposal != null}
+  const {data: delegateData} = useDelegatee(
+    {tokenAddress: daoToken?.address as string},
+    {enabled: !multisigDAO && !isOnWrongNetwork && daoToken != null}
   );
+  const currentDelegate = delegateData === null ? address : delegateData;
 
   const pluginClient = usePluginClient(pluginType);
 
@@ -199,12 +184,8 @@ export const Proposal: React.FC = () => {
   const [votingInProcess, setVotingInProcess] = useState(false);
   const [expandedProposal, setExpandedProposal] = useState(false);
 
-  // Display the voting-power gating dialog when user has balance but delegated
-  // his token to someone else
-  const displayVotingGate =
-    !multisigDAO &&
-    tokenBalance.gt(constants.Zero) &&
-    pastVotingPower.lte(constants.Zero);
+  // Display the voting-power gating dialog when user delegated his voting power
+  const displayVotingGate = !multisigDAO && currentDelegate !== address;
 
   const editor = useEditor({
     editable: false,


### PR DESCRIPTION
## Description

- The `canVote` function from the SDK already checks if the user can vote based on his past voting power. In order to display the delegation flow when the user delegated his tokens, we need to check if the user's balance is greater than zero and his past voting power is zero, meaning that he delegate his voting power to another address or didn't reclaim his voting power yet.

Task: [APP-2369](https://aragonassociation.atlassian.net/browse/APP-2369)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2369]: https://aragonassociation.atlassian.net/browse/APP-2369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ