### PR TITLE
APP-2557- Fix: Cached DAO type after creation

### DIFF
--- a/src/context/createDao.tsx
+++ b/src/context/createDao.tsx
@@ -488,7 +488,15 @@ const CreateDaoProvider: React.FC<{children: ReactNode}> = ({children}) => {
                     address: step.address.toLocaleLowerCase(),
                     chain: CHAIN_METADATA[network].id,
                     ensDomain: daoCreationData.ensSubdomain || '',
-                    plugins: daoCreationData.plugins,
+                    plugins: [
+                      {
+                        id:
+                          membership === 'token'
+                            ? 'token-voting.plugin.dao.eth'
+                            : 'multisig.plugin.dao.eth',
+                        data: daoCreationData.plugins[0].data,
+                      },
+                    ],
                     metadata: {
                       name: metadata.name,
                       avatar: metadata.avatar,


### PR DESCRIPTION
## Description

- Set installed plugin typed as id after dao creation

Task: [APP-2557](https://aragonassociation.atlassian.net/browse/APP-2557)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2557]: https://aragonassociation.atlassian.net/browse/APP-2557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ