### PR TITLE
fix: APP-2380 - Fix reclaim flow when user has ENS

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,11 @@ This guide provides information on various topics related to developing with Ara
 
 ## Contents
 
-- [Feature Flags](./feature-flags.md)
+- [Feature Flags](./featureFlags.md)
   Feature flags in the Aragon App allow developers to enable or disable certain features depending on the environment.
 
-- [Local Development with Linked ODS Library](./local-development-with-linked-ods-library.md)
+- [Local Development with Linked ODS Library](./linkOdsLibrary.md)
   Discover how to test and develop the Aragon ODS library locally by creating a link to the `@aragon/ods` package.
 
-- [Network State](./network-state.md)
+- [Network State](./networkState.md)
   Understand how the current network is determined for every page in the application.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.5.8",
-    "@aragon/ods": "^0.2.12",
+    "@aragon/ods": "^0.2.13",
     "@aragon/sdk-client": "^1.13.1-rc1",
     "@elastic/apm-rum-react": "^2.0.0",
     "@radix-ui/react-accordion": "^1.1.2",

--- a/src/containers/delegateVotingMenu/delegateVotingMenu.tsx
+++ b/src/containers/delegateVotingMenu/delegateVotingMenu.tsx
@@ -152,7 +152,7 @@ export const DelegateVotingMenu: React.FC = () => {
         ensName: currentDelegateEns,
       });
     }
-  }, [setValue, currentDelegate, currentDelegateEns, address]);
+  }, [setValue, currentDelegate, currentDelegateEns]);
 
   // Set the token-delegate form field to connected address when the dialog
   // is opened in reclaim mode

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,10 +41,10 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.0"
 
-"@aragon/ods@^0.2.12":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@aragon/ods/-/ods-0.2.12.tgz#310bd2686acc84165a02c11c379c24424b69193b"
-  integrity sha512-M2m+jWCbDVXntNowzoAMfUJTDSX73sW9Px+j1XAZOmdAYPBrVXKukuvIpfu9gN+JZ69/rmxuUw8PvK6v/EFgOA==
+"@aragon/ods@^0.2.13":
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/@aragon/ods/-/ods-0.2.13.tgz#ebf3c2a93a29a49b998f0996deea20601b4c2ab8"
+  integrity sha512-52PbLWtPe8xP6mHwK113qbopa/eRwJbxC20h4o6t6fr9KADndNBfe+9jCfOJ2OMc83M0wEqnvIyYutyMdscqlA==
   dependencies:
     "@radix-ui/react-dialog" "^1.0.4"
     "@radix-ui/react-dropdown-menu" "^2.0.5"


### PR DESCRIPTION
## Description

- Update the `@aragon/ods` library to include a fix on the `WalletInput` component (programmatically changing the input value when previous address has ENS)
- Remove unneeded dependency on `useEffect` call
- Fix documentation links

Task: [APP-2380](https://aragonassociation.atlassian.net/browse/APP-2380)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2380]: https://aragonassociation.atlassian.net/browse/APP-2380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ