### PR TITLE
Fix: APP-2476 - Limit members to only 3 addresses in snapshot

### DIFF
--- a/src/containers/membershipSnapshot/index.tsx
+++ b/src/containers/membershipSnapshot/index.tsx
@@ -75,6 +75,8 @@ export const MembershipSnapshot: React.FC<Props> = ({
 
   if (members.length === 0) return null;
 
+  const displayedMembers = members.slice(0, 3);
+
   if (horizontal && isDesktop) {
     return (
       <div className="flex space-x-3">
@@ -102,7 +104,7 @@ export const MembershipSnapshot: React.FC<Props> = ({
         </div>
         <div className="w-2/3 space-y-2">
           <ListItemGrid>
-            <MembersList token={daoToken} members={members} />
+            <MembersList token={daoToken} members={displayedMembers} />
           </ListItemGrid>
           <ButtonText
             mode="secondary"
@@ -142,7 +144,7 @@ export const MembershipSnapshot: React.FC<Props> = ({
       />
       <MembersList
         token={daoToken}
-        members={members.slice(0, 3)}
+        members={displayedMembers}
         isCompactMode={true}
       />
       <ButtonText


### PR DESCRIPTION
## Description

- Limit members to only 3 addresses in membership snapshot on the DAO Dashboard

Note: Test with this [DAO](https://staging-app.aragon.org/#/daos/ethereum/ifcsoccerchampions.dao.eth/dashboard)
Task: [APP-2476](https://aragonassociation.atlassian.net/browse/APP-2476)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2476]: https://aragonassociation.atlassian.net/browse/APP-2476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ