### PR TITLE
fix: APP-2473 SCCAction tuples

### DIFF
--- a/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/src/containers/smartContractComposer/components/inputForm.tsx
@@ -357,7 +357,11 @@ export const ComponentForType: React.FC<ComponentForTypeProps> = ({
                   input={component}
                   functionName={`${functionName}.${input.name}`}
                   formHandleName={
-                    formHandleName ? `${formHandleName}[${index}]` : undefined
+                    formHandleName
+                      ? `${formHandleName}[${index}]`
+                      : disabled
+                      ? `${formName}[${index}]`
+                      : undefined
                   }
                   disabled={disabled}
                   isValid={isValid}
@@ -458,7 +462,7 @@ export function FormlessComponentForType({
         return (
           <>
             {input.components?.map(component => (
-              <div key={component.name}>
+              <div key={component.name} className="ml-3">
                 <div className="mb-1.5 text-base font-bold capitalize text-ui-800">
                   {input.name}
                 </div>
@@ -474,18 +478,20 @@ export function FormlessComponentForType({
       return (
         <>
           {Object.entries(input.value as {}).map((value, index) => {
-            return (
-              <div key={index}>
-                <div className="mb-1.5 text-base font-bold capitalize text-ui-800">
-                  {value[0]}
+            if (Number.isNaN(parseInt(value[0]))) {
+              return (
+                <div key={index} className="ml-3">
+                  <div className="mb-1.5 text-base font-bold capitalize text-ui-800">
+                    {value[0]}
+                  </div>
+                  <FormlessComponentForType
+                    key={index}
+                    input={{value: value[1], type: typeof value[1]} as Input}
+                    disabled={disabled}
+                  />
                 </div>
-                <FormlessComponentForType
-                  key={index}
-                  input={{value: value[1], type: typeof value[1]} as Input}
-                  disabled={disabled}
-                />
-              </div>
-            );
+              );
+            }
           })}
         </>
       );

--- a/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/src/containers/smartContractComposer/components/inputForm.tsx
@@ -37,7 +37,6 @@ const extractTupleValues = (
   formData: Record<string, unknown>
 ) => {
   const tuple: unknown[] = [];
-  console.log('formData', formData);
 
   input.components?.map(component => {
     if (component.type !== 'tuple') {

--- a/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/src/containers/smartContractComposer/components/inputForm.tsx
@@ -305,11 +305,6 @@ export const ComponentForType: React.FC<ComponentForTypeProps> = ({
       );
 
     case 'int':
-    case 'uint8':
-    case 'int8':
-    case 'uint32':
-    case 'int32':
-    case 'uint256':
       return (
         <Controller
           defaultValue=""
@@ -357,14 +352,15 @@ export const ComponentForType: React.FC<ComponentForTypeProps> = ({
                   input={component}
                   functionName={`${functionName}.${input.name}`}
                   formHandleName={
-                    formHandleName
-                      ? `${formHandleName}[${index}]`
-                      : disabled
-                      ? `${formName}[${index}]`
-                      : undefined
+                    formHandleName ? `${formHandleName}[${index}]` : undefined
                   }
                   disabled={disabled}
                   isValid={isValid}
+                  defaultValue={
+                    defaultValue
+                      ? (defaultValue as Array<unknown>)[index]
+                      : undefined
+                  }
                 />
               </div>
             ))}
@@ -442,11 +438,6 @@ export function FormlessComponentForType({
       );
 
     case 'int':
-    case 'uint8':
-    case 'int8':
-    case 'uint32':
-    case 'int32':
-    case 'uint256':
       return (
         <NumberInput
           name={input.name}


### PR DESCRIPTION
## Description

**Refer to [APP-2220](https://aragonassociation.atlassian.net/browse/APP-2220) for the test cases and QA instructions**

- Tuple fields were being shown twice on execution widget on the proposal page. Removed that.
- Fixed empty tuple fields on the review proposal page's execution widget.

Task: [APP-2473](https://aragonassociation.atlassian.net/browse/APP-2473)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the test network.


[APP-2473]: https://aragonassociation.atlassian.net/browse/APP-2473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APP-2220]: https://aragonassociation.atlassian.net/browse/APP-2220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ