### PR TITLE
fix: APP-2348 tweaked validation appearance for minting tokens action

### DIFF
--- a/src/containers/actionBuilder/mintTokens/addressTokenRow.tsx
+++ b/src/containers/actionBuilder/mintTokens/addressTokenRow.tsx
@@ -10,7 +10,7 @@ import {
   TextInput,
 } from '@aragon/ods';
 import Big from 'big.js';
-import React, {useCallback} from 'react';
+import React, {useCallback, useEffect} from 'react';
 import {Controller, useFormContext, useWatch} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
@@ -151,6 +151,12 @@ const TokenField: React.FC<IndexProps> = ({actionIndex, fieldIndex}) => {
     if (Number(value) > 0) return true;
     return t('errors.lteZero') as string;
   };
+
+  useEffect(() => {
+    trigger(
+      `actions.${actionIndex}.inputs.mintTokensToWallets.${fieldIndex}.amount`
+    );
+  }, [actionIndex, fieldIndex, trigger]);
 
   return (
     <Controller


### PR DESCRIPTION
## Description

Minting New DAO Tokens - 'The amount must be greater than zero' message disabled by default

Task: [APP-2348 ](https://aragonassociation.atlassian.net/browse/APP-2348 )

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.
