### PR TITLE
Fix: APP-2514 - Change default Proposal Threshold for DAO with Newly Minted token to ≥1 token

### DIFF
--- a/src/components/addWallets/row.tsx
+++ b/src/components/addWallets/row.tsx
@@ -252,8 +252,6 @@ const WalletRow: React.FC<WalletRowProps> = ({index, onDelete}) => {
                   const [totalSupply, amount] = getValues([
                     'tokenTotalSupply',
                     `wallets.${index}.amount`,
-                    'eligibilityType',
-                    'eligibilityTokenAmount',
                   ]);
 
                   const newTotalSupply = Number(totalSupply) - Number(amount);

--- a/src/components/addWallets/row.tsx
+++ b/src/components/addWallets/row.tsx
@@ -249,12 +249,7 @@ const WalletRow: React.FC<WalletRowProps> = ({index, onDelete}) => {
               ),
               callback: () => {
                 if (typeof onDelete === 'function') {
-                  const [
-                    totalSupply,
-                    amount,
-                    eligibilityType,
-                    eligibilityTokenAmount,
-                  ] = getValues([
+                  const [totalSupply, amount] = getValues([
                     'tokenTotalSupply',
                     `wallets.${index}.amount`,
                     'eligibilityType',
@@ -267,20 +262,6 @@ const WalletRow: React.FC<WalletRowProps> = ({index, onDelete}) => {
                     newTotalSupply < 0 ? 0 : newTotalSupply
                   );
                   onDelete(index);
-                  if (eligibilityType === 'token') {
-                    if (eligibilityTokenAmount === amount) {
-                      let minAmount = walletFieldArray[0]?.amount;
-                      (walletFieldArray as TokenVotingWalletField[]).forEach(
-                        (wallet, mapIndex) => {
-                          if (mapIndex !== index)
-                            if (Number(wallet.amount) < Number(minAmount)) {
-                              minAmount = wallet.amount;
-                            }
-                        }
-                      );
-                      setValue('minimumTokenAmount', minAmount);
-                    }
-                  }
                   alert(t('alert.chip.removedAddress') as string);
                 }
               },

--- a/src/components/addWallets/row.tsx
+++ b/src/components/addWallets/row.tsx
@@ -100,7 +100,6 @@ const WalletRow: React.FC<WalletRowProps> = ({index, onDelete}) => {
       let totalSupply = 0;
       let minAmount = walletFieldArray[0]?.amount;
       const address = getValues(`wallets.${index}.address`);
-      const eligibilityType = getValues('eligibilityType');
       if (address === '') trigger(`wallets.${index}.address`);
 
       // calculate total token supply disregarding error invalid fields
@@ -112,9 +111,6 @@ const WalletRow: React.FC<WalletRowProps> = ({index, onDelete}) => {
           totalSupply = Number(wallet.amount) + totalSupply;
       });
       setValue('tokenTotalSupply', totalSupply);
-
-      if (eligibilityType === 'token')
-        setValue('minimumTokenAmount', minAmount);
 
       // Number of characters after decimal point greater than
       // the number of decimals in the token itself


### PR DESCRIPTION
## Description

Found the following in `createDAO.tsx`: `eligibilityTokenAmount: 1, minimumTokenAmount: 1,` meaning that the default value for the Proposal Threshold is already `1`. So I did the following:

- Removed setting on DAO creation with new token which sets Proposal Threshold to the lowest entered token amount at the wallet rows (see image 1)

- Then removed the logic which is setting the Proposal Threshold to the lowest entered token amount at the wallet rows on deletion of a wallet row



Image 1

<img width="1572" alt="image" src="https://github.com/aragon/app/assets/16764792/c1777f92-ac19-497d-bdac-882b6e533b9a">


Task: [APP-2514](https://aragonassociation.atlassian.net/browse/APP-2514)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2514]: https://aragonassociation.atlassian.net/browse/APP-2514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ