### PR TITLE
Fix: APP-2460 - Updated CrowdIn key for Aragon Updates

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1595,8 +1595,8 @@
       "alertTitle": "Some updates may be unsafe",
       "alertDesc": "One or more actions aren't in the Aragon Update Registry, indicating that this update could be potentially harmful.",
       "desc": "All actions are listed in the Aragon Update Registry, which is managed by the Aragon team. However, always exercise caution when evaluating updates. To learn more about Aragon OSx updates, {{link}}.",
-      "descLinkLabel": "Read more",
-      "descLinkUrl": "https://"
+      "descLinkLabel": "read more in our guides",
+      "descLinkURL": "https://aragon.org/how-to/update-your-aragon-dao"
     },
     "proposal": {
       "bannerTitle": "Verified Aragon App Update"


### PR DESCRIPTION
## Description

- updates the translation key for OSx Update card
- adds link to OSx updates guide

Task: [APP-2460](https://aragonassociation.atlassian.net/browse/APP-2460)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2460]: https://aragonassociation.atlassian.net/browse/APP-2460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ