### PR TITLE
Fix: Synpress startup error and the Login test

### DIFF
--- a/tests/e2e/pages/LoginComponent.ts
+++ b/tests/e2e/pages/LoginComponent.ts
@@ -1,8 +1,20 @@
 export default class ConnectComponent {
   /** Actions to connect Metamask wallet to app */
   connectMetamask() {
-    cy.get('nav button').click();
-    cy.get('.web3modal-provider-wrapper').first().click();
+    cy.get('nav button:last').click();
+    cy.get('w3m-modal')
+      .shadow()
+      .find('w3m-modal-router')
+      .shadow()
+      .find('w3m-connect-wallet-view')
+      .shadow()
+      .find('w3m-desktop-wallet-selection')
+      .shadow()
+      .find('w3m-wallet-button[name="MetaMask"')
+      .shadow()
+      .find('button')
+      .click();
+    cy.wait(1000);
     cy.switchToMetamaskWindow();
     cy.acceptMetamaskAccess().should('be.true');
     cy.switchToCypressWindow();

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "baseUrl": "../../node_modules",
+    "baseUrl": "./",
     "types": [
       "cypress",
       "@synthetixio/synpress/support",


### PR DESCRIPTION
## Description

- Fixes a bug that prevents Synpress from starting up
- Fixes the metamask connect wallet test. It was broken since we moved to WalletConnect v2

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.
