### PR TITLE
fix: APP-2266 - Disable wallet-connect URI field on connection loading or success

### DIFF
--- a/src/containers/walletConnect/dAppValidationModal/index.tsx
+++ b/src/containers/walletConnect/dAppValidationModal/index.tsx
@@ -202,6 +202,10 @@ const WCdAppValidation: React.FC<Props> = props => {
               <WalletInputLegacy
                 mode={error ? 'critical' : 'default'}
                 name={name}
+                disabled={
+                  connectionStatus === ConnectionState.LOADING ||
+                  connectionStatus === ConnectionState.SUCCESS
+                }
                 onBlur={onBlur}
                 onChange={onChange}
                 value={value ?? ''}


### PR DESCRIPTION
- Disable WalleteConnect URI field when the connection state is loading or success

Task: [APP-2266](https://aragonassociation.atlassian.net/browse/APP-2266)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2266]: https://aragonassociation.atlassian.net/browse/APP-2266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ