### PR TITLE
Feature: APP-2623 - Decoding OSx update actions & conditionally show banner/settings card

### DIFF
--- a/src/abis/daoABI.ts
+++ b/src/abis/daoABI.ts
@@ -1,3 +1,5 @@
+import {Abi} from 'utils/abiDecoder';
+
 export const daoABI = [
   {inputs: [], stateMutability: 'nonpayable', type: 'constructor'},
   {
@@ -33,4 +35,4 @@ export const daoABI = [
     type: 'function',
   },
   {stateMutability: 'payable', type: 'receive'},
-];
+] as unknown as Abi[];

--- a/src/abis/daoABI.ts
+++ b/src/abis/daoABI.ts
@@ -1,0 +1,36 @@
+export const daoABI = [
+  {inputs: [], stateMutability: 'nonpayable', type: 'constructor'},
+  {
+    inputs: [
+      {internalType: 'address', name: '_where', type: 'address'},
+      {internalType: 'address', name: '_who', type: 'address'},
+      {internalType: 'bytes32', name: '_permissionId', type: 'bytes32'},
+    ],
+    name: 'grant',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {internalType: 'address', name: 'newImplementation', type: 'address'},
+      {internalType: 'bytes', name: 'data', type: 'bytes'},
+    ],
+    name: 'upgradeToAndCall',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {internalType: 'address', name: '_where', type: 'address'},
+      {internalType: 'address', name: '_who', type: 'address'},
+      {internalType: 'bytes32', name: '_permissionId', type: 'bytes32'},
+    ],
+    name: 'revoke',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {stateMutability: 'payable', type: 'receive'},
+];

--- a/src/abis/daoFactoryABI.ts
+++ b/src/abis/daoFactoryABI.ts
@@ -1,0 +1,16 @@
+export const daoFactoryABI = [
+  {
+    constant: true,
+    inputs: [],
+    name: 'daoBase',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+];

--- a/src/containers/defineProposal/update.tsx
+++ b/src/containers/defineProposal/update.tsx
@@ -231,10 +231,7 @@ export const DefineUpdateProposal: React.FC = () => {
     }
 
     if (updateFramework?.plugin && pluginSelectedVersion?.version) {
-      const versionKey = getVersionKey(
-        pluginSelectedVersion.version.release,
-        pluginSelectedVersion.version.build
-      );
+      const versionKey = `${pluginSelectedVersion.version.release}.${pluginSelectedVersion.version.build}`;
 
       const preparedData: PreparedPluginData | undefined =
         availablePluginUpdates?.get(versionKey)?.preparedData;
@@ -353,7 +350,3 @@ const UpdateGroupWrapper = styled.div.attrs({
 const UpdateContainer = styled.div.attrs({
   className: 'space-y-4',
 })``;
-
-function getVersionKey(release: number, build: number) {
-  return `${release}.${build}`;
-}

--- a/src/containers/defineProposal/update.tsx
+++ b/src/containers/defineProposal/update.tsx
@@ -22,6 +22,8 @@ import {useProtocolVersion} from 'services/aragon-sdk/queries/use-protocol-versi
 import {useReleaseNotes} from 'services/aragon-sdk/queries/use-release-notes';
 import {osxUpdates} from 'utils/osxUpdates';
 import {ProposalFormData} from 'utils/types';
+import {useNavigate} from 'react-router-dom';
+import {NotFound} from 'utils/paths';
 
 type ModalState = {
   type: 'os' | 'plugin' | 'none';
@@ -36,6 +38,7 @@ export const DefineUpdateProposal: React.FC = () => {
 
   // hooks
   const {t} = useTranslation();
+  const navigate = useNavigate();
 
   const {
     handlePreparePlugin,
@@ -305,11 +308,9 @@ export const DefineUpdateProposal: React.FC = () => {
     availablePluginUpdates?.size === 0 &&
     availableProtocolUpdates?.size === 0
   ) {
-    return (
-      <div className="flex h-40 items-center justify-center">
-        No updates currently available for your DAO.
-      </div>
-    );
+    navigate(NotFound, {
+      replace: true,
+    });
   }
 
   return (

--- a/src/containers/navbar/updateBanner.tsx
+++ b/src/containers/navbar/updateBanner.tsx
@@ -12,6 +12,7 @@ import styled from 'styled-components';
 import {useNetwork} from 'context/network';
 import {useDaoDetailsQuery} from 'hooks/useDaoDetails';
 import {PluginTypes} from 'hooks/usePluginClient';
+import {useUpdateExists} from 'hooks/useUpdateExists';
 import {useWallet} from 'hooks/useWallet';
 import {useIsMember} from 'services/aragon-sdk/queries/use-is-member';
 import {featureFlags} from 'utils/featureFlags';
@@ -19,6 +20,8 @@ import {NewProposal} from 'utils/paths';
 import {ProposalTypes} from 'utils/types';
 
 const UpdateBanner: React.FC = () => {
+  const [bannerHidden, setBannerHidden] = useState(false);
+
   const {t} = useTranslation();
   const {dao} = useParams();
   const navigate = useNavigate();
@@ -27,68 +30,62 @@ const UpdateBanner: React.FC = () => {
   const {network} = useNetwork();
   const {address} = useWallet();
 
-  const [showUpdateBanner, setShowUpdateBanner] = useState(true);
-
+  const updateExists = useUpdateExists();
   const {data: daoDetails} = useDaoDetailsQuery();
-
-  const pluginAddress = daoDetails?.plugins?.[0]?.instanceAddress as string;
-  const pluginType = daoDetails?.plugins?.[0]?.id as PluginTypes;
-
   const {data: isMember} = useIsMember({
     address: address as string,
-    pluginAddress,
-    pluginType,
+    pluginAddress: daoDetails?.plugins?.[0]?.instanceAddress as string,
+    pluginType: daoDetails?.plugins?.[0]?.id as PluginTypes,
   });
-
-  if (
-    location.pathname.includes('new-proposal') ||
-    location.pathname.includes('settings') ||
-    location.pathname.includes('create')
-  )
-    return null;
 
   const daoUpdateEnabled =
     featureFlags.getValue('VITE_FEATURE_FLAG_OSX_UPDATES') === 'true';
 
-  // TODO: when do we show banner?
-  function handleBannerClosed() {
-    setShowUpdateBanner(false);
-  }
+  const showBanner =
+    !bannerHidden && isMember && updateExists && daoUpdateEnabled;
 
-  if (daoUpdateEnabled && isMember && showUpdateBanner)
-    return (
-      <UpdateContainer>
-        <DummyElement />
-        <MessageWrapper>
-          <TextWrapper>
-            <IconUpdate className="text-neutral-0" />
-            <span className="font-semibold text-neutral-0 ft-text-base">
-              {t('update.banner.title')}
-            </span>
-          </TextWrapper>
-          <ButtonText
-            label="View updates"
-            size="small"
-            bgWhite
-            mode={'secondary'}
-            onClick={() =>
-              navigate(
-                generatePath(NewProposal, {
-                  type: ProposalTypes.OSUpdates,
-                  network,
-                  dao: dao,
-                })
-              )
-            }
-          />
-        </MessageWrapper>
-        <IconClose
-          className="cursor-pointer justify-self-end text-neutral-0"
-          onClick={handleBannerClosed}
+  if (
+    location.pathname.includes('new-proposal') ||
+    location.pathname.includes('settings') ||
+    location.pathname.includes('create') ||
+    showBanner === false
+  )
+    return null;
+
+  return (
+    <UpdateContainer>
+      <DummyElement />
+      <MessageWrapper>
+        <TextWrapper>
+          <IconUpdate className="text-neutral-0" />
+          <span className="font-semibold text-neutral-0 ft-text-base">
+            {t('update.banner.title')}
+          </span>
+        </TextWrapper>
+        <ButtonText
+          label="View updates"
+          size="small"
+          bgWhite
+          mode={'secondary'}
+          onClick={() =>
+            navigate(
+              generatePath(NewProposal, {
+                type: ProposalTypes.OSUpdates,
+                network,
+                dao: dao,
+              })
+            )
+          }
         />
-      </UpdateContainer>
-    );
-  return null;
+      </MessageWrapper>
+      <IconClose
+        className="cursor-pointer justify-self-end text-neutral-0"
+        onClick={() => {
+          setBannerHidden(true);
+        }}
+      />
+    </UpdateContainer>
+  );
 };
 
 const DummyElement = styled.div.attrs({

--- a/src/containers/navbar/updateBanner.tsx
+++ b/src/containers/navbar/updateBanner.tsx
@@ -41,8 +41,12 @@ const UpdateBanner: React.FC = () => {
   const daoUpdateEnabled =
     featureFlags.getValue('VITE_FEATURE_FLAG_OSX_UPDATES') === 'true';
 
-  const showBanner =
-    !bannerHidden && isMember && updateExists && daoUpdateEnabled;
+  const showBanner = !!(
+    !bannerHidden &&
+    isMember &&
+    updateExists &&
+    daoUpdateEnabled
+  );
 
   if (
     location.pathname.includes('new-proposal') ||

--- a/src/containers/reviewProposal/index.tsx
+++ b/src/containers/reviewProposal/index.tsx
@@ -48,6 +48,7 @@ import {
   ProposalTypes,
   SupportedVotingSettings,
 } from 'utils/types';
+import {useProviders} from 'context/providers';
 
 type ReviewProposalProps = {
   defineProposalStepNumber: number;
@@ -62,6 +63,7 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
   const {client, network} = useClient();
   const {t, i18n} = useTranslation();
   const {setStep} = useFormStep();
+  const {api: provider} = useProviders();
 
   const [displayedActions, setDisplayedActions] = useState<Action[]>([]);
 
@@ -234,6 +236,7 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
         currentProtocolVersion,
         client,
         network,
+        provider,
         t
       ).then(actions => {
         if (actions) {
@@ -252,6 +255,7 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
     type,
     updateFramework,
     values.actions,
+    provider,
   ]);
 
   useEffect(() => {

--- a/src/containers/reviewProposal/index.tsx
+++ b/src/containers/reviewProposal/index.tsx
@@ -6,7 +6,7 @@ import StarterKit from '@tiptap/starter-kit';
 import {Locale, format, formatDistanceToNow} from 'date-fns';
 import * as Locales from 'date-fns/locale';
 import {TFunction} from 'i18next';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {useFormContext, useWatch} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
@@ -37,9 +37,8 @@ import {
   getCanonicalUtcOffset,
   getFormattedUtcOffset,
 } from 'utils/date';
-import {decodeOsUpdateAction} from 'utils/library';
 import {
-  encodeOsUpdateAction,
+  getDecodedUpdateActions,
   getErc20VotingParticipation,
   getNonEmptyActions,
 } from 'utils/proposals';
@@ -66,28 +65,29 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
 
   const [displayedActions, setDisplayedActions] = useState<Action[]>([]);
 
-  const osSelectedVersion = useWatch({name: 'osSelectedVersion'});
-  const updateFramework = useWatch({name: 'updateFramework'});
-
   const {data: daoDetails, isLoading: detailsLoading} = useDaoDetailsQuery();
   const daoAddress = daoDetails?.address as string;
-  const pluginAddress = daoDetails?.plugins?.[0]?.instanceAddress as string;
   const pluginType = daoDetails?.plugins?.[0]?.id as PluginTypes;
+  const pluginAddress = daoDetails?.plugins?.[0]?.instanceAddress as string;
 
-  const {data: protocolVersion} = useProtocolVersion(daoAddress);
+  const {data: currentProtocolVersion, isLoading: protocolVersionLoading} =
+    useProtocolVersion(daoAddress);
 
   const {data: votingSettings, isLoading: votingSettingsLoading} =
     useVotingSettings({pluginAddress, pluginType});
+
   const isMultisig = isMultisigVotingSettings(votingSettings);
 
   // Member list only needed for multisig so first page (1000) is sufficient
   const {
     data: {members, daoToken},
   } = useDaoMembers(pluginAddress, pluginType, {page: 0});
-
   const {data: totalSupply} = useTokenSupply(daoToken?.address as string);
 
   const {getValues, setValue} = useFormContext();
+  const updateFramework = useWatch({name: 'updateFramework'});
+  const osSelectedVersion = useWatch({name: 'osSelectedVersion'});
+  const pluginSelectedVersion = useWatch({name: 'pluginSelectedVersion'});
   const values = getValues();
 
   const editor = useEditor({
@@ -102,31 +102,24 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
     ],
   });
 
-  const startDate = useMemo(() => {
-    const {startSwitch, startDate, startTime, startUtc} = values;
+  const {startSwitch, startDate, startTime, startUtc} = values;
 
-    if (startSwitch === 'now') {
-      return new Date(
-        `${getCanonicalDate()}T${getCanonicalTime()}:00${getCanonicalUtcOffset()}`
-      );
-    } else {
-      return Date.parse(
-        `${startDate}T${startTime}:00${getCanonicalUtcOffset(startUtc)}`
-      );
-    }
-  }, [values]);
+  let calculatedStartDate: number | Date;
+  let formattedStartDate = t('labels.now');
 
-  const formattedStartDate = useMemo(() => {
-    const {startSwitch} = values;
-    if (startSwitch === 'now') {
-      return t('labels.now');
-    }
-
-    return `${format(
-      startDate,
+  if (startSwitch === 'now') {
+    calculatedStartDate = new Date(
+      `${getCanonicalDate()}T${getCanonicalTime()}:00${getCanonicalUtcOffset()}`
+    );
+  } else {
+    calculatedStartDate = Date.parse(
+      `${startDate}T${startTime}:00${getCanonicalUtcOffset(startUtc)}`
+    );
+    formattedStartDate = `${format(
+      calculatedStartDate,
       KNOWN_FORMATS.proposals
     )} ${getFormattedUtcOffset()}`;
-  }, [startDate, t, values]);
+  }
 
   /**
    * This is the primary (approximate) end date display which is rendered in Voting Terminal
@@ -219,53 +212,6 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
   }, [votingSettings, daoToken, members, t, totalSupply?.raw]);
 
   /*************************************************
-   *             Callbacks & Handlers              *
-   *************************************************/
-  const getDecodedUpdateActions = useCallback(async () => {
-    if (!client) return;
-
-    const updateActions = [];
-
-    for (const action of values.actions as Action[]) {
-      if (
-        action.name === 'os_update' &&
-        updateFramework?.os &&
-        osSelectedVersion?.version
-      ) {
-        // encode and decode the osUpdateAction so that it can be
-        // decoded and passed to the generic SCC external action card
-        const encodedOsAction = await encodeOsUpdateAction(
-          protocolVersion,
-          osSelectedVersion.version,
-          network,
-          daoAddress,
-          client
-        );
-
-        // decode using the SDK to get around the proxy issue
-        // TODO: remove this when the implementation contract and ABI can be
-        // fetched properly by the generic action decoder
-        const decoded = decodeOsUpdateAction(encodedOsAction, client, t);
-
-        if (decoded) {
-          updateActions.push(decoded);
-        }
-      }
-    }
-
-    setDisplayedActions(updateActions);
-  }, [
-    client,
-    daoAddress,
-    network,
-    osSelectedVersion?.version,
-    protocolVersion,
-    t,
-    updateFramework?.os,
-    values.actions,
-  ]);
-
-  /*************************************************
    *                    Effects                    *
    *************************************************/
   useEffect(() => {
@@ -276,15 +222,36 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
           isMultisig ? votingSettings : undefined
         )
       );
-    } else {
-      getDecodedUpdateActions();
+    }
+  }, [isMultisig, type, values.actions, votingSettings]);
+
+  useEffect(() => {
+    if (type === ProposalTypes.OSUpdates) {
+      getDecodedUpdateActions(
+        daoAddress,
+        getNonEmptyActions(values.actions),
+        updateFramework,
+        currentProtocolVersion,
+        client,
+        network,
+        t
+      ).then(actions => {
+        if (actions) {
+          setDisplayedActions(actions);
+        }
+      });
     }
   }, [
-    getDecodedUpdateActions,
-    isMultisig,
+    client,
+    daoAddress,
+    network,
+    osSelectedVersion,
+    pluginSelectedVersion,
+    currentProtocolVersion,
+    t,
     type,
+    updateFramework,
     values.actions,
-    votingSettings,
   ]);
 
   useEffect(() => {
@@ -296,7 +263,12 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
   /*************************************************
    *                    Render                     *
    *************************************************/
-  if (detailsLoading || votingSettingsLoading || !terminalProps)
+  if (
+    detailsLoading ||
+    votingSettingsLoading ||
+    protocolVersionLoading ||
+    !terminalProps
+  )
     return <Loading />;
 
   if (!editor) {
@@ -438,7 +410,6 @@ export const StyledEditorContent = styled(EditorContent)`
   }
 `;
 
-// this is slightly different from
 function getReviewProposalTerminalProps(
   t: TFunction,
   daoSettings: SupportedVotingSettings,

--- a/src/containers/reviewProposal/index.tsx
+++ b/src/containers/reviewProposal/index.tsx
@@ -88,8 +88,6 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
 
   const {getValues, setValue} = useFormContext();
   const updateFramework = useWatch({name: 'updateFramework'});
-  const osSelectedVersion = useWatch({name: 'osSelectedVersion'});
-  const pluginSelectedVersion = useWatch({name: 'pluginSelectedVersion'});
   const values = getValues();
 
   const editor = useEditor({
@@ -217,21 +215,21 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
    *                    Effects                    *
    *************************************************/
   useEffect(() => {
-    if (type === ProposalTypes.Default) {
+    if (type !== ProposalTypes.OSUpdates) {
       setDisplayedActions(
         getNonEmptyActions(
-          values.actions,
+          getValues('actions'),
           isMultisig ? votingSettings : undefined
         )
       );
     }
-  }, [isMultisig, type, values.actions, votingSettings]);
+  }, [getValues, isMultisig, type, votingSettings]);
 
   useEffect(() => {
     if (type === ProposalTypes.OSUpdates) {
       getDecodedUpdateActions(
         daoAddress,
-        getNonEmptyActions(values.actions),
+        getNonEmptyActions(getValues('actions')),
         updateFramework,
         currentProtocolVersion,
         client,
@@ -246,16 +244,14 @@ const ReviewProposal: React.FC<ReviewProposalProps> = ({
     }
   }, [
     client,
-    daoAddress,
-    network,
-    osSelectedVersion,
-    pluginSelectedVersion,
     currentProtocolVersion,
+    daoAddress,
+    getValues,
+    network,
+    provider,
     t,
     type,
     updateFramework,
-    values.actions,
-    provider,
   ]);
 
   useEffect(() => {

--- a/src/containers/setupVotingForm/index.tsx
+++ b/src/containers/setupVotingForm/index.tsx
@@ -6,11 +6,7 @@ import {
   isMultisigVotingSettings,
   isTokenVotingSettings,
 } from 'services/aragon-sdk/queries/use-voting-settings';
-import {
-  ProposalFormData,
-  StringIndexed,
-  SupportedVotingSettings,
-} from 'utils/types';
+import {StringIndexed, SupportedVotingSettings} from 'utils/types';
 import SetupMultisigVotingForm from './multisig';
 import SetupTokenVotingForm from './tokenVoting';
 
@@ -19,7 +15,7 @@ export type Props = {
 };
 
 const SetupVotingForm: React.FC<Props> = ({pluginSettings}) => {
-  const {setError, clearErrors} = useFormContext<ProposalFormData>();
+  const {setError, clearErrors} = useFormContext();
 
   /*************************************************
    *                    Render                     *

--- a/src/containers/setupVotingForm/multisig.tsx
+++ b/src/containers/setupVotingForm/multisig.tsx
@@ -1,4 +1,5 @@
 import {AlertInline, CheckboxListItem, Label} from '@aragon/ods-old';
+import {MultisigVotingSettings} from '@aragon/sdk-client';
 import React, {useCallback, useMemo, useState} from 'react';
 import {Controller, useFormContext, useWatch} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
@@ -9,6 +10,9 @@ import Duration, {DurationLabel} from 'containers/duration';
 import UtcMenu from 'containers/utcMenu';
 import {timezones} from 'containers/utcMenu/utcData';
 import {useGlobalModalContext} from 'context/globalModals';
+import {useDaoDetailsQuery} from 'hooks/useDaoDetails';
+import {useDaoMembers} from 'hooks/useDaoMembers';
+import {useVotingSettings} from 'services/aragon-sdk/queries/use-voting-settings';
 import {
   MINS_IN_DAY,
   MULTISIG_MAX_REC_DURATION_DAYS,
@@ -23,11 +27,6 @@ import {
 } from 'utils/date';
 import {FormSection} from '.';
 import {DateTimeErrors} from './dateTimeErrors';
-import {ProposalFormData} from 'utils/types';
-import {useVotingSettings} from 'services/aragon-sdk/queries/use-voting-settings';
-import {useDaoDetailsQuery} from 'hooks/useDaoDetails';
-import {useDaoMembers} from 'hooks/useDaoMembers';
-import {MultisigVotingSettings} from '@aragon/sdk-client';
 
 const MAX_DURATION_MILLS =
   MULTISIG_MAX_REC_DURATION_DAYS * MINS_IN_DAY * 60 * 1000;
@@ -53,7 +52,7 @@ const SetupMultisigVotingForm: React.FC = () => {
 
   const [utcInstance, setUtcInstance] = useState<UtcInstance>('first');
   const {control, formState, getValues, resetField, setValue, trigger} =
-    useFormContext<ProposalFormData>();
+    useFormContext();
 
   const [endTimeWarning, startSwitch, durationSwitch] = useWatch({
     control,

--- a/src/containers/setupVotingForm/tokenVoting.tsx
+++ b/src/containers/setupVotingForm/tokenVoting.tsx
@@ -4,6 +4,7 @@ import {Controller, useFormContext, useWatch} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
 
+import {MajorityVotingSettings} from '@aragon/sdk-client';
 import DateTimeSelector from 'containers/dateTimeSelector';
 import Duration, {DurationLabel} from 'containers/duration';
 import UtcMenu from 'containers/utcMenu';
@@ -19,8 +20,6 @@ import {
 } from 'utils/date';
 import {DateTimeErrors} from './dateTimeErrors';
 import {ToggleCheckList, UtcInstance} from './multisig';
-import {ProposalFormData} from 'utils/types';
-import {MajorityVotingSettings} from '@aragon/sdk-client';
 
 type Props = {
   pluginSettings: MajorityVotingSettings;
@@ -34,7 +33,7 @@ const SetupTokenVotingForm: React.FC<Props> = ({pluginSettings}) => {
 
   const [utcInstance, setUtcInstance] = useState<UtcInstance>('first');
   const {control, formState, getValues, resetField, setValue, trigger} =
-    useFormContext<ProposalFormData>();
+    useFormContext();
 
   const [endTimeWarning, startSwitch, durationSwitch] = useWatch({
     control,

--- a/src/containers/updateListItem/updateListItem.tsx
+++ b/src/containers/updateListItem/updateListItem.tsx
@@ -87,11 +87,13 @@ export const UpdateListItem: React.FC<CheckboxListItemProps> = ({
           <Helptext>
             <EditorContent editor={editor} />
           </Helptext>
-          <Link
-            label={linkLabel}
-            iconRight={<IconLinkExternal />}
-            href={releaseNote?.html_url}
-          />
+          <span>
+            <Link
+              label={linkLabel}
+              iconRight={<IconLinkExternal />}
+              href={releaseNote?.html_url}
+            />
+          </span>
         </div>
         {(buttonPrimaryLabel || buttonSecondaryLabel) && (
           <div className="mt-6 flex flex-col gap-y-3">

--- a/src/containers/withdrawStepper/index.tsx
+++ b/src/containers/withdrawStepper/index.tsx
@@ -1,8 +1,10 @@
+import {DaoDetails} from '@aragon/sdk-client';
 import React from 'react';
 import {useFormContext, useFormState, useWatch} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 
 import {FullScreenStepper, Step} from 'components/fullScreenStepper';
+import ConfigureActions from 'containers/configureActions';
 import {
   DefineProposal,
   isValid as defineProposalIsValid,
@@ -11,6 +13,7 @@ import ReviewProposal from 'containers/reviewProposal';
 import SetupVotingForm, {
   isValid as setupVotingIsValid,
 } from 'containers/setupVotingForm';
+import {useActionsContext} from 'context/actions';
 import {useNetwork} from 'context/network';
 import {useWallet} from 'hooks/useWallet';
 import {generatePath} from 'react-router-dom';
@@ -18,11 +21,8 @@ import {trackEvent} from 'services/analytics';
 import {getCanonicalUtcOffset} from 'utils/date';
 import {toDisplayEns} from 'utils/library';
 import {Finance} from 'utils/paths';
-import {ProposalFormData, SupportedVotingSettings} from 'utils/types';
-import ConfigureActions from 'containers/configureActions';
+import {SupportedVotingSettings} from 'utils/types';
 import {actionsAreValid} from 'utils/validators';
-import {useActionsContext} from 'context/actions';
-import {DaoDetails} from '@aragon/sdk-client';
 
 interface WithdrawStepperProps {
   enableTxModal: () => void;
@@ -40,7 +40,7 @@ const WithdrawStepper: React.FC<WithdrawStepperProps> = ({
   const {address} = useWallet();
   const {actions, addAction} = useActionsContext();
 
-  const {control, getValues} = useFormContext<ProposalFormData>();
+  const {control, getValues} = useFormContext();
 
   const {errors, dirtyFields} = useFormState({control: control});
 

--- a/src/context/createProposal.tsx
+++ b/src/context/createProposal.tsx
@@ -122,7 +122,7 @@ const CreateProposalWrapper: React.FC<Props> = ({
   const queryClient = useQueryClient();
 
   const navigate = useNavigate();
-  const {getValues} = useFormContext<ProposalFormData>();
+  const {getValues} = useFormContext();
 
   const {network} = useNetwork();
   const translatedNetwork = translateToNetworkishName(network);
@@ -660,7 +660,9 @@ const CreateProposalWrapper: React.FC<Props> = ({
           title,
           summary,
           description,
-          resources: resources.filter(r => r.name && r.url),
+          resources: (resources as ProposalFormData['links']).filter(
+            r => r.name && r.url
+          ),
         },
         actions: proposalCreationData.actions ?? [],
         status: proposalCreationData.startDate

--- a/src/context/update.tsx
+++ b/src/context/update.tsx
@@ -44,7 +44,7 @@ type UpdateContextType = {
   availableOSxVersions: Map<string, OSX> | null;
 };
 
-type PreparedPluginData = {
+export type PreparedPluginData = {
   permissions: MultiTargetPermission[];
   pluginAddress: string;
   pluginRepo: string;
@@ -223,15 +223,14 @@ const UpdateProvider: React.FC<{children: ReactElement}> = ({children}) => {
         if (
           release.release >= daoDetails!.plugins[0].release &&
           build.build > daoDetails!.plugins[0].build
-        )
-          pluginVersions.set(`${release.release}.${build.build}`, {
+        ) {
+          const versionKey = `${release.release}.${build.build}`;
+          pluginVersions.set(versionKey, {
             version: {
               build: build.build,
               release: release.release,
             },
-            ...(preparedPluginList?.has(
-              `${release.release}.${build.build}`
-            ) && {
+            ...(preparedPluginList?.has(versionKey) && {
               isPrepared: true,
               preparedData: {
                 ...preparedPluginList.get(`${release.release}.${build.build}`),
@@ -242,6 +241,7 @@ const UpdateProvider: React.FC<{children: ReactElement}> = ({children}) => {
                 isLatest: true,
               }),
           });
+        }
 
         setValue('pluginSelectedVersion', {
           version: {

--- a/src/context/update.tsx
+++ b/src/context/update.tsx
@@ -34,7 +34,6 @@ import {usePreparedPlugins} from 'services/aragon-sdk/queries/use-prepared-plugi
 import {useProtocolVersion} from 'services/aragon-sdk/queries/use-protocol-version';
 import {TransactionState} from 'utils/constants';
 import {compareVersions} from 'utils/library';
-import {CreateProposalFormData} from 'utils/types';
 
 type UpdateContextType = {
   /** Prepares the creation data and awaits user confirmation to start process */
@@ -150,7 +149,7 @@ const UpdateProvider: React.FC<{children: ReactElement}> = ({children}) => {
       daoAddressOrEns: daoDetails?.address as string,
     });
 
-  const {getValues, setValue} = useFormContext<CreateProposalFormData>();
+  const {getValues, setValue} = useFormContext();
   const pluginSelectedVersion = getValues('pluginSelectedVersion');
 
   const shouldPoll =

--- a/src/context/update.tsx
+++ b/src/context/update.tsx
@@ -27,7 +27,6 @@ import PublishModal from 'containers/transactionModals/publishModal';
 import {useClient} from 'hooks/useClient';
 import {usePollGasFee} from 'hooks/usePollGasfee';
 import {useWallet} from 'hooks/useWallet';
-// import {trackEvent} from 'services/analytics';
 import {TransactionState} from 'utils/constants';
 import {CreateProposalFormData} from 'utils/types';
 import {PluginTypes, usePluginClient} from 'hooks/usePluginClient';
@@ -190,7 +189,7 @@ const UpdateProvider: React.FC<{children: ReactElement}> = ({children}) => {
         compareVersions(
           SupportedVersion[key as keyof typeof SupportedVersion],
           versions?.join('.') as string
-        )
+        ) === 1
       ) {
         OSXVersions.set(
           SupportedVersion[key as keyof typeof SupportedVersion],
@@ -201,14 +200,14 @@ const UpdateProvider: React.FC<{children: ReactElement}> = ({children}) => {
             ...(key === 'LATEST' && {isLatest: true}),
           } as OSX
         );
-      }
 
-      if (key === 'LATEST') {
-        setValue('osSelectedVersion', {
-          version: SupportedVersion[
-            key as keyof typeof SupportedVersion
-          ] as string,
-        });
+        if (key === 'LATEST') {
+          setValue('osSelectedVersion', {
+            version: SupportedVersion[
+              key as keyof typeof SupportedVersion
+            ] as string,
+          });
+        }
       }
     });
 
@@ -241,21 +240,21 @@ const UpdateProvider: React.FC<{children: ReactElement}> = ({children}) => {
                 isLatest: true,
               }),
           });
-        }
 
-        setValue('pluginSelectedVersion', {
-          version: {
-            build: release.builds[release.builds.length - 1].build,
-            release: release.release,
-          },
-          isPrepared: Boolean(
-            preparedPluginList?.has(
-              `${release.release}.${
-                release.builds[release.builds.length - 1].build
-              }`
-            )
-          ),
-        });
+          setValue('pluginSelectedVersion', {
+            version: {
+              build: release.builds[release.builds.length - 1].build,
+              release: release.release,
+            },
+            isPrepared: Boolean(
+              preparedPluginList?.has(
+                `${release.release}.${
+                  release.builds[release.builds.length - 1].build
+                }`
+              )
+            ),
+          });
+        }
       });
     });
 
@@ -427,14 +426,6 @@ const UpdateProvider: React.FC<{children: ReactElement}> = ({children}) => {
                 } as PreparedPluginData,
               }
             );
-            console.log('success', {
-              permissions: step.permissions,
-              pluginAddress: step.pluginAddress,
-              pluginRepo: step.pluginRepo,
-              versionTag: step.versionTag,
-              initData: step.initData,
-              helpers: step.helpers,
-            });
             dispatch({
               type: 'setPluginAvailableVersions',
               payload: pluginListTemp as Map<string, Plugin>,

--- a/src/hooks/useUpdateExists.ts
+++ b/src/hooks/useUpdateExists.ts
@@ -1,0 +1,40 @@
+import {SupportedVersion} from '@aragon/sdk-client-common';
+
+import {usePluginVersions} from 'services/aragon-sdk/queries/use-plugin-versions';
+import {useProtocolVersion} from 'services/aragon-sdk/queries/use-protocol-version';
+import {compareVersions} from 'utils/library';
+import {useDaoDetailsQuery} from './useDaoDetails';
+import {PluginTypes} from './usePluginClient';
+
+export const useUpdateExists = (): boolean => {
+  const {data: daoDetails} = useDaoDetailsQuery();
+
+  const daoAddress = daoDetails?.address as string;
+  const installedPlugin = daoDetails?.plugins?.[0];
+  const pluginType = installedPlugin?.id as PluginTypes;
+
+  const {data: plugins} = usePluginVersions({pluginType, daoAddress});
+  const {data: installedProtocol} = useProtocolVersion(daoAddress);
+
+  // check whether protocol update exists
+  const latestProtocolVersion = SupportedVersion.LATEST as string;
+  const installedProtocolVersion = installedProtocol?.join('.');
+
+  const protocolUpdateExists = !!(
+    installedProtocolVersion &&
+    compareVersions(latestProtocolVersion, installedProtocolVersion) === 1
+  );
+
+  // check whether plugin update exists
+  const latestPlugin = plugins?.current;
+  const latestPluginVersion = `${latestPlugin?.release?.number}.${latestPlugin?.build?.number}`;
+  const installedPluginVersion = `${installedPlugin?.release}.${installedPlugin?.build}`;
+
+  const pluginUpdateExists = !!(
+    latestPlugin &&
+    installedPlugin &&
+    compareVersions(latestPluginVersion, installedPluginVersion) === 1
+  );
+
+  return protocolUpdateExists || pluginUpdateExists;
+};

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -89,6 +89,7 @@ import {
 import {Action} from 'utils/types';
 import {GaslessVotingTerminal} from '../containers/votingTerminal/gaslessVotingTerminal';
 import {useGaslessHasAlreadyVote} from '../context/useGaslessVoting';
+import {daoABI} from 'abis/daoABI';
 
 export const PENDING_PROPOSAL_STATUS_INTERVAL = 1000 * 10;
 export const PROPOSAL_STATUS_INTERVAL = 1000 * 60;
@@ -274,6 +275,7 @@ export const Proposal: React.FC = () => {
         client?.decoding.findInterface(action.data) ||
         pluginClient?.decoding.findInterface(action.data);
 
+      console.log(functionParams);
       switch (functionParams?.functionName) {
         case 'transfer':
           return decodeWithdrawToAction(
@@ -305,7 +307,16 @@ export const Proposal: React.FC = () => {
         case 'setMetadata':
           return decodeMetadataToAction(action.data, client);
         case 'upgradeToAndCall':
-          return decodeOsUpdateAction(action, client, t);
+          return decodeOsUpdateAction(action, client);
+        case 'grant':
+        case 'revoke':
+          return decodeToExternalAction(
+            action,
+            proposal.dao.address,
+            network,
+            t,
+            daoABI
+          );
         default: {
           try {
             const decodedAction = await decodeWithdrawToAction(

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -276,7 +276,6 @@ export const Proposal: React.FC = () => {
         client?.decoding.findInterface(action.data) ||
         pluginClient?.decoding.findInterface(action.data);
 
-      console.log(functionParams);
       switch (functionParams?.functionName) {
         case 'transfer':
           return decodeWithdrawToAction(

--- a/src/pages/proposeSettings.tsx
+++ b/src/pages/proposeSettings.tsx
@@ -24,6 +24,7 @@ import {FullScreenStepper, Step} from 'components/fullScreenStepper';
 import {Loading} from 'components/temporary';
 import CompareSettings from 'containers/compareSettings';
 import {isValid as defineProposalIsValid} from 'containers/defineProposal';
+import {DefineProposal} from 'containers/defineProposal/';
 import ReviewProposal from 'containers/reviewProposal';
 import SetupVotingForm from 'containers/setupVotingForm';
 import PublishModal from 'containers/transactionModals/publishModal';
@@ -35,10 +36,10 @@ import {useDaoDetailsQuery} from 'hooks/useDaoDetails';
 import {useDaoToken} from 'hooks/useDaoToken';
 import {
   PluginTypes,
+  isGaslessVotingClient,
   isMultisigClient,
   isTokenVotingClient,
   usePluginClient,
-  isGaslessVotingClient,
 } from 'hooks/usePluginClient';
 import {usePollGasFee} from 'hooks/usePollGasfee';
 import {useTokenSupply} from 'hooks/useTokenSupply';
@@ -72,16 +73,13 @@ import {
   ActionUpdatePluginSettings,
   ProposalId,
   ProposalResource,
-  ProposalSettingsFormData,
 } from 'utils/types';
-import {DefineProposal} from 'containers/defineProposal/';
 
 export const ProposeSettings: React.FC = () => {
   const {t} = useTranslation();
   const {network} = useNetwork();
 
-  const {getValues, setValue, control} =
-    useFormContext<ProposalSettingsFormData>();
+  const {getValues, setValue, control} = useFormContext();
   const [showTxModal, setShowTxModal] = useState(false);
   const {errors, dirtyFields} = useFormState({
     control,

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -39,6 +39,7 @@ import {EditSettings} from 'utils/paths';
 import GaslessVotingSettings from '../containers/settings/gaslessVoting';
 import {useIsMember} from 'services/aragon-sdk/queries/use-is-member';
 import {useWallet} from 'hooks/useWallet';
+import {useUpdateExists} from 'hooks/useUpdateExists';
 
 export const Settings: React.FC = () => {
   const {t} = useTranslation();
@@ -48,6 +49,7 @@ export const Settings: React.FC = () => {
 
   // move into components when proper loading experience is implemented
   const {data: daoDetails, isLoading} = useDaoDetailsQuery();
+  const updateExists = useUpdateExists();
 
   const pluginAddress = daoDetails?.plugins?.[0]?.instanceAddress as string;
   const pluginType = daoDetails?.plugins?.[0]?.id as PluginTypes;
@@ -69,9 +71,11 @@ export const Settings: React.FC = () => {
   const daoUpdateEnabled =
     featureFlags.getValue('VITE_FEATURE_FLAG_OSX_UPDATES') === 'true';
 
+  const showUpdatesCard = updateExists && isMember && daoUpdateEnabled;
+
   return (
     <SettingsWrapper>
-      {daoUpdateEnabled && isMember && (
+      {showUpdatesCard && (
         <div className={`mt-1 xl:mt-3 ${styles.fullWidth}`}>
           <SettingsUpdateCard />
         </div>

--- a/src/utils/library.ts
+++ b/src/utils/library.ts
@@ -12,6 +12,7 @@ import {
 } from '@aragon/sdk-client';
 import {
   DaoAction,
+  DecodedApplyUpdateParams,
   LIVE_CONTRACTS,
   SupportedNetwork as SdkSupportedNetworks,
   SupportedNetworksArray,
@@ -20,7 +21,7 @@ import {
   resolveIpfsCid,
 } from '@aragon/sdk-client-common';
 import {fetchEnsAvatar} from '@wagmi/core';
-import {BigNumber, BigNumberish, constants, providers} from 'ethers';
+import {BigNumber, BigNumberish, constants, ethers, providers} from 'ethers';
 import {
   formatUnits as ethersFormatUnits,
   hexlify,
@@ -28,6 +29,7 @@ import {
 } from 'ethers/lib/utils';
 import {TFunction} from 'i18next';
 
+import {daoFactoryABI} from 'abis/daoFactoryABI';
 import {MultisigWalletField} from 'components/multisigWallets/row';
 import {PluginTypes} from 'hooks/usePluginClient';
 import {getEtherscanVerifiedContract} from 'services/etherscanAPI';
@@ -61,6 +63,7 @@ import {i18n} from '../../i18n.config';
 import {Abi, addABI, decodeMethod} from './abiDecoder';
 import {attachEtherNotice} from './contract';
 import {getTokenInfo} from './tokens';
+import {daoABI} from 'abis/daoABI';
 
 export function formatUnits(amount: BigNumberish, decimals: number) {
   if (amount.toString().includes('.') || !decimals) {
@@ -399,16 +402,27 @@ export async function decodeMetadataToAction(
  * @returns A promise that resolves to the decoded action
  * or undefined if the action could not be decoded.
  */
+/**
+ * Decodes a DAO action to an external contract action (SCC or Wallet Connect).
+ * @param action - DAO action to decode.
+ * @param daoAddress - The address of the DAO.
+ * @param network - Supported network.
+ * @param t - Translation function.
+ * @param ABI - Array of ABI definitions used instead of the one fetched via the block scan API.
+ * @param bypassAddress - Optional address used in the place of the `to` value of the action.
+ * @returns Promise resolving to the decoded external contract action or undefined.
+ */
 export async function decodeToExternalAction(
   action: DaoAction,
   daoAddress: string,
   network: SupportedNetworks,
   t: TFunction,
-  ABI?: Abi[]
+  ABI?: Abi[],
+  bypassAddress?: string
 ): Promise<ActionExternalContract | undefined> {
   try {
     const etherscanData = await getEtherscanVerifiedContract(
-      action.to,
+      bypassAddress ?? action.to,
       network
     );
 
@@ -491,13 +505,65 @@ export async function decodeToExternalAction(
 }
 
 /**
+ * Decodes OS update actions for a DAO to external contract action in
+ * order to display the properties in the generic action card.
+ *
+ * @param daoAddress - The address of the DAO.
+ * @param t - Translation function.
+ * @param encodedAction - Encoded DAO action.
+ * @param network - Supported network.
+ * @param provider - Ethers provider.
+ * @returns Promise resolving to the decoded external action.
+ */
+export async function decodeOSUpdateActions(
+  daoAddress: string,
+  t: TFunction,
+  encodedAction: DaoAction,
+  network: SupportedNetworks,
+  provider: ethers.providers.Provider
+) {
+  const translatedNetwork = translateToNetworkishName(network ?? 'unsupported');
+
+  if (translatedNetwork !== 'unsupported') {
+    const {daoFactoryAddress} =
+      LIVE_CONTRACTS[SupportedVersion.LATEST][translatedNetwork];
+
+    let daoImplementationAddress: string | undefined;
+
+    try {
+      // interact with the DAO Factory to get the proxy's implementation address
+      const contract = new ethers.Contract(
+        daoFactoryAddress,
+        daoFactoryABI,
+        provider
+      );
+
+      daoImplementationAddress = await contract.daoBase();
+    } catch (error) {
+      console.error(
+        'Error fetching the DAO base implementation address',
+        error
+      );
+    }
+
+    return decodeToExternalAction(
+      encodedAction,
+      daoAddress,
+      network,
+      t,
+      daoImplementationAddress ? undefined : daoABI,
+      daoImplementationAddress
+    );
+  }
+}
+
+/**
  * Decodes the OS update action and prepares data for an external contract action.
  * @param encodedAction The encoded action to decode.
  * @param client The client instance used for decoding.
- * @param t The translation function.
  * @returns ActionSCC object representing the decoded action, or undefined if decoding fails.
  */
-export function decodeOsUpdateAction(
+export function decodeUpgradeToAndCallAction(
   encodedAction: DaoAction | undefined,
   client: Client | undefined
 ) {
@@ -513,24 +579,14 @@ export function decodeOsUpdateAction(
       encodedAction.data
     );
 
-    const inputs = Object.entries(decoded).map(([key, value]) => {
-      let displayedValue = value;
-      let displayedType = typeof value as string;
-
-      if (typeof value === 'object' && Object.keys(value).length === 0)
-        displayedValue = ' ';
-
-      if (typeof value === 'string') displayedType = 'address';
-      else if (value instanceof Array) displayedType = 'bytes';
-
-      return {name: key, type: displayedType, value: displayedValue};
-    });
+    const inputs = entriesToExternalContractActionProps(decoded);
+    const functionName =
+      client.decoding.findInterface(encodedAction.data)?.functionName ??
+      'upgradeToAndCall';
 
     return {
       name: 'external_contract_action',
-      functionName:
-        client.decoding.findInterface(encodedAction.data)?.functionName ??
-        'upgradeToAndCall',
+      functionName,
       contractName: 'DAO',
       contractAddress: encodedAction.to,
       inputs,
@@ -540,6 +596,71 @@ export function decodeOsUpdateAction(
       'decodeOsUpdateAction: failed to decode os_update action',
       error
     );
+  }
+}
+
+/**
+ * Decodes an encoded DaoAction and generates an ActionSCC for applying updates
+ * for a plugin
+ * @param encodedAction - Encoded DaoAction containing data to decode.
+ * @param client - Initialized Client instance required for decoding.
+ * @returns ActionSCC or logs errors if decoding fails or client is not initialized.
+ */
+export function decodeApplyUpdateAction(
+  encodedAction: DaoAction,
+  client: Client | undefined
+) {
+  if (!client) {
+    console.error('SDK client is not initialized correctly');
+    return;
+  }
+
+  if (!encodedAction) return;
+
+  try {
+    const decoded: DecodedApplyUpdateParams = client.decoding.applyUpdateAction(
+      encodedAction.data
+    );
+
+    const inputs = entriesToExternalContractActionProps(decoded);
+    const functionName =
+      client.decoding.findInterface(encodedAction.data)?.functionName ??
+      'applyUpdate';
+
+    return {
+      name: 'external_contract_action',
+      functionName,
+      contractName: 'PluginSetupProcessor',
+      contractAddress: encodedAction.to,
+      inputs,
+    } as ActionSCC;
+  } catch (error) {
+    console.error(
+      'decodeApplyUpdateAction: failed to decode apply_update action',
+      error
+    );
+  }
+}
+
+/**
+ * Transforms entries of an object into an array of external action properties
+ * @param decoded - The object whose entries are to be transformed.
+ * @returns An array of objects with name, type, and value properties.
+ */
+function entriesToExternalContractActionProps(decoded: object) {
+  if (decoded != null && typeof decoded === 'object') {
+    return Object.entries(decoded).map(([key, value]) => {
+      let displayedValue = value;
+      let displayedType = typeof value as string;
+
+      if (typeof value === 'object' && Object.keys(value).length === 0) {
+        displayedValue = ' ';
+      } else if (typeof value === 'string') {
+        displayedType = 'address';
+      }
+
+      return {name: key, type: displayedType, value: displayedValue};
+    });
   }
 }
 

--- a/src/utils/library.ts
+++ b/src/utils/library.ts
@@ -1232,21 +1232,21 @@ export const walletInWalletList = (
  *          - -1 if version1 is less than version2
  *          - 0 if version1 is equal to version2
  */
-export function compareVersions(version1: string, version2: string): boolean {
-  if (!version1 || !version2) return false;
+export function compareVersions(version1: string, version2: string): number {
+  if (!version1 || !version2) return 0;
 
   const v1 = version1.split('.').map(Number);
   const v2 = version2.split('.').map(Number);
 
   for (let i = 0; i < v1.length; i++) {
     if (v1[i] > v2[i]) {
-      return true;
+      return 1;
     } else if (v1[i] < v2[i]) {
-      return false;
+      return -1;
     }
   }
 
-  return false;
+  return 0;
 }
 
 /**

--- a/src/utils/proposals.ts
+++ b/src/utils/proposals.ts
@@ -1074,10 +1074,7 @@ export async function getDecodedUpdateActions(
     if (pluginAction && updateFramework?.plugin) {
       const encodedPluginActions = client.encoding.applyUpdateAction(
         daoAddress,
-        {
-          initData: new Uint8Array([]),
-          ...pluginAction.inputs,
-        }
+        pluginAction.inputs
       );
 
       const decodedPluginActions = [];

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,6 +1,5 @@
 import {InputValue} from '@aragon/ods-old';
 import {
-  ApplyInstallationParams,
   DaoMetadata,
   Erc20TokenDetails,
   MultisigProposal,
@@ -11,7 +10,11 @@ import {
   VoteValues,
   VotingSettings,
 } from '@aragon/sdk-client';
-import {SupportedVersion, VersionTag} from '@aragon/sdk-client-common';
+import {
+  ApplyUpdateParams,
+  SupportedVersion,
+  VersionTag,
+} from '@aragon/sdk-client-common';
 import {
   GaslessPluginVotingSettings,
   GaslessVotingProposal,
@@ -335,7 +338,7 @@ export type ActionOSUpdate = {
 
 export type ActionPluginUpdate = {
   name: 'plugin_update';
-  inputs: ApplyInstallationParams;
+  inputs: ApplyUpdateParams;
 };
 
 export type ActionUpdateMultisigPluginSettings = {


### PR DESCRIPTION
## Description

- decodes the OSx update actions
- shows update banner and settings card conditionally (membership based)
- shows only the upgradeable component (plugin or os) when updating
- navigates to 404 if user accesses update route when no updates are available.

Task: [APP-2623](https://aragonassociation.atlassian.net/browse/APP-2623)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2623]: https://aragonassociation.atlassian.net/browse/APP-2623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ