### PR TITLE
fix: APP-2519 - Background overlays 'All Links' Modal

### DIFF
--- a/src/@aragon/ods-old/components/dropdown/dropdown.tsx
+++ b/src/@aragon/ods-old/components/dropdown/dropdown.tsx
@@ -82,10 +82,8 @@ export const Dropdown: React.FC<DropdownProps> = ({
 };
 
 const StyledContent = styled(DropdownMenu.Content).attrs({
-  className: 'bg-neutral-0 rounded-xl p-2 shadow-neutral-xl' as string,
-})`
-  z-index: 50;
-`;
+  className: 'bg-neutral-0 rounded-xl p-2 shadow-neutral-xl z-50' as string,
+})``;
 
 const StyledItem = styled(DropdownMenu.Item).attrs({
   className:

--- a/src/@aragon/ods-old/components/dropdown/dropdown.tsx
+++ b/src/@aragon/ods-old/components/dropdown/dropdown.tsx
@@ -82,7 +82,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
 };
 
 const StyledContent = styled(DropdownMenu.Content).attrs({
-  className: 'bg-neutral-0 rounded-xl p-2 shadow-neutral-xl',
+  className: 'bg-neutral-0 rounded-xl p-2 shadow-neutral-xl' as string,
 })`
   z-index: 50;
 `;

--- a/src/@aragon/ods-old/components/dropdown/dropdown.tsx
+++ b/src/@aragon/ods-old/components/dropdown/dropdown.tsx
@@ -82,8 +82,10 @@ export const Dropdown: React.FC<DropdownProps> = ({
 };
 
 const StyledContent = styled(DropdownMenu.Content).attrs({
-  className: 'bg-neutral-0 rounded-xl p-2 shadow-neutral-xl' as string,
-})``;
+  className: 'bg-neutral-0 rounded-xl p-2 shadow-neutral-xl',
+})`
+  z-index: 50;
+`;
 
 const StyledItem = styled(DropdownMenu.Item).attrs({
   className:


### PR DESCRIPTION
## Description

Fix so the 'All links' dropdown now overlays the illustrations, see images below for Desktop and Mobile (Android).

Z-index of `1` would have worked, but chose z-index of `50` since same value was chosen for alert chips (it's random).

<img width="128" alt="image" src="https://github.com/aragon/app/assets/16764792/bdf8e89c-7be1-4a4c-a321-79361d60d802">
 


Desktop
<img width="452" alt="image" src="https://github.com/aragon/app/assets/16764792/8eb2980b-46aa-46ce-8163-e98cd61b22a0">


Mobile (Android)
<img width="343" alt="image" src="https://github.com/aragon/app/assets/16764792/26ef8bb1-52e0-447a-8d9e-2bd3a9fc6690">


Task: [APP-2519](https://aragonassociation.atlassian.net/browse/APP-2519)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2519]: https://aragonassociation.atlassian.net/browse/APP-2519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ