### PR TITLE
feat: APP-2457 token based dao proposals can start immediately with n…

### DIFF
--- a/src/containers/reviewProposal/index.tsx
+++ b/src/containers/reviewProposal/index.tsx
@@ -155,7 +155,6 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
       durationHours,
       durationMinutes,
       durationSwitch,
-      startSwitch,
       endDate,
       endTime,
       endUtc,

--- a/src/containers/reviewProposal/index.tsx
+++ b/src/containers/reviewProposal/index.tsx
@@ -83,18 +83,15 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
     const {startSwitch, startDate, startTime, startUtc} = values;
 
     if (startSwitch === 'now') {
-      const startMinutesDelay = isMultisig ? 0 : 10;
       return new Date(
-        `${getCanonicalDate()}T${getCanonicalTime({
-          minutes: startMinutesDelay,
-        })}:00${getCanonicalUtcOffset()}`
+        `${getCanonicalDate()}T${getCanonicalTime()}:00${getCanonicalUtcOffset()}`
       );
     } else {
       return Date.parse(
         `${startDate}T${startTime}:00${getCanonicalUtcOffset(startUtc)}`
       );
     }
-  }, [isMultisig, values]);
+  }, [values]);
 
   const formattedStartDate = useMemo(() => {
     const {startSwitch} = values;
@@ -182,17 +179,14 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
 
     // adding 10 minutes to offset the 10 minutes added by starting now
     if (startSwitch === 'now') {
-      const startMinutesDelay = isMultisig ? 0 : 10;
-      endDateTime = new Date(
-        endDateTime.getTime() + minutesToMills(startMinutesDelay)
-      );
+      endDateTime = new Date(endDateTime.getTime());
     }
 
     return `~${format(
       endDateTime,
       KNOWN_FORMATS.proposals
     )} ${getFormattedUtcOffset()}`;
-  }, [isMultisig, values]);
+  }, [values]);
 
   const terminalProps = useMemo(() => {
     if (votingSettings) {

--- a/src/containers/reviewProposal/index.tsx
+++ b/src/containers/reviewProposal/index.tsx
@@ -176,11 +176,6 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
       );
     }
 
-    // adding 10 minutes to offset the 10 minutes added by starting now
-    if (startSwitch === 'now') {
-      endDateTime = new Date(endDateTime.getTime());
-    }
-
     return `~${format(
       endDateTime,
       KNOWN_FORMATS.proposals

--- a/src/containers/reviewProposal/index.tsx
+++ b/src/containers/reviewProposal/index.tsx
@@ -31,7 +31,6 @@ import {
   getCanonicalTime,
   getCanonicalUtcOffset,
   getFormattedUtcOffset,
-  minutesToMills,
 } from 'utils/date';
 import {getErc20VotingParticipation, getNonEmptyActions} from 'utils/proposals';
 import {ProposalResource, SupportedVotingSettings} from 'utils/types';

--- a/src/context/createProposal.tsx
+++ b/src/context/createProposal.tsx
@@ -338,18 +338,32 @@ const CreateProposalWrapper: React.FC<Props> = ({
       // getting dates
       let startDateTime: Date;
 
+      /**
+       * Here we defined base startDate.
+       */
       if (startSwitch === 'now') {
+        // Taking current time, but we won't pass it to SC cuz it's gonna be outdated. Needed for calculations below.
         startDateTime = new Date(
           `${getCanonicalDate()}T${getCanonicalTime()}:00${getCanonicalUtcOffset()}`
         );
       } else {
+        // Taking time user has set.
         startDateTime = new Date(
           `${startDate}T${startTime}:00${getCanonicalUtcOffset(startUtc)}`
         );
       }
 
+      // Minimum allowed end date (if endDate is lower than that SC call fails)
+      const minEndDateTimeMills =
+        startDateTime.valueOf() +
+        daysToMills(minDays || 0) +
+        hoursToMills(minHours || 0) +
+        minutesToMills(minMinutes || 0);
+
       // End date
       let endDateTime;
+
+      // user specifies duration in time/second exact way
       if (durationSwitch === 'duration') {
         const [days, hours, minutes] = getValues([
           'durationDays',
@@ -367,27 +381,32 @@ const CreateProposalWrapper: React.FC<Props> = ({
           });
 
         endDateTime = new Date(endDateTimeMill);
+
+        // In case the endDate is close to being minimum durable, (and we starting immediately)
+        // to avoid passing late-date possibly, we just rely on SDK to set proper Date
+        if (
+          endDateTime.valueOf() <= minEndDateTimeMills &&
+          startSwitch === 'now'
+        ) {
+          /* Pass enddate as undefined to SDK to auto-calculate min endDate */
+          endDateTime = undefined;
+        }
       } else {
+        // In case exact time specified by user
         endDateTime = new Date(
           `${endDate}T${endTime}:00${getCanonicalUtcOffset(endUtc)}`
         );
       }
 
-      if (startSwitch === 'now') {
-        endDateTime = new Date(endDateTime.getTime());
-      } else {
+      if (startSwitch === 'duration' && endDateTime) {
+        // Making sure we are not in past for further calculation
         if (startDateTime.valueOf() < new Date().valueOf()) {
           startDateTime = new Date(
             `${getCanonicalDate()}T${getCanonicalTime()}:00${getCanonicalUtcOffset()}`
           );
         }
 
-        const minEndDateTimeMills =
-          startDateTime.valueOf() +
-          daysToMills(minDays || 0) +
-          hoursToMills(minHours || 0) +
-          minutesToMills(minMinutes || 0);
-
+        // If provided date is expired
         if (endDateTime.valueOf() < minEndDateTimeMills) {
           const legacyStartDate = new Date(
             `${startDate}T${startTime}:00${getCanonicalUtcOffset(startUtc)}`
@@ -402,19 +421,18 @@ const CreateProposalWrapper: React.FC<Props> = ({
 
       /**
        * In case "now" as start time is selected, we want
-       * to keep startDate and endDate undefined, so it's automatically evaluated.
+       * to keep startDate undefined, so it's automatically evaluated.
        * If we just provide "Date.now()", than after user still goes through the flow
        * it's going to be date from the past. And SC-call evaluation will fail.
        */
       const finalStartDate = startSwitch === 'now' ? undefined : startDateTime;
-      const finalEndDate = startSwitch === 'now' ? undefined : endDateTime;
 
       // Ignore encoding if the proposal had no actions
       return {
         pluginAddress,
         metadataUri: ipfsUri || '',
         startDate: finalStartDate,
-        endDate: finalEndDate,
+        endDate: endDateTime,
         actions,
       };
     }, [

--- a/src/context/createProposal.tsx
+++ b/src/context/createProposal.tsx
@@ -337,15 +337,10 @@ const CreateProposalWrapper: React.FC<Props> = ({
 
       // getting dates
       let startDateTime: Date;
-      const startMinutesDelay = isMultisigVotingSettings(votingSettings)
-        ? 0
-        : 10;
 
       if (startSwitch === 'now') {
         startDateTime = new Date(
-          `${getCanonicalDate()}T${getCanonicalTime({
-            minutes: startMinutesDelay,
-          })}:00${getCanonicalUtcOffset()}`
+          `${getCanonicalDate()}T${getCanonicalTime()}:00${getCanonicalUtcOffset()}`
         );
       } else {
         startDateTime = new Date(
@@ -379,15 +374,11 @@ const CreateProposalWrapper: React.FC<Props> = ({
       }
 
       if (startSwitch === 'now') {
-        endDateTime = new Date(
-          endDateTime.getTime() + minutesToMills(startMinutesDelay)
-        );
+        endDateTime = new Date(endDateTime.getTime());
       } else {
         if (startDateTime.valueOf() < new Date().valueOf()) {
           startDateTime = new Date(
-            `${getCanonicalDate()}T${getCanonicalTime({
-              minutes: startMinutesDelay,
-            })}:00${getCanonicalUtcOffset()}`
+            `${getCanonicalDate()}T${getCanonicalTime()}:00${getCanonicalUtcOffset()}`
           );
         }
 
@@ -410,22 +401,20 @@ const CreateProposalWrapper: React.FC<Props> = ({
       }
 
       /**
-       * For multisig proposals, in case "now" as start time is selected, we want
-       * to keep startDate undefined, so it's automatically evaluated.
+       * In case "now" as start time is selected, we want
+       * to keep startDate and endDate undefined, so it's automatically evaluated.
        * If we just provide "Date.now()", than after user still goes through the flow
        * it's going to be date from the past. And SC-call evaluation will fail.
        */
-      const finalStartDate =
-        startSwitch === 'now' && isMultisigVotingSettings(votingSettings)
-          ? undefined
-          : startDateTime;
+      const finalStartDate = startSwitch === 'now' ? undefined : startDateTime;
+      const finalEndDate = startSwitch === 'now' ? undefined : endDateTime;
 
       // Ignore encoding if the proposal had no actions
       return {
         pluginAddress,
         metadataUri: ipfsUri || '',
         startDate: finalStartDate,
-        endDate: endDateTime,
+        endDate: finalEndDate,
         actions,
       };
     }, [
@@ -436,7 +425,6 @@ const CreateProposalWrapper: React.FC<Props> = ({
       minMinutes,
       pluginAddress,
       pluginClient?.methods,
-      votingSettings,
     ]);
 
   const estimateCreationFees = useCallback(async () => {

--- a/src/pages/proposeSettings.tsx
+++ b/src/pages/proposeSettings.tsx
@@ -480,18 +480,32 @@ const ProposeSettingWrapper: React.FC<Props> = ({
         // getting dates
         let startDateTime: Date;
 
+        /**
+         * Here we defined base startDate.
+         */
         if (startSwitch === 'now') {
+          // Taking current time, but we won't pass it to SC cuz it's gonna be outdated. Needed for calculations below.
           startDateTime = new Date(
             `${getCanonicalDate()}T${getCanonicalTime()}:00${getCanonicalUtcOffset()}`
           );
         } else {
+          // Taking time user has set.
           startDateTime = new Date(
             `${startDate}T${startTime}:00${getCanonicalUtcOffset(startUtc)}`
           );
         }
 
+        // Minimum allowed end date (if endDate is lower than that SC call fails)
+        const minEndDateTimeMills =
+          startDateTime.valueOf() +
+          daysToMills(minDays || 0) +
+          hoursToMills(minHours || 0) +
+          minutesToMills(minMinutes || 0);
+
         // End date
         let endDateTime;
+
+        // user specifies duration in time/second exact way
         if (durationSwitch === 'duration') {
           const [days, hours, minutes] = getValues([
             'durationDays',
@@ -504,27 +518,32 @@ const ProposeSettingWrapper: React.FC<Props> = ({
             startDateTime.valueOf() + offsetToMills({days, hours, minutes});
 
           endDateTime = new Date(endDateTimeMill);
+
+          // In case the endDate is close to being minimum durable, (and we starting immediately)
+          // to avoid passing late-date possibly, we just rely on SDK to set proper Date
+          if (
+            endDateTime.valueOf() <= minEndDateTimeMills &&
+            startSwitch === 'now'
+          ) {
+            /* Pass enddate as undefined to SDK to auto-calculate min endDate */
+            endDateTime = undefined;
+          }
         } else {
+          // In case exact time specified by user
           endDateTime = new Date(
             `${endDate}T${endTime}:00${getCanonicalUtcOffset(endUtc)}`
           );
         }
 
-        if (startSwitch === 'now') {
-          endDateTime = new Date(endDateTime.getTime());
-        } else {
+        if (startSwitch === 'duration' && endDateTime) {
+          // Making sure we are not in past for further calculation
           if (startDateTime.valueOf() < new Date().valueOf()) {
             startDateTime = new Date(
               `${getCanonicalDate()}T${getCanonicalTime()}:00${getCanonicalUtcOffset()}`
             );
           }
 
-          const minEndDateTimeMills =
-            startDateTime.valueOf() +
-            daysToMills(minDays || 0) +
-            hoursToMills(minHours || 0) +
-            minutesToMills(minMinutes || 0);
-
+          // If provided date is expired
           if (endDateTime.valueOf() < minEndDateTimeMills) {
             const legacyStartDate = new Date(
               `${startDate}T${startTime}:00${getCanonicalUtcOffset(startUtc)}`
@@ -539,20 +558,19 @@ const ProposeSettingWrapper: React.FC<Props> = ({
 
         /**
          * In case "now" as start time is selected, we want
-         * to keep startDate and endDate undefined, so it's automatically evaluated.
+         * to keep startDate undefined, so it's automatically evaluated.
          * If we just provide "Date.now()", than after user still goes through the flow
          * it's going to be date from the past. And SC-call evaluation will fail.
          */
         const finalStartDate =
           startSwitch === 'now' ? undefined : startDateTime;
-        const finalEndDate = startSwitch === 'now' ? undefined : endDateTime;
 
         // Ignore encoding if the proposal had no actions
         return {
           pluginAddress,
           metadataUri: ipfsUri || '',
           startDate: finalStartDate,
-          endDate: finalEndDate,
+          endDate: endDateTime,
           actions,
         };
       };

--- a/src/pages/proposeSettings.tsx
+++ b/src/pages/proposeSettings.tsx
@@ -479,15 +479,10 @@ const ProposeSettingWrapper: React.FC<Props> = ({
 
         // getting dates
         let startDateTime: Date;
-        const startMinutesDelay = isMultisigVotingSettings(votingSettings)
-          ? 0
-          : 10;
 
         if (startSwitch === 'now') {
           startDateTime = new Date(
-            `${getCanonicalDate()}T${getCanonicalTime({
-              minutes: startMinutesDelay,
-            })}:00${getCanonicalUtcOffset()}`
+            `${getCanonicalDate()}T${getCanonicalTime()}:00${getCanonicalUtcOffset()}`
           );
         } else {
           startDateTime = new Date(
@@ -516,15 +511,11 @@ const ProposeSettingWrapper: React.FC<Props> = ({
         }
 
         if (startSwitch === 'now') {
-          endDateTime = new Date(
-            endDateTime.getTime() + minutesToMills(startMinutesDelay)
-          );
+          endDateTime = new Date(endDateTime.getTime());
         } else {
           if (startDateTime.valueOf() < new Date().valueOf()) {
             startDateTime = new Date(
-              `${getCanonicalDate()}T${getCanonicalTime({
-                minutes: startMinutesDelay,
-              })}:00${getCanonicalUtcOffset()}`
+              `${getCanonicalDate()}T${getCanonicalTime()}:00${getCanonicalUtcOffset()}`
             );
           }
 
@@ -547,22 +538,21 @@ const ProposeSettingWrapper: React.FC<Props> = ({
         }
 
         /**
-         * For multisig proposals, in case "now" as start time is selected, we want
-         * to keep startDate undefined, so it's automatically evaluated.
+         * In case "now" as start time is selected, we want
+         * to keep startDate and endDate undefined, so it's automatically evaluated.
          * If we just provide "Date.now()", than after user still goes through the flow
          * it's going to be date from the past. And SC-call evaluation will fail.
          */
         const finalStartDate =
-          startSwitch === 'now' && isMultisigVotingSettings(votingSettings)
-            ? undefined
-            : startDateTime;
+          startSwitch === 'now' ? undefined : startDateTime;
+        const finalEndDate = startSwitch === 'now' ? undefined : endDateTime;
 
         // Ignore encoding if the proposal had no actions
         return {
           pluginAddress,
           metadataUri: ipfsUri || '',
           startDate: finalStartDate,
-          endDate: endDateTime,
+          endDate: finalEndDate,
           actions,
         };
       };


### PR DESCRIPTION
As a DAO operator in a token based DAO, I want my proposals to start immediately after creating them as opposed to having to wait 10 minutes so that I can vote immediately after creating the proposal.

Task: [APP-2457](https://aragonassociation.atlassian.net/browse/APP-2457)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2457]: https://aragonassociation.atlassian.net/browse/APP-2457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ