### PR TITLE
fix: APP-2266 - Add checks to verify dApp connection

### DIFF
--- a/src/containers/walletConnect/dAppValidationModal/index.tsx
+++ b/src/containers/walletConnect/dAppValidationModal/index.tsx
@@ -133,7 +133,11 @@ const WCdAppValidation: React.FC<Props> = props => {
     setConnectionStatus(ConnectionState.LOADING);
 
     try {
-      await wcConnect({uri, metadataName: selecteddApp?.name.toLowerCase()});
+      const session = await wcConnect({
+        uri,
+        metadataName: selecteddApp?.name.toLowerCase(),
+      });
+      setSessionTopic(session.pairingTopic);
       setConnectionStatus(ConnectionState.SUCCESS);
     } catch (error: unknown) {
       if (error === METADATA_NAME_ERROR) {

--- a/src/containers/walletConnect/dAppValidationModal/index.tsx
+++ b/src/containers/walletConnect/dAppValidationModal/index.tsx
@@ -25,6 +25,7 @@ import {useAlertContext} from 'context/alert';
 import {TransactionState as ConnectionState} from 'utils/constants/misc';
 import {useWalletConnectContext} from '../walletConnectProvider';
 import {AllowListDApp} from '../selectAppModal';
+import {METADATA_NAME_ERROR} from '../walletConnectProvider/useWalletConnectInterceptor';
 
 type Props = {
   onBackButtonClicked: () => void;
@@ -130,36 +131,24 @@ const WCdAppValidation: React.FC<Props> = props => {
 
   const handleConnectDApp = useCallback(async () => {
     setConnectionStatus(ConnectionState.LOADING);
-    const wcConnection = await wcConnect({uri});
 
-    if (wcConnection) {
-      setSessionTopic(wcConnection.topic);
-    } else {
-      setConnectionStatus(ConnectionState.ERROR);
+    try {
+      await wcConnect({uri, metadataName: selecteddApp?.name});
+      setConnectionStatus(ConnectionState.SUCCESS);
+    } catch (error: unknown) {
+      if (error === METADATA_NAME_ERROR) {
+        setConnectionStatus(ConnectionState.INCORRECT_URI);
+      } else {
+        setConnectionStatus(ConnectionState.ERROR);
+      }
     }
-  }, [uri, wcConnect]);
+  }, [uri, wcConnect, selecteddApp?.name]);
 
-  // Update connectionStatus to SUCCESS when the session is active and acknowledged or reset
-  // the connection state if the session has been terminated on the dApp
+  // Reset the connection state if the session has been terminated on the dApp
   useEffect(() => {
-    const isLoading = connectionStatus === ConnectionState.LOADING;
     const isSuccess = connectionStatus === ConnectionState.SUCCESS;
 
-    if (
-      isLoading &&
-      currentSession != null &&
-      currentSession.peer.metadata.name
-        .toLowerCase()
-        .includes((selecteddApp as AllowListDApp).name.toLowerCase())
-    ) {
-      setConnectionStatus(ConnectionState.SUCCESS);
-    } else if (
-      currentSession?.peer.metadata.name
-        .toLowerCase()
-        .includes((selecteddApp as AllowListDApp).name.toLowerCase()) === false
-    ) {
-      setConnectionStatus(ConnectionState.INCORRECT_URI);
-    } else if (isSuccess && currentSession == null) {
+    if (isSuccess && currentSession == null) {
       resetConnectionState();
     }
   }, [connectionStatus, currentSession, resetConnectionState, selecteddApp]);

--- a/src/containers/walletConnect/dAppValidationModal/index.tsx
+++ b/src/containers/walletConnect/dAppValidationModal/index.tsx
@@ -133,7 +133,7 @@ const WCdAppValidation: React.FC<Props> = props => {
     setConnectionStatus(ConnectionState.LOADING);
 
     try {
-      await wcConnect({uri, metadataName: selecteddApp?.name});
+      await wcConnect({uri, metadataName: selecteddApp?.name.toLowerCase()});
       setConnectionStatus(ConnectionState.SUCCESS);
     } catch (error: unknown) {
       if (error === METADATA_NAME_ERROR) {

--- a/src/containers/walletConnect/walletConnectProvider/useWalletConnectInterceptor.ts
+++ b/src/containers/walletConnect/walletConnectProvider/useWalletConnectInterceptor.ts
@@ -24,7 +24,7 @@ export type VerifyConnectionOptions = {
 };
 
 export type WcInterceptorValues = {
-  wcConnect: (options: WcConnectOptions) => Promise<WcSession | undefined>;
+  wcConnect: (options: WcConnectOptions) => Promise<WcSession>;
   wcDisconnect: (topic: string) => Promise<void>;
   sessions: WcSession[];
   actions: WcActionRequest[];

--- a/src/containers/walletConnect/walletConnectProvider/useWalletConnectInterceptor.ts
+++ b/src/containers/walletConnect/walletConnectProvider/useWalletConnectInterceptor.ts
@@ -70,8 +70,9 @@ export function useWalletConnectInterceptor(): WcInterceptorValues {
 
       const metadataNameMatch =
         metadataName == null ||
-        matchingSession?.peer.metadata.name.toLowerCase() ===
-          connection.peerMetadata?.name.toLowerCase();
+        matchingSession?.peer.metadata.name
+          .toLowerCase()
+          .includes(metadataName);
 
       if (matchingSession && !metadataNameMatch) {
         throw METADATA_NAME_ERROR;

--- a/src/services/aragon-sdk/selectors/proposal.ts
+++ b/src/services/aragon-sdk/selectors/proposal.ts
@@ -166,8 +166,6 @@ function syncMultisigVotes(
     }
   });
 
-  console.log([...uniqueCachedApprovals, ...Array.from(serverApprovals)]);
-
   return [...uniqueCachedApprovals, ...Array.from(serverApprovals)];
 }
 

--- a/src/services/walletConnectInterceptor.ts
+++ b/src/services/walletConnectInterceptor.ts
@@ -3,7 +3,7 @@ import {buildApprovedNamespaces, getSdkError} from '@walletconnect/utils';
 import Web3WalletClient, {Web3Wallet} from '@walletconnect/web3wallet';
 import {AuthClientTypes} from '@walletconnect/auth-client';
 import {Web3WalletTypes} from '@walletconnect/web3wallet';
-import {SessionTypes} from '@walletconnect/types';
+import {PairingTypes, SessionTypes} from '@walletconnect/types';
 
 class WalletConnectInterceptor {
   clientMetadata: AuthClientTypes.Metadata = {
@@ -57,6 +57,35 @@ class WalletConnectInterceptor {
 
   connect(uri: string) {
     return this.client?.core.pairing.pair({uri});
+  }
+
+  pingTopic(topic: string) {
+    return this.client?.core.pairing.ping({topic});
+  }
+
+  async verifyConnection(
+    connection: PairingTypes.Struct
+  ): Promise<SessionTypes.Struct | undefined> {
+    const matchingSession = this.getActiveSessions().find(
+      ({pairingTopic}) => pairingTopic === connection.topic
+    );
+
+    if (matchingSession) {
+      return matchingSession;
+    }
+
+    // Connection is expired as there's still no matching session
+    if (Date.now() / 1000 > connection.expiry) {
+      throw new Error('walletConnectInterceptor: connection is expired');
+    }
+
+    // The pingTopic function throws error when the topic is not
+    // valid anymore
+    try {
+      await this.pingTopic(connection.topic);
+    } catch (error) {
+      throw new Error('walletConnectInterceptor: topic not valid');
+    }
   }
 
   approveSession(


### PR DESCRIPTION
## Description

- Update the `wcConnect` function to check for connection status and throw error in case the connection is not valid
- Add the following checks in order to verify the status of the dApp connection and display error in case the connection is expired or not valid:
  - Ping the wallet-connect topic to verify its status;
  - Throw error when connection expires by checking the `connection.timeout` attribute;
  - Throw error on internal expiration check (after 60 seconds) in case there's no timeout set on the connection;

Task: [APP-2266](https://aragonassociation.atlassian.net/browse/APP-2266)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2266]: https://aragonassociation.atlassian.net/browse/APP-2266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ