### PR TITLE
fix: APP-2579 tweaked token withdraw amount display on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.5.8",
-    "@aragon/ods": "^1.0.1",
+    "@aragon/ods": "^1.0.4",
     "@aragon/sdk-client": "^1.18.1",
     "@elastic/apm-rum-react": "^2.0.0",
     "@radix-ui/react-accordion": "^1.1.2",

--- a/src/@aragon/ods-old/components/cards/cardToken.tsx
+++ b/src/@aragon/ods-old/components/cards/cardToken.tsx
@@ -111,13 +111,13 @@ export const CardToken: React.FC<CardTokenProps> = ({
 type CardProps = Pick<CardTokenProps, 'bgWhite'>;
 
 const Card = styled.div.attrs<CardProps>(({bgWhite}) => ({
-  className: `flex justify-between space-x-8 items-center py-5 px-6 overflow-hidden ${
+  className: `flex justify-between items-center py-5 px-6 overflow-hidden ${
     bgWhite ? 'bg-neutral-50' : 'bg-neutral-0'
   } rounded-xl`,
 }))<CardProps>``;
 
 const CoinDetailsWithImage = styled.div.attrs({
-  className: 'flex items-center flex-auto',
+  className: 'flex items-center flex-auto overflow-hidden',
 })``;
 
 const CoinImage = styled.img.attrs(({src}) => ({
@@ -142,7 +142,7 @@ const SecondaryCoinDetails = styled.div.attrs({
 })``;
 
 const MarketProperties = styled.div.attrs({
-  className: 'text-right space-y-2 flex-auto overflow-hidden',
+  className: 'text-right space-y-2 flex-auto',
 })``;
 
 const FiatValue = styled.h1.attrs({

--- a/src/components/executionWidget/actions/withdrawCard.tsx
+++ b/src/components/executionWidget/actions/withdrawCard.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import {AccordionMethod} from 'components/accordionMethod';
 import {ActionWithdraw} from 'utils/types';
+import {NumberFormat, formatterUtils} from '@aragon/ods';
 
 export const WithdrawCard: React.FC<{
   action: ActionWithdraw;
@@ -34,10 +35,12 @@ export const WithdrawCard: React.FC<{
           tokenCount={action.amount}
           treasuryShare={
             action.tokenPrice
-              ? new Intl.NumberFormat('en-US', {
-                  style: 'currency',
-                  currency: 'USD',
-                }).format(action.tokenPrice * action.amount)
+              ? (formatterUtils.formatNumber(
+                  action.tokenPrice * action.amount,
+                  {
+                    format: NumberFormat.FIAT_TOTAL_SHORT,
+                  }
+                ) as string)
               : t('finance.unknownUSDValue')
           }
           type={'transfer'}

--- a/src/components/executionWidget/actions/withdrawCard.tsx
+++ b/src/components/executionWidget/actions/withdrawCard.tsx
@@ -13,6 +13,27 @@ export const WithdrawCard: React.FC<{
 }> = ({action, daoName}) => {
   const {t} = useTranslation();
 
+  const amount = Number(action.amount) || 0;
+  const tokenPrice = Number(action.tokenPrice) || 0;
+
+  const tokenCountDisplay =
+    amount > 99999
+      ? (formatterUtils.formatNumber(amount, {
+          format: NumberFormat.TOKEN_AMOUNT_SHORT,
+        }) as string)
+      : (formatterUtils.formatNumber(
+          amount.toFixed(amount > 100 ? 2 : amount < 10 ? 6 : 3),
+          {
+            format: NumberFormat.TOKEN_AMOUNT_LONG,
+          }
+        ) as string);
+
+  const treasuryShareDisplay = tokenPrice
+    ? (formatterUtils.formatNumber(tokenPrice * amount, {
+        format: NumberFormat.FIAT_TOTAL_SHORT,
+      }) as string)
+    : t('finance.unknownUSDValue');
+
   return (
     <AccordionMethod
       type="execution-widget"
@@ -32,17 +53,8 @@ export const WithdrawCard: React.FC<{
           tokenName={action.tokenName}
           tokenImageUrl={action.tokenImgUrl}
           tokenSymbol={action.tokenSymbol}
-          tokenCount={action.amount}
-          treasuryShare={
-            action.tokenPrice
-              ? (formatterUtils.formatNumber(
-                  action.tokenPrice * action.amount,
-                  {
-                    format: NumberFormat.FIAT_TOTAL_SHORT,
-                  }
-                ) as string)
-              : t('finance.unknownUSDValue')
-          }
+          tokenCount={tokenCountDisplay}
+          treasuryShare={treasuryShareDisplay}
           type={'transfer'}
         />
       </Container>

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,10 +48,10 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.0"
 
-"@aragon/ods@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@aragon/ods/-/ods-1.0.1.tgz#872476b0806243fae89ca336323320bc083330f5"
-  integrity sha512-5/QHgmLhyZKR4tRccrPAm7FkqpqUooOfRlFapr6uDYAejHwQ4zP3v271cyJRy0wv3MhKiIQinL+1roqberC8nQ==
+"@aragon/ods@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@aragon/ods/-/ods-1.0.4.tgz#181f61af112de96abe3f7219d38f92383ecbf83b"
+  integrity sha512-/QHMEG4U7uOX3oxu3EBmtFVq43S6iq1gs0tO203rb7pj8VaCJnjIN/E0rUjn0hfDB5HIz4A/3ZqMxIyn7Kbitg==
   dependencies:
     "@radix-ui/react-progress" "^1.0.3"
     classnames "^2.3.2"


### PR DESCRIPTION
## Description

When opening a Token Withdrawal Proposal at Mobile, you cannot see the complete token amount (see image 1, token amount is 2,000 USD, see image 2). So the issue is that you don’t know exactly what you are voting on.

Task: [APP-2579](https://aragonassociation.atlassian.net/browse/APP-2579)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2579]: https://aragonassociation.atlassian.net/browse/APP-2579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ