### PR TITLE
fix: break words in proposal title to fix overflow of long word

### DIFF
--- a/src/components/daoCard/index.tsx
+++ b/src/components/daoCard/index.tsx
@@ -91,7 +91,7 @@ const HeaderContainer = styled.div.attrs({
 })``;
 
 const Title = styled.p.attrs({
-  className: 'font-bold text-ui-800 ft-text-xl',
+  className: 'font-bold text-ui-800 ft-text-xl break-words',
 })``;
 
 // The line desktop breakpoint does not work with


### PR DESCRIPTION
## Description

I've added tailwindcss class to title inside proposal card, so that it doesn't overflow to side when there's a long word in title. This should fix the layout breaking on mobile devices. 

Fixes #1022 

Task: no task

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.
