### PR TITLE
fix: APP-2534 - Fix styling issues of new ODS design system

### DIFF
--- a/src/@aragon/ods-old/components/input/dateInput.tsx
+++ b/src/@aragon/ods-old/components/input/dateInput.tsx
@@ -27,9 +27,10 @@ const InputContainer = styled.div.attrs<InputContainerProps>(({disabled}) => {
   if (disabled) {
     className += ' bg-neutral-100 text-neutral-300 border-neutral-200';
   } else {
-    const focusVisibleClasses = 'focus-within:ring focus-within:ring-primary';
+    const focusVisibleClasses =
+      'focus-within:border-primary-500 focus-within:hover:border-primary-500';
     const hoverClasses = 'hover:border-neutral-300';
-    const activeClasses = 'active:border-primary-500 active:ring-0';
+    const activeClasses = 'active:border-primary-500';
     className += ` bg-neutral-0 text-neutral-600 ${focusVisibleClasses} ${hoverClasses} ${activeClasses}`;
   }
   return {className, disabled};

--- a/src/@aragon/ods-old/components/input/numberInput.tsx
+++ b/src/@aragon/ods-old/components/input/numberInput.tsx
@@ -153,9 +153,8 @@ const Container = styled.div.attrs<StyledContainerProps>(
     } inline-flex bg-neutral-0 ${
       width ? '' : 'w-full'
     } focus:outline-none items-center py-1.5 px-2
-      focus-within:ring focus-within:ring-primary justify-between
+      focus-within:border-primary-500 focus-within:hover:border-primary-500 justify-between
       rounded-xl hover:border-neutral-300 border-2 active:border-primary-500
-      active:ring-0
     `;
 
     if (mode === 'default') {

--- a/src/@aragon/ods-old/components/input/textInput.tsx
+++ b/src/@aragon/ods-old/components/input/textInput.tsx
@@ -49,10 +49,8 @@ export const Container = styled.div.attrs<StyledContainerProps>(
   ({mode, disabled, containerClassName}) => {
     let className = `${
       disabled ? 'bg-neutral-100 border-neutral-200 border-2' : 'bg-neutral-0'
-    } flex items-center focus-within:ring
-    focus-within:ring-primary
-    rounded-xl hover:border-neutral-300 border-2 h-12
-    active:border-primary-500 active:ring-0 `;
+    } flex items-center focus-within:border-primary-500 focus-within:hover:border-primary-500
+    rounded-xl hover:border-neutral-300 border-2 h-12 `;
 
     if (containerClassName) {
       className += containerClassName;

--- a/src/@aragon/ods-old/components/input/valueInput.tsx
+++ b/src/@aragon/ods-old/components/input/valueInput.tsx
@@ -59,8 +59,8 @@ export const Container = styled.div.attrs<StyledContainerProps>(
     let className = `${
       disabled ? 'bg-neutral-100 border-neutral-200' : 'bg-neutral-0'
     } flex items-center space-x-3 p-1.5 pl-4 text-neutral-600 rounded-xl
-    border-2 focus-within:ring focus-within:ring-primary
-    hover:border-neutral-300 active:border-primary-500 active:ring-0 `;
+    border-2 focus-within:border-primary-500 focus-within:hover:border-primary-500
+    hover:border-neutral-300 active:border-primary-500 `;
 
     if (mode === 'default') {
       className += 'border-neutral-100';

--- a/src/@aragon/ods-old/components/input/walletInput.tsx
+++ b/src/@aragon/ods-old/components/input/walletInput.tsx
@@ -583,7 +583,7 @@ export const Container = styled.div.attrs<StyledContainerProps>(
 
     const focusClass = disabled
       ? ''
-      : 'focus-within:ring focus-within:ring-primary';
+      : 'focus-within:border-primary-500 focus-within:hover:border-primary-500';
 
     const bgAndBorderColor = disabled
       ? 'bg-neutral-100 border-neutral-200 text-neutral-700'

--- a/src/@aragon/ods-old/components/input/walletInputLegacy.tsx
+++ b/src/@aragon/ods-old/components/input/walletInputLegacy.tsx
@@ -69,8 +69,8 @@ export const Container = styled.div.attrs<StyledContainerProps>(
     let className = `${
       disabled ? 'bg-neutral-100 border-neutral-200' : 'bg-neutral-0'
     } flex items-center space-x-3 p-1.5 pl-4 text-neutral-600 rounded-xl
-    border-2 focus-within:ring focus-within:ring-primary
-    hover:border-neutral-300 active:border-primary-500 active:ring-0 `;
+    border-2 focus-within:border-primary-500 focus-within:hover:border-primary-500
+    hover:border-neutral-300 active:border-primary-500 `;
 
     if (mode === 'default') {
       className += 'border-neutral-100';

--- a/src/@aragon/ods-old/components/spinner/spinner.tsx
+++ b/src/@aragon/ods-old/components/spinner/spinner.tsx
@@ -34,7 +34,7 @@ const StyledSpinner = styled.div.attrs<SpinnerProps>(({size}) => {
   };
   const className = `rounded-full
         ease-linear border-2
-        border-t-2 border-neutral-0
+        border-t-2 border-[transparent]
         ${sizes[size]}
     `;
 

--- a/src/@aragon/ods-old/components/table/votersTable.tsx
+++ b/src/@aragon/ods-old/components/table/votersTable.tsx
@@ -82,7 +82,7 @@ export const VotersTable: React.FC<VotersTableProps> = ({
 };
 
 const Container = styled.div.attrs({
-  className: 'w-full border-2 rounded-xl whitespace-nowrap',
+  className: 'w-full border-2 border-neutral-100 rounded-xl whitespace-nowrap',
 })`
   button:first-child {
     border-top-right-radius: 12px;

--- a/src/@aragon/ods-old/components/textarea/textarea.tsx
+++ b/src/@aragon/ods-old/components/textarea/textarea.tsx
@@ -8,7 +8,7 @@ export type TextareaSimpleProps = Omit<
 
 export const TextareaSimple = styled.textarea.attrs({
   className: `py-3 px-4 rounded-xl resize-none w-full border-2 border-neutral-100 hover:border-neutral-300
-    disabled:bg-neutral-100 disabled:border-neutral-200 focus:ring focus:ring-primary focus:outline-none bg-neutral-0 text-neutral-600 active:border-primary-500 active:ring-0`,
+    disabled:bg-neutral-100 disabled:border-neutral-200 focus-within:border-primary-500 focus-within:hover:border-primary-500 focus:outline-none bg-neutral-0 text-neutral-600 active:border-primary-500`,
 })`
   min-height: 144px;
 

--- a/src/@aragon/ods-old/components/textarea/wysiwyg.tsx
+++ b/src/@aragon/ods-old/components/textarea/wysiwyg.tsx
@@ -228,7 +228,7 @@ const Container = styled.div.attrs<Props>(({disabled, fullScreen = false}) => ({
   className: `w-full text-neutral-600 overflow-auto ${
     fullScreen
       ? 'h-screen flex flex-col fixed top-0'
-      : 'rounded-xl border-2 border-neutral-100 hover:border-neutral-300 focus-within:ring focus-within:ring-primary active:border-primary-500 active:ring-0 '
+      : 'rounded-xl border-2 border-neutral-100 hover:border-neutral-300 focus-within:border-primary-500 focus-within:hover:border-primary-500 active:border-primary-500 '
   } ${disabled ? 'bg-neutral-100 border-neutral-200' : 'bg-neutral-0'}`,
 }))<Props>`
   ::-webkit-input-placeholder {
@@ -258,14 +258,15 @@ const Toolgroup = styled.div.attrs({
 const StyledEditorContent = styled(EditorContent)`
   flex: 1;
 
+  .ProseMirror:focus,
+  .ProseMirror:focus-visible {
+    outline: none;
+  }
+
   .ProseMirror {
     padding: 12px 16px;
     height: 100%;
     min-height: 112px;
-
-    :focus {
-      outline: none;
-    }
 
     ul {
       list-style-type: decimal;

--- a/src/containers/transactionModals/publishModal.tsx
+++ b/src/containers/transactionModals/publishModal.tsx
@@ -171,7 +171,7 @@ const PublishModal: React.FC<PublishModalProps> = ({
 export default PublishModal;
 
 const GasCostTableContainer = styled.div.attrs({
-  className: 'm-6 bg-neutral-0 rounded-xl border border-neutral-100 divide-y',
+  className: 'm-6 bg-neutral-0 rounded-xl border border-neutral-100',
 })``;
 
 const GasCostEthContainer = styled.div.attrs({

--- a/src/utils/htmlIn.ts
+++ b/src/utils/htmlIn.ts
@@ -14,7 +14,7 @@ export const htmlIn =
       const linkLabel = t((key + 'LinkLabel') as TParam0);
       value = value.replace(
         '<<link>>',
-        `<a class="font-semibold truncate inline-flex items-center space-x-3 max-w-full rounded cursor-pointer hover:text-primary-700 active:text-primary-800 focus-visible:ring focus-visible:ring-primary text-primary-500" href="${linkUrl}" target=”_blank”>${linkLabel}</a>`
+        `<a class="font-semibold truncate inline-flex items-center space-x-3 max-w-full rounded cursor-pointer hover:text-primary-700 active:text-primary-800 focus-visible:ring focus:outline-none focus-visible:ring-primary text-primary-500" href="${linkUrl}" target=”_blank”>${linkLabel}</a>`
       );
     }
     return value;


### PR DESCRIPTION
## Description

- Correctly style active states of input fields with primary border instead of outline (getting aligned with the new design system)
- Fix white spinner variant
- Fix divider on publish modal
- Fix border on voters table

NOTE:
As of the new design system (see [here](https://www.figma.com/file/jfKRr1V9evJUp1uBeyP3Zz/v1.0.0?type=design&node-id=8192-18156&mode=design&t=GZ4V4lWp2vASZNuF-4)), the input has a solid border when active/focused and a ring when focused by keyboard but we can't make such distinction (see [here](https://github.com/WICG/focus-visible/issues/131) with the current setup

Task: [APP-2534](https://aragonassociation.atlassian.net/browse/APP-2534)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2534]: https://aragonassociation.atlassian.net/browse/APP-2534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ