### PR TITLE
feat: APP-2462 everything to display dao credentials dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.5.8",
-    "@aragon/ods": "^0.2.17",
+    "@aragon/ods": "^0.2.18",
     "@aragon/sdk-client": "^1.13.1-rc1",
     "@elastic/apm-rum-react": "^2.0.0",
     "@radix-ui/react-accordion": "^1.1.2",

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -162,12 +162,13 @@ export const Dashboard: React.FC = () => {
     removePendingDaoMutation,
   ]);
 
-  const handleClipboardActions = useCallback(async () => {
-    await navigator.clipboard.writeText(
-      `https://app.aragon.org/#/daos/${network}/${liveAddressOrEns}`
-    );
-    alert(t('alert.chip.inputCopied'));
-  }, [alert, liveAddressOrEns, network, t]);
+  const onCopy = useCallback(
+    async (copyContent: string) => {
+      await navigator.clipboard.writeText(copyContent);
+      alert(t('alert.chip.inputCopied'));
+    },
+    [alert, t]
+  );
 
   const handleFavoriteClick = useCallback(
     async (dao: NavigationDao) => {
@@ -261,6 +262,7 @@ export const Dashboard: React.FC = () => {
           <HeaderDao
             daoName={liveDao.metadata.name}
             daoEnsName={toDisplayEns(liveDao.ensDomain)}
+            // daoAddress={liveDao.address}
             daoAvatar={liveDao?.metadata?.avatar}
             daoUrl={`app.aragon.org/#/daos/${network}/${liveAddressOrEns}`}
             description={liveDao.metadata.description}
@@ -271,7 +273,7 @@ export const Dashboard: React.FC = () => {
             daoChain={CHAIN_METADATA[network].name}
             daoType={daoType}
             favorited={isFavoritedDao}
-            copiedOnClick={handleClipboardActions}
+            // onCopy={onCopy}
             onFavoriteClick={() =>
               handleFavoriteClick({
                 address: liveDao.address.toLowerCase(),

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -262,7 +262,7 @@ export const Dashboard: React.FC = () => {
           <HeaderDao
             daoName={liveDao.metadata.name}
             daoEnsName={toDisplayEns(liveDao.ensDomain)}
-            // daoAddress={liveDao.address}
+            daoAddress={liveDao.address}
             daoAvatar={liveDao?.metadata?.avatar}
             daoUrl={`app.aragon.org/#/daos/${network}/${liveAddressOrEns}`}
             description={liveDao.metadata.description}
@@ -273,7 +273,7 @@ export const Dashboard: React.FC = () => {
             daoChain={CHAIN_METADATA[network].name}
             daoType={daoType}
             favorited={isFavoritedDao}
-            // onCopy={onCopy}
+            onCopy={onCopy}
             onFavoriteClick={() =>
               handleFavoriteClick({
                 address: liveDao.address.toLowerCase(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,10 +46,10 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.0"
 
-"@aragon/ods@^0.2.17":
-  version "0.2.17"
-  resolved "https://registry.yarnpkg.com/@aragon/ods/-/ods-0.2.17.tgz#c714849d8b3e7b418caf480136a1cc0055e2a1bd"
-  integrity sha512-4yzowzMmSNvcrbiQmVBnics6X5DQoe8M6pxtyVbdvZdoLJNgLanZPfPLgD+j1NJMl7eprtYedJyV9V4lToxXqw==
+"@aragon/ods@^0.2.18":
+  version "0.2.18"
+  resolved "https://registry.yarnpkg.com/@aragon/ods/-/ods-0.2.18.tgz#e030e1a8467322fa19f47befa99b4626cdf024c4"
+  integrity sha512-rxY5EPTpRqSt2IVHSRbxR/mgDUBZmPeh02Jnk8DMLTyb3YBoff93yIXpUSoQ0CMkLMDkHxXjEP5fJZ5BsZOuHg==
   dependencies:
     "@radix-ui/react-dialog" "^1.0.4"
     "@radix-ui/react-dropdown-menu" "^2.0.5"


### PR DESCRIPTION
## Description

As a user, I want to be able to access my DAO address name from the dashboard so that I don’t have to go all the way to the deposit flow (currently the fastest way to access the DAO address).

**Needs to be merged AFTER ODS PR is approved and new version of ODS released to support this change.**
Here's my ODS PR: https://github.com/aragon/ods/pull/32 @Fabricevladimir @RuggeroCino 

Task: [APP-2462](https://aragonassociation.atlassian.net/browse/APP-2462)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2462]: https://aragonassociation.atlassian.net/browse/APP-2462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ