### PR TITLE
fix: APP-2697 - When +3 Links at Dashboard they display on Links Drop down and Dashboard

### DIFF
--- a/src/@aragon/ods-old/components/headers/headerDao.tsx
+++ b/src/@aragon/ods-old/components/headers/headerDao.tsx
@@ -212,13 +212,13 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
           </NetworkDetails>
         </NetworkDetailsContainer>
         <ActionWrapper>
-          <LinksWrapper>
-            {links
-              ?.slice(0, DEFAULT_LINKS_SHOWN)
-              ?.map(({label, href}, index: number) => (
+          {links?.length <= DEFAULT_LINKS_SHOWN && (
+            <LinksWrapper>
+              {links?.map(({label, href}, index) => (
                 <Link {...{label, href}} external key={index} />
               ))}
-          </LinksWrapper>
+            </LinksWrapper>
+          )}
           <ActionContainer>
             {showDropdown && (
               <Dropdown


### PR DESCRIPTION
## Description

When number of links is greater than `DEFAULT_LINKS_SHOWN` (3) than it would still display the `LinksWrapper` at Desktop. With the edits in this PR the `LinksWrapper` only displays when the total number of links equals or is smaller than `DEFAULT_LINKS_SHOWN`.

See images below for before and after edits.

Note: the image displaying in front of the drop down is taken care of in another ticket.

Before
<img width="1664" alt="image" src="https://github.com/aragon/app/assets/16764792/a0970fdb-ecdf-4d99-933d-0cedfa7e14e8">


After
<img width="1663" alt="image" src="https://github.com/aragon/app/assets/16764792/e60bfcd0-06d9-40b7-b009-6093c0f931d3">



Task: [APP-2697](https://aragonassociation.atlassian.net/browse/APP-2697)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2697]: https://aragonassociation.atlassian.net/browse/APP-2697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ