### PR TITLE
fix: APP-2338 - Fix dialog handling on deposit dialog

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -10,7 +10,7 @@ import Footer from 'containers/footer';
 import Navbar from 'containers/navbar';
 import DaoSelectMenu from 'containers/navbar/daoSelectMenu';
 import ExploreNav from 'containers/navbar/exploreNav';
-import NetworkErrorMenu from 'containers/networkErrorMenu';
+import {NetworkErrorMenu} from 'containers/networkErrorMenu';
 import TransactionDetail from 'containers/transactionDetail';
 import TransferMenu from 'containers/transferMenu';
 import {WalletMenu} from 'containers/walletMenu';

--- a/src/components/protectedRoute/index.tsx
+++ b/src/components/protectedRoute/index.tsx
@@ -161,12 +161,12 @@ const ProtectedRoute: React.FC = () => {
       setShowLoginModal(true);
     } else {
       if (isOnWrongNetwork) {
-        open('network');
+        open('network', {onClose: () => navigate(-1)});
       } else {
         close();
       }
     }
-  }, [address, close, isOnWrongNetwork, open]);
+  }, [address, close, isOnWrongNetwork, open, navigate]);
 
   // close the LoginRequired modal when web3Modal is shown
   useEffect(() => {

--- a/src/containers/networkErrorMenu/index.tsx
+++ b/src/containers/networkErrorMenu/index.tsx
@@ -13,8 +13,16 @@ import styled from 'styled-components';
 import {CHAIN_METADATA} from 'utils/constants';
 import {handleClipboardActions, shortenAddress} from 'utils/library';
 
-const NetworkErrorMenu = () => {
-  const {isOpen, close} = useGlobalModalContext('network');
+interface INetworkErrorMenuState {
+  onClose?: () => void;
+  onSuccess?: () => void;
+}
+
+export const NetworkErrorMenu = () => {
+  const {isOpen, close, modalState} =
+    useGlobalModalContext<INetworkErrorMenuState>('network');
+  const {onClose, onSuccess} = modalState ?? {};
+
   const {network} = useNetwork();
   const {switchWalletNetwork} = useSwitchNetwork();
   const {address, ensName, ensAvatarUrl, connectorName} = useWallet();
@@ -22,8 +30,19 @@ const NetworkErrorMenu = () => {
   const {t} = useTranslation();
   const {alert} = useAlertContext();
 
+  const handleCloseMenu = () => {
+    onClose?.();
+    close();
+  };
+
+  const handleSwitchNetwork = () => {
+    switchWalletNetwork();
+    close();
+    onSuccess?.();
+  };
+
   return (
-    <ModalBottomSheetSwitcher onClose={close} isOpen={isOpen}>
+    <ModalBottomSheetSwitcher onClose={handleCloseMenu} isOpen={isOpen}>
       <ModalHeader>
         <AvatarAddressContainer>
           <Avatar src={ensAvatarUrl || address || ''} size="small" />
@@ -45,7 +64,7 @@ const NetworkErrorMenu = () => {
             mode="ghost"
             icon={<IconClose />}
             size="small"
-            onClick={() => close()}
+            onClick={handleCloseMenu}
           />
         )}
       </ModalHeader>
@@ -70,10 +89,7 @@ const NetworkErrorMenu = () => {
             label={t('alert.wrongNetwork.buttonLabel', {
               network: CHAIN_METADATA[network].name,
             })}
-            onClick={() => {
-              switchWalletNetwork();
-              close();
-            }}
+            onClick={handleSwitchNetwork}
             size="large"
           />
         )}
@@ -81,8 +97,6 @@ const NetworkErrorMenu = () => {
     </ModalBottomSheetSwitcher>
   );
 };
-
-export default NetworkErrorMenu;
 
 const ModalHeader = styled.div.attrs({
   className: 'flex p-3 bg-ui-0 rounded-xl gap-2 sticky top-0',

--- a/src/containers/transactionModals/depositModal.tsx
+++ b/src/containers/transactionModals/depositModal.tsx
@@ -1,5 +1,5 @@
 import {AlertInline, ButtonText} from '@aragon/ods';
-import React, {useCallback, useEffect, useRef} from 'react';
+import React, {useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 import {generatePath, useNavigate} from 'react-router-dom';
 import styled from 'styled-components';
@@ -25,41 +25,6 @@ const DepositModal: React.FC = () => {
 
   const networkSupportsENS = ENS_SUPPORTED_NETWORKS.includes(network);
 
-  // NOTE: This login => network flow can and should be extracted
-  // if later on we have a component that requires the same process
-  const loginFlowTriggeredRef = useRef(false);
-
-  /*************************************************
-   *                Hooks & Effects                *
-   *************************************************/
-  // Show login modal or network modal based on connection status
-  useEffect(() => {
-    if (loginFlowTriggeredRef.current) {
-      if (!isConnected) open('wallet');
-      else {
-        if (isOnWrongNetwork) open('network');
-        else close();
-      }
-    }
-  }, [close, isConnected, isOnWrongNetwork, open]);
-
-  // Close the login modal once the status is connecting
-  useEffect(() => {
-    if (loginFlowTriggeredRef.current) {
-      if (status === 'connecting' || isConnected) close();
-    }
-  }, [close, isConnected, isOnWrongNetwork, open, status]);
-
-  // show the deposit modal again when user on right network and logged in
-  useEffect(() => {
-    if (loginFlowTriggeredRef.current) {
-      if (isConnected && !isOnWrongNetwork) {
-        open('deposit');
-        loginFlowTriggeredRef.current = false;
-      }
-    }
-  }, [isConnected, isOnWrongNetwork, open]);
-
   /*************************************************
    *             Callbacks and Handlers            *
    *************************************************/
@@ -75,14 +40,21 @@ const DepositModal: React.FC = () => {
 
   // close modal and initiate the login/wrong network flow
   const handleConnectClick = useCallback(() => {
-    close();
-    loginFlowTriggeredRef.current = true;
-  }, [close]);
+    if (!isConnected) {
+      const modalState = {onSuccess: () => open('deposit')};
+      open('wallet', modalState);
+    } else if (isOnWrongNetwork) {
+      const modalState = {onSuccess: () => open('deposit')};
+      open('network', modalState);
+    }
+  }, [open, isConnected, isOnWrongNetwork]);
 
   /*************************************************
    *                     Render                    *
    *************************************************/
-  if (!daoDetails) return null;
+  if (!daoDetails) {
+    return null;
+  }
 
   return (
     <ModalBottomSheetSwitcher

--- a/src/containers/transactionModals/depositModal.tsx
+++ b/src/containers/transactionModals/depositModal.tsx
@@ -40,11 +40,11 @@ const DepositModal: React.FC = () => {
 
   // close modal and initiate the login/wrong network flow
   const handleConnectClick = useCallback(() => {
+    const modalState = {onSuccess: () => open('deposit')};
+
     if (!isConnected) {
-      const modalState = {onSuccess: () => open('deposit')};
       open('wallet', modalState);
     } else if (isOnWrongNetwork) {
-      const modalState = {onSuccess: () => open('deposit')};
       open('network', modalState);
     }
   }, [open, isConnected, isOnWrongNetwork]);


### PR DESCRIPTION
## Description

- Go back to previous page when opening the new-withdrawal page from the deposit dialog being connected to the wrong network and closing the network dialog
- Correctly display the network dialog when clicking on "connect" from the deposit dialog being connected to the wrong network

Task: [APP-2338](https://aragonassociation.atlassian.net/browse/APP-2338)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2338]: https://aragonassociation.atlassian.net/browse/APP-2338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ