### PR TITLE
fix: FL-2485 - Correctly handle start/end time inputs on proposal creation

### DIFF
--- a/src/containers/reviewProposal/index.tsx
+++ b/src/containers/reviewProposal/index.tsx
@@ -95,7 +95,7 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
 
   const formattedStartDate = useMemo(() => {
     const {startSwitch} = values;
-    if (startSwitch === 'now' || isMultisig) {
+    if (startSwitch === 'now') {
       return t('labels.now');
     }
 
@@ -103,7 +103,7 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
       startDate,
       KNOWN_FORMATS.proposals
     )} ${getFormattedUtcOffset()}`;
-  }, [isMultisig, startDate, t, values]);
+  }, [startDate, t, values]);
 
   /**
    * This is the primary (approximate) end date display which is rendered in Voting Terminal


### PR DESCRIPTION
## Description

- Fix racing condition on `dateTimeSelector` component when validating date and time inputs
- Correctly display start-time and strategy on new multisig proposal preview

Task: [APP-2485](https://aragonassociation.atlassian.net/browse/APP-2485)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2485]: https://aragonassociation.atlassian.net/browse/APP-2485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ