### PR TITLE
fix: APP-2575 createDao details wording changes

### DIFF
--- a/src/containers/goLive/community.tsx
+++ b/src/containers/goLive/community.tsx
@@ -121,7 +121,12 @@ const Community: React.FC = () => {
                 <Dd>
                   <div className="flex items-center space-x-3">
                     <span>
-                      {tokenName} ({govTokenSymbol})
+                      {isGovTokenRequiresWrapping && (
+                        <span>{t('labels.review.tokenSymbolGovernance')}</span>
+                      )}
+                      <span>
+                        {tokenName} ({govTokenSymbol})
+                      </span>
                     </span>
 
                     {/* TODO: check the owner for token contract, if it belongs to

--- a/src/containers/goLive/community.tsx
+++ b/src/containers/goLive/community.tsx
@@ -122,7 +122,9 @@ const Community: React.FC = () => {
                   <div className="flex items-center space-x-3">
                     <span>
                       {isGovTokenRequiresWrapping && (
-                        <span>{t('labels.review.tokenSymbolGovernance')}</span>
+                        <span>
+                          {t('labels.review.tokenSymbolGovernance')}&nbsp;
+                        </span>
                       )}
                       <span>
                         {tokenName} ({govTokenSymbol})

--- a/src/containers/goLive/community.tsx
+++ b/src/containers/goLive/community.tsx
@@ -121,8 +121,7 @@ const Community: React.FC = () => {
                 <Dd>
                   <div className="flex items-center space-x-3">
                     <span>
-                      {t('labels.review.tokenSymbolGovernance')} {tokenName} (
-                      {govTokenSymbol})
+                      {tokenName} ({govTokenSymbol})
                     </span>
 
                     {/* TODO: check the owner for token contract, if it belongs to

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -817,7 +817,7 @@
       "wrappedReferenceParticipationValueLabel": "{{gTokenSymbol}} *"
     },
     "review": {
-      "title": "Review details",
+      "title": "Deploy your DAO",
       "description": "Double-check that everything is correct before deploying your DAO.",
       "network": "{{network}} net",
       "distributionLink": "See {{count}} addresses",


### PR DESCRIPTION
## Description

There seem to be two issues at the ‘Review Page’ when creating a (Token Based) DAO:

- When creating DAO with fresh token: ‘Governance’ is added to the ‘Token’ name (see image 1). After deploying the DAO, it has not added ‘Governance’ to it, which is good. So looks like a ‘Review Page’ issue only.
- The button says ‘Review details’ (see image 2). I remember it said ‘Deploy your DAO’. Has this been a conscious change?

Task: [APP-2575](https://aragonassociation.atlassian.net/browse/APP-2575)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2575]: https://aragonassociation.atlassian.net/browse/APP-2575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ