### PR TITLE
Fix: APP-2501 SCC field validations for uint, int, and bool

### DIFF
--- a/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/src/containers/smartContractComposer/components/inputForm.tsx
@@ -353,7 +353,11 @@ export const ComponentForType: React.FC<ComponentForTypeProps> = ({
                   input={component}
                   functionName={`${functionName}.${input.name}`}
                   formHandleName={
-                    formHandleName ? `${formHandleName}[${index}]` : undefined
+                    formHandleName
+                      ? `${formHandleName}[${index}]`
+                      : disabled
+                      ? `${formName}[${index}]`
+                      : undefined
                   }
                   disabled={disabled}
                   isValid={isValid}

--- a/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/src/containers/smartContractComposer/components/inputForm.tsx
@@ -353,11 +353,7 @@ export const ComponentForType: React.FC<ComponentForTypeProps> = ({
                   input={component}
                   functionName={`${functionName}.${input.name}`}
                   formHandleName={
-                    formHandleName
-                      ? `${formHandleName}[${index}]`
-                      : disabled
-                      ? `${formName}[${index}]`
-                      : undefined
+                    formHandleName ? `${formHandleName}[${index}]` : undefined
                   }
                   disabled={disabled}
                   isValid={isValid}

--- a/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/src/containers/smartContractComposer/components/inputForm.tsx
@@ -216,7 +216,9 @@ const InputForm: React.FC<InputFormProps> = ({
 };
 
 const classifyInputType = (inputName: string) => {
-  if (inputName.includes('int') && inputName.includes('[]') === false) {
+  if (inputName.includes('uint') && inputName.includes('[]') === false) {
+    return 'uint';
+  } else if (inputName.includes('int') && inputName.includes('[]') === false) {
     return 'int';
   } else return inputName;
 };
@@ -305,6 +307,54 @@ export const ComponentForType: React.FC<ComponentForTypeProps> = ({
         />
       );
 
+    case 'bool':
+      return (
+        <Controller
+          defaultValue=""
+          name={formName}
+          render={({field: {name, value, onBlur, onChange}}) => (
+            <TextInput
+              name={name}
+              onBlur={onBlur}
+              onChange={onChange}
+              placeholder={`${input.name} (${input.type})`}
+              mode={
+                !isValid && value !== 'true' && value !== 'false'
+                  ? 'critical'
+                  : 'default'
+              }
+              value={value}
+              disabled={disabled}
+            />
+          )}
+        />
+      );
+
+    case 'uint':
+      return (
+        <Controller
+          defaultValue=""
+          name={formName}
+          render={({field: {name, value, onBlur, onChange}}) => (
+            <NumberInput
+              name={name}
+              onBlur={onBlur}
+              onChange={onChange}
+              placeholder="0"
+              disabled={disabled}
+              mode={
+                !isValid &&
+                (!value || value < 0) &&
+                input.name !== getDefaultPayableAmountInputName(t)
+                  ? 'critical'
+                  : 'default'
+              }
+              value={value}
+            />
+          )}
+        />
+      );
+
     case 'int':
       return (
         <Controller
@@ -316,7 +366,6 @@ export const ComponentForType: React.FC<ComponentForTypeProps> = ({
               onBlur={onBlur}
               onChange={onChange}
               placeholder="0"
-              includeDecimal
               disabled={disabled}
               mode={
                 !isValid &&
@@ -441,12 +490,12 @@ export function FormlessComponentForType({
         />
       );
 
+    case 'uint':
     case 'int':
       return (
         <NumberInput
           name={input.name}
           placeholder="0"
-          includeDecimal
           disabled={disabled}
           value={input.value as string}
         />


### PR DESCRIPTION
## Description

To test, use the `removeLiquidityETHWithPermit` method on `0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D` contract on goerli network.

Task: [APP-2501](https://aragonassociation.atlassian.net/browse/APP-2501)

- Removed ability to add decimals on uint and int fields
- bool only accepts true/false now

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2501]: https://aragonassociation.atlassian.net/browse/APP-2501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ