### PR TITLE
Fix: WalletConnect acknowledged error

### DIFF
--- a/src/containers/walletConnect/actionListenerModal/index.tsx
+++ b/src/containers/walletConnect/actionListenerModal/index.tsx
@@ -20,12 +20,14 @@ import {
   parseWCIconUrl,
 } from 'utils/library';
 import {useWalletConnectContext} from '../walletConnectProvider';
+import {AllowListDApp} from '../selectAppModal';
 
 type Props = {
   onBackButtonClicked: () => void;
   onClose: () => void;
   isOpen: boolean;
   selectedSession: SessionTypes.Struct;
+  selecteddApp?: AllowListDApp;
   actionIndex: number;
 };
 
@@ -34,6 +36,7 @@ const ActionListenerModal: React.FC<Props> = ({
   onClose,
   actionIndex,
   selectedSession,
+  selecteddApp,
   isOpen,
 }) => {
   const {t} = useTranslation();
@@ -177,7 +180,8 @@ const ActionListenerModal: React.FC<Props> = ({
     return null;
   }
 
-  const metadataName = selectedSession.peer.metadata.name;
+  const metadataName =
+    selecteddApp?.shortName || selectedSession.peer.metadata.name;
   const metadataURL = selectedSession.peer.metadata.url;
   const metadataIcon = parseWCIconUrl(
     metadataURL,

--- a/src/containers/walletConnect/dAppValidationModal/index.tsx
+++ b/src/containers/walletConnect/dAppValidationModal/index.tsx
@@ -15,7 +15,7 @@ import {
 } from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
-import {SessionTypes, SignClientTypes} from '@walletconnect/types';
+import {SessionTypes} from '@walletconnect/types';
 
 import ModalBottomSheetSwitcher from 'components/modalBottomSheetSwitcher';
 import ModalHeader from 'components/modalHeader';
@@ -24,13 +24,14 @@ import {handleClipboardActions} from 'utils/library';
 import {useAlertContext} from 'context/alert';
 import {TransactionState as ConnectionState} from 'utils/constants/misc';
 import {useWalletConnectContext} from '../walletConnectProvider';
+import {AllowListDApp} from '../selectAppModal';
 
 type Props = {
   onBackButtonClicked: () => void;
   onConnectionSuccess: (session: SessionTypes.Struct) => void;
   onClose: () => void;
   isOpen: boolean;
-  selecteddApp?: SignClientTypes.Metadata;
+  selecteddApp?: AllowListDApp;
 };
 
 // Wallet connect id input name
@@ -149,15 +150,13 @@ const WCdAppValidation: React.FC<Props> = props => {
       currentSession != null &&
       currentSession.peer.metadata.name
         .toLowerCase()
-        .includes((selecteddApp as SignClientTypes.Metadata).name.toLowerCase())
+        .includes((selecteddApp as AllowListDApp).name.toLowerCase())
     ) {
       setConnectionStatus(ConnectionState.SUCCESS);
     } else if (
       currentSession?.peer.metadata.name
         .toLowerCase()
-        .includes(
-          (selecteddApp as SignClientTypes.Metadata).name.toLowerCase()
-        ) === false
+        .includes((selecteddApp as AllowListDApp).name.toLowerCase()) === false
     ) {
       setConnectionStatus(ConnectionState.INCORRECT_URI);
     } else if (isSuccess && currentSession == null) {
@@ -185,7 +184,7 @@ const WCdAppValidation: React.FC<Props> = props => {
   return (
     <ModalBottomSheetSwitcher isOpen={isOpen} onClose={onClose}>
       <ModalHeader
-        title={selecteddApp.name}
+        title={selecteddApp.shortName}
         showBackButton
         onBackButtonClicked={handleBackClick}
         {...(isDesktop ? {showCloseButton: true, onClose} : {})}
@@ -239,7 +238,7 @@ const WCdAppValidation: React.FC<Props> = props => {
           <AlertWrapper>
             <AlertInline
               label={t('modal.dappConnect.validation.alertSuccess', {
-                dappName: currentSession?.peer.metadata.name,
+                dappName: selecteddApp.shortName,
               })}
               mode="success"
             />
@@ -249,7 +248,7 @@ const WCdAppValidation: React.FC<Props> = props => {
           <AlertWrapper>
             <AlertInline
               label={t('modal.dappConnect.validation.alertCriticalQRcode', {
-                dappName: selecteddApp.name,
+                dappName: selecteddApp.shortName,
               })}
               mode="critical"
             />
@@ -259,7 +258,7 @@ const WCdAppValidation: React.FC<Props> = props => {
           <AlertWrapper>
             <AlertInline
               label={t('modal.dappConnect.validation.alertCriticalGeneral', {
-                dappName: currentSession?.peer.metadata.name,
+                dappName: selecteddApp.shortName,
               })}
               mode="critical"
             />

--- a/src/containers/walletConnect/dAppValidationModal/index.tsx
+++ b/src/containers/walletConnect/dAppValidationModal/index.tsx
@@ -151,11 +151,7 @@ const WCdAppValidation: React.FC<Props> = props => {
         .toLowerCase()
         .includes((selecteddApp as SignClientTypes.Metadata).name.toLowerCase())
     ) {
-      setConnectionStatus(
-        currentSession.acknowledged
-          ? ConnectionState.SUCCESS
-          : ConnectionState.ERROR
-      );
+      setConnectionStatus(ConnectionState.SUCCESS);
     } else if (
       currentSession?.peer.metadata.name
         .toLowerCase()

--- a/src/containers/walletConnect/dAppValidationModal/index.tsx
+++ b/src/containers/walletConnect/dAppValidationModal/index.tsx
@@ -193,7 +193,9 @@ const WCdAppValidation: React.FC<Props> = props => {
         <FormGroup>
           <Label
             label={t('modal.dappConnect.validation.codeInputLabel')}
-            helpText={t('modal.dappConnect.validation.codeInputHelp')}
+            helpText={t('modal.dappConnect.validation.codeInputHelp', {
+              dappName: selecteddApp.shortName,
+            })}
           />
           {/* TODO: Please add validation when format of wc Code is known */}
           <Controller

--- a/src/containers/walletConnect/index.tsx
+++ b/src/containers/walletConnect/index.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import {useFormContext} from 'react-hook-form';
-import {SessionTypes, SignClientTypes} from '@walletconnect/types';
+import {SessionTypes} from '@walletconnect/types';
 
 import {useActionsContext} from 'context/actions';
 import WCdAppValidation, {WC_URI_INPUT_NAME} from './dAppValidationModal';
@@ -11,7 +11,7 @@ import {
   WalletConnectContextProvider,
   useWalletConnectInterceptor,
 } from './walletConnectProvider';
-import SelectWCApp from './selectAppModal';
+import SelectWCApp, {AllowListDApp} from './selectAppModal';
 
 type WalletConnectProps = {
   actionIndex: number;
@@ -26,7 +26,7 @@ const WalletConnect: React.FC<WalletConnectProps> = ({actionIndex}) => {
   const [dAppValidationIsOpen, setdAppValidationIsOpen] = useState(false);
   const [listeningActionsIsOpen, setListeningActionsIsOpen] = useState(false);
   const [selectedSession, setSelectedSession] = useState<SessionTypes.Struct>();
-  const [selecteddApp, setSelecteddApp] = useState<SignClientTypes.Metadata>();
+  const [selecteddApp, setSelecteddApp] = useState<AllowListDApp>();
 
   const displayDefaultDialogs =
     !listeningActionsIsOpen && !dAppValidationIsOpen;
@@ -40,18 +40,16 @@ const WalletConnect: React.FC<WalletConnectProps> = ({actionIndex}) => {
     removeAction(actionIndex);
   }, [actionIndex, removeAction]);
 
-  const handledConnectNewdApp = useCallback(
-    (dApp: SignClientTypes.Metadata) => {
-      setSelecteddApp(dApp);
-      setdAppValidationIsOpen(true);
-    },
-    []
-  );
+  const handledConnectNewdApp = useCallback((dApp: AllowListDApp) => {
+    setSelecteddApp(dApp);
+    setdAppValidationIsOpen(true);
+  }, []);
 
   const handleSelectExistingdApp = useCallback(
-    (session: SessionTypes.Struct) => {
-      setListeningActionsIsOpen(true);
+    (session: SessionTypes.Struct, dApp: AllowListDApp) => {
       setSelectedSession(session);
+      setSelecteddApp(dApp);
+      setListeningActionsIsOpen(true);
     },
     []
   );
@@ -133,6 +131,7 @@ const WalletConnect: React.FC<WalletConnectProps> = ({actionIndex}) => {
           onBackButtonClicked={handledAppValidationBackClick}
           onClose={handleClosedAppValidation}
           isOpen={listeningActionsIsOpen}
+          selecteddApp={selecteddApp}
           selectedSession={selectedSession}
           actionIndex={actionIndex}
         />

--- a/src/containers/walletConnect/index.tsx
+++ b/src/containers/walletConnect/index.tsx
@@ -84,15 +84,14 @@ const WalletConnect: React.FC<WalletConnectProps> = ({actionIndex}) => {
     }
 
     const isSelectedSessionActive =
-      wcValues.activeSessions.find(
-        ({topic}) => topic === selectedSession.topic
-      ) != null;
+      wcValues.sessions.find(({topic}) => topic === selectedSession.topic) !=
+      null;
 
     if (!isSelectedSessionActive) {
       setSelectedSession(undefined);
       setListeningActionsIsOpen(false);
     }
-  }, [wcValues.activeSessions, selectedSession]);
+  }, [wcValues.sessions, selectedSession]);
 
   /*************************************************
    *                     Render                    *

--- a/src/containers/walletConnect/index.tsx
+++ b/src/containers/walletConnect/index.tsx
@@ -72,9 +72,9 @@ const WalletConnect: React.FC<WalletConnectProps> = ({actionIndex}) => {
   const handleOnConnectionSuccess = useCallback(
     (session: SessionTypes.Struct) => {
       resetField(WC_URI_INPUT_NAME);
+      setSelectedSession(session);
       setdAppValidationIsOpen(false);
       setListeningActionsIsOpen(true);
-      setSelectedSession(session);
     },
     [resetField]
   );

--- a/src/containers/walletConnect/selectAppModal/index.tsx
+++ b/src/containers/walletConnect/selectAppModal/index.tsx
@@ -43,7 +43,7 @@ const SelectWCApp: React.FC<Props> = props => {
   const {isDesktop} = useScreen();
   const {onConnectNewdApp, onSelectExistingdApp, onClose, isOpen} = props;
 
-  const {activeSessions} = useWalletConnectContext();
+  const {sessions} = useWalletConnectContext();
 
   /*************************************************
    *                     Render                    *
@@ -62,7 +62,7 @@ const SelectWCApp: React.FC<Props> = props => {
       <Content>
         <div className="space-y-1">
           {AllowListDApps.map(dApp => {
-            const filteredSession = activeSessions.filter(session =>
+            const filteredSession = sessions.filter(session =>
               session.peer.metadata.name
                 .toLowerCase()
                 .includes(dApp.name.toLowerCase())

--- a/src/containers/walletConnect/selectAppModal/index.tsx
+++ b/src/containers/walletConnect/selectAppModal/index.tsx
@@ -12,15 +12,21 @@ import useScreen from 'hooks/useScreen';
 import {htmlIn} from 'utils/htmlIn';
 
 type Props = {
-  onConnectNewdApp: (dApp: SignClientTypes.Metadata) => void;
-  onSelectExistingdApp: (session: SessionTypes.Struct) => void;
+  onConnectNewdApp: (dApp: AllowListDApp) => void;
+  onSelectExistingdApp: (
+    session: SessionTypes.Struct,
+    dApp: AllowListDApp
+  ) => void;
   onClose: () => void;
   isOpen: boolean;
 };
 
-const AllowListDApps: SignClientTypes.Metadata[] = [
+export type AllowListDApp = SignClientTypes.Metadata & {shortName: string};
+
+export const AllowListDApps: AllowListDApp[] = [
   {
     name: 'CoW Swap | The smartest way to trade cryptocurrencies',
+    shortName: 'CoW Swap',
     description:
       'CoW Swap finds the lowest prices from all decentralized exchanges and DEX aggregators & saves you more with p2p trading and protection from MEV',
     url: 'https://swap.cow.fi',
@@ -63,8 +69,8 @@ const SelectWCApp: React.FC<Props> = props => {
             );
             return (
               <ListItemAction
-                key={dApp.name}
-                title={dApp.name}
+                key={dApp.shortName}
+                title={dApp.shortName}
                 iconLeft={parseWCIconUrl(dApp.url, dApp.icons[0])}
                 bgWhite
                 iconRight={
@@ -81,7 +87,7 @@ const SelectWCApp: React.FC<Props> = props => {
                 truncateText
                 onClick={() => {
                   if (filteredSession[0]) {
-                    onSelectExistingdApp(filteredSession[0]);
+                    onSelectExistingdApp(filteredSession[0], dApp);
                   } else {
                     onConnectNewdApp(dApp);
                   }

--- a/src/containers/walletConnect/walletConnectProvider/useWalletConnectInterceptor.ts
+++ b/src/containers/walletConnect/walletConnectProvider/useWalletConnectInterceptor.ts
@@ -33,7 +33,8 @@ export function useWalletConnectInterceptor(): WcInterceptorValues {
   const [sessions, setSessions] = useState<WcSession[]>(
     walletConnectInterceptor.getActiveSessions(daoDetails?.address)
   );
-  const activeSessions = sessions.filter(session => session.acknowledged);
+
+  const activeSessions = sessions;
 
   const [actions, setActions] = useState<WcActionRequest[]>([]);
 

--- a/src/containers/walletConnect/walletConnectProvider/useWalletConnectInterceptor.ts
+++ b/src/containers/walletConnect/walletConnectProvider/useWalletConnectInterceptor.ts
@@ -22,7 +22,6 @@ export type WcInterceptorValues = {
   ) => Promise<PairingTypes.Struct | undefined>;
   wcDisconnect: (topic: string) => Promise<void>;
   sessions: WcSession[];
-  activeSessions: WcSession[];
   actions: WcActionRequest[];
 };
 
@@ -33,8 +32,6 @@ export function useWalletConnectInterceptor(): WcInterceptorValues {
   const [sessions, setSessions] = useState<WcSession[]>(
     walletConnectInterceptor.getActiveSessions(daoDetails?.address)
   );
-
-  const activeSessions = sessions;
 
   const [actions, setActions] = useState<WcActionRequest[]>([]);
 
@@ -111,5 +108,5 @@ export function useWalletConnectInterceptor(): WcInterceptorValues {
     };
   }, [handleRequest]);
 
-  return {wcConnect, wcDisconnect, sessions, activeSessions, actions};
+  return {wcConnect, wcDisconnect, sessions, actions};
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1301,7 +1301,7 @@
       "title": "Select dApp",
       "desc": "You can interact with the following dApps to add actions to your proposal. Learn more about {{link}}.",
       "descLinkLabel": "in our guide",
-      "descLinkURL": "https://",
+      "descLinkURL": "https://aragon.org/how-to/swap-tokens-with-cowswap",
       "validation": {
         "codeInputHelp": "To connect, open {{dappName}}, copy the WalletConnect QR code to your clipboard, and paste it here.",
         "modalTitle": "{{dappName}}",

--- a/src/services/walletConnectInterceptor.ts
+++ b/src/services/walletConnectInterceptor.ts
@@ -10,7 +10,9 @@ class WalletConnectInterceptor {
     name: 'Aragon DAO',
     description: 'Aragon DAO',
     url: 'https://aragon.org',
-    icons: ['https://walletconnect.org/walletconnect-logo.png'],
+    icons: [
+      'https://assets.website-files.com/5e997428d0f2eb13a90aec8c/635283b535e03c60d5aafe64_logo_aragon_isotype.png',
+    ],
   };
 
   client: Web3WalletClient | undefined;


### PR DESCRIPTION
## Description

1. Added a shortName field to metadata to give dApps a shorter name on our WC action modals
2. The `session.acknowledged` is returning `false` when the connection is first established with a dApp. Upon closing the Connect DApp Action modal on App and reopening it, the `session.acknowledged` is returned as `true`. 
Pieter and Me are facing this issue. Pieter's comment [here](https://aragonassociation.atlassian.net/browse/APP-2483?focusedCommentId=19305)
When I was going through WalletConnect's Example https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-v2, they seem to be using the getActiveSessions() directly without filtering on `session.acknowledged`. So thought we could also do the same.

@RuggeroCino @jamesej 

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.
