### PR TITLE
fix: APP-2607 - Fix timestamp string for proposals creation date on members page

### DIFF
--- a/src/components/userProposalList/userProposalList.tsx
+++ b/src/components/userProposalList/userProposalList.tsx
@@ -89,7 +89,9 @@ export const UserProposalList: React.FC<IUserProposalListProps> = props => {
                   </p>
                 </div>
                 <p className="text-neutral-500 ft-text-base">
-                  {getRelativeDate(proposal.creationDate)}
+                  {t('members.profile.labelTimestamp', {
+                    time: getRelativeDate(proposal.creationDate),
+                  })}
                 </p>
               </div>
               <IconChevronRight className="shrink-0 text-neutral-300" />


### PR DESCRIPTION
## Description

- Correctly display "x ago" (e.g. 1 month ago) on proposals creation date 

Task: [APP-2607](https://aragonassociation.atlassian.net/browse/APP-2607)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2607]: https://aragonassociation.atlassian.net/browse/APP-2607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ