### PR TITLE
Ad-hoc release-0.1.32 fix

### DIFF
--- a/src/containers/reviewProposal/index.tsx
+++ b/src/containers/reviewProposal/index.tsx
@@ -36,6 +36,7 @@ import {
 import {getErc20VotingParticipation, getNonEmptyActions} from 'utils/proposals';
 import {ProposalResource, SupportedVotingSettings} from 'utils/types';
 import {UpdateVerificationCard} from 'containers/updateVerificationCard';
+import {featureFlags} from 'utils/featureFlags';
 
 type ReviewProposalProps = {
   defineProposalStepNumber: number;
@@ -246,14 +247,17 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
           )}
 
           {/* TODO: Add isUpdateProposal check once it's developed */}
-          <UpdateVerificationCard
-            actions={getNonEmptyActions(
-              values.actions,
-              isMultisigVotingSettings(votingSettings)
-                ? votingSettings
-                : undefined
-            )}
-          />
+          {featureFlags.getValue('VITE_FEATURE_FLAG_OSX_UPDATES') ===
+            'true' && (
+            <UpdateVerificationCard
+              actions={getNonEmptyActions(
+                values.actions,
+                isMultisigVotingSettings(votingSettings)
+                  ? votingSettings
+                  : undefined
+              )}
+            />
+          )}
 
           {votingSettings && (
             <VotingTerminal


### PR DESCRIPTION
## Description

Fix to v0.1.32 release
- Add feature flag to showing OSx updates security card in Review Proposal

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the test network.
