### PR TITLE
fix: APP-2567 remove wallets reset action

### DIFF
--- a/src/containers/actionBuilder/removeAddresses/index.tsx
+++ b/src/containers/actionBuilder/removeAddresses/index.tsx
@@ -78,6 +78,11 @@ const RemoveAddresses: React.FC<RemoveAddressesProps> = ({
     alert(t('alert.chip.removedAllAddresses'));
   }
 
+  function handleResetAll() {
+    replace([]);
+    alert(t('alert.chip.resetAction'));
+  }
+
   const rowActions = [
     {
       component: (
@@ -94,7 +99,12 @@ const RemoveAddresses: React.FC<RemoveAddressesProps> = ({
   ];
 
   const methodActions = (() => {
-    const result = [];
+    const result = [
+      {
+        component: <ListItemAction title={t('labels.resetAction')} bgWhite />,
+        callback: handleResetAll,
+      },
+    ];
 
     if (allowRemove) {
       result.push({


### PR DESCRIPTION
## Description

There is an option to clear out the form of the an action in the action builder, by clicking “reset action”. This exists for some actions and not others. This is to ensure it is on the “remove wallets” action.

Task: [APP-2567](https://aragonassociation.atlassian.net/browse/APP-2567)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2567]: https://aragonassociation.atlassian.net/browse/APP-2567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ