### PR TITLE
fix: APP-2561 - Display correct icon on delegation-gating menu

### DIFF
--- a/src/containers/delegationGatingMenu/delegationGatingMenu.tsx
+++ b/src/containers/delegationGatingMenu/delegationGatingMenu.tsx
@@ -4,13 +4,7 @@ import styled from 'styled-components';
 import React from 'react';
 import {formatUnits} from 'ethers/lib/utils';
 import {useTranslation} from 'react-i18next';
-import {
-  ButtonText,
-  IllustrationHuman,
-  IlluObject,
-  Link,
-  IconLinkExternal,
-} from '@aragon/ods-old';
+import {ButtonText, IlluObject, Link, IconLinkExternal} from '@aragon/ods-old';
 import {useDaoDetailsQuery} from 'hooks/useDaoDetails';
 import {useDaoToken} from 'hooks/useDaoToken';
 import {Address, useBalance} from 'wagmi';
@@ -122,18 +116,7 @@ export const DelegationGatingMenu: React.FC = () => {
     >
       <div className="flex flex-col gap-6 px-4 py-6 text-center">
         <ContentGroup className="items-center">
-          {needsSelfDelegation ? (
-            <IllustrationHuman
-              width={343}
-              height={193}
-              body="elevating"
-              expression="excited"
-              hair="curly"
-              accessory="piercings_tattoo"
-            />
-          ) : (
-            <IlluObject object="warning" />
-          )}
+          <IlluObject object="warning" />
           <p className="text-2xl leading-tight text-neutral-800">
             {t(`modal.delegation.CantVote.title`)}
           </p>


### PR DESCRIPTION
## Description

- Update the icon on the delegation gating menu. As for the new design, we always display the warning icon.

Task: [APP-2561](https://aragonassociation.atlassian.net/browse/APP-2561)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2561]: https://aragonassociation.atlassian.net/browse/APP-2561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ