### PR TITLE
fix: APP-2918 - Retry IPFS calls when creating a DAO

### DIFF
--- a/src/context/createDao.tsx
+++ b/src/context/createDao.tsx
@@ -51,6 +51,7 @@ import {
   GaslessPluginVotingSettings,
 } from '@vocdoni/gasless-voting';
 import {useCensus3CreateToken} from '../hooks/useCensus3';
+import {retry} from 'utils/retry';
 
 const DEFAULT_TOKEN_DECIMALS = 18;
 
@@ -83,17 +84,15 @@ const CreateDaoProvider: React.FC<{children: ReactNode}> = ({children}) => {
     daoCreationData !== undefined &&
     creationProcessState === TransactionState.WAITING;
 
-  const disableActionButton =
-    !daoCreationData && creationProcessState !== TransactionState.SUCCESS;
-
   /*************************************************
    *                   Handlers                    *
    *************************************************/
   const handlePublishDao = async () => {
-    setCreationProcessState(TransactionState.WAITING);
+    setCreationProcessState(TransactionState.LOADING);
     setShowModal(true);
     const creationParams = await getDaoSettings();
     setDaoCreationData(creationParams);
+    setCreationProcessState(TransactionState.WAITING);
   };
 
   // Handler for modal button click
@@ -376,8 +375,10 @@ const CreateDaoProvider: React.FC<{children: ReactNode}> = ({children}) => {
     if (daoLogo) {
       try {
         const daoLogoBuffer = await readFile(daoLogo as Blob);
-        const logoCID = await client?.ipfs.add(new Uint8Array(daoLogoBuffer));
-        await client?.ipfs.pin(logoCID!);
+        const logoCID = await retry(
+          () => client?.ipfs.add(new Uint8Array(daoLogoBuffer))
+        );
+        await retry(() => client?.ipfs.pin(logoCID!));
         metadata.avatar = `ipfs://${logoCID}`;
       } catch (e) {
         metadata.avatar = undefined;
@@ -385,7 +386,11 @@ const CreateDaoProvider: React.FC<{children: ReactNode}> = ({children}) => {
     }
 
     try {
-      const ipfsUri = await client?.methods.pinMetadata(metadata);
+      // TODO: to be removed
+      await new Promise(resolve => {
+        setTimeout(() => resolve(true), 1000);
+      });
+      const ipfsUri = await retry(() => client?.methods.pinMetadata(metadata));
       return {
         metadataUri: ipfsUri || '',
         // TODO: We're using dao name without spaces for ens, We need to add alert
@@ -393,8 +398,10 @@ const CreateDaoProvider: React.FC<{children: ReactNode}> = ({children}) => {
         ensSubdomain: daoEnsName || '',
         plugins: [...plugins],
       };
-    } catch {
-      throw Error('Could not pin metadata on IPFS');
+    } catch (error: unknown) {
+      setCreationProcessState(TransactionState.ERROR);
+      console.error('Could not pin metadata on IPFS', error);
+      throw error;
     }
   }, [
     client?.ipfs,
@@ -539,6 +546,10 @@ const CreateDaoProvider: React.FC<{children: ReactNode}> = ({children}) => {
     [TransactionState.SUCCESS]: t('TransactionModal.launchDaoDashboard'),
     [TransactionState.WAITING]: t('TransactionModal.publishDaoButtonLabel'),
   };
+
+  const dialogAction =
+    daoCreationData == null ? handlePublishDao : handleExecuteCreation;
+
   return (
     <CreateDaoContext.Provider value={{handlePublishDao}}>
       {children}
@@ -548,13 +559,12 @@ const CreateDaoProvider: React.FC<{children: ReactNode}> = ({children}) => {
         state={creationProcessState || TransactionState.WAITING}
         isOpen={showModal}
         onClose={handleCloseModal}
-        callback={handleExecuteCreation}
+        callback={dialogAction}
         closeOnDrag={creationProcessState !== TransactionState.LOADING}
         maxFee={maxFee}
         averageFee={averageFee}
         gasEstimationError={gasEstimationError}
         tokenPrice={tokenPrice}
-        disabledCallback={disableActionButton}
       />
     </CreateDaoContext.Provider>
   );

--- a/src/context/createDao.tsx
+++ b/src/context/createDao.tsx
@@ -386,6 +386,10 @@ const CreateDaoProvider: React.FC<{children: ReactNode}> = ({children}) => {
     }
 
     try {
+      // TODO: to be removed
+      await new Promise(resolve => {
+        setTimeout(() => resolve(true), 1000);
+      });
       const ipfsUri = await retry(() => client?.methods.pinMetadata(metadata));
       return {
         metadataUri: ipfsUri || '',

--- a/src/context/createDao.tsx
+++ b/src/context/createDao.tsx
@@ -386,10 +386,6 @@ const CreateDaoProvider: React.FC<{children: ReactNode}> = ({children}) => {
     }
 
     try {
-      // TODO: to be removed
-      await new Promise(resolve => {
-        setTimeout(() => resolve(true), 1000);
-      });
       const ipfsUri = await retry(() => client?.methods.pinMetadata(metadata));
       return {
         metadataUri: ipfsUri || '',

--- a/src/context/createDao.tsx
+++ b/src/context/createDao.tsx
@@ -544,7 +544,9 @@ const CreateDaoProvider: React.FC<{children: ReactNode}> = ({children}) => {
   };
 
   const dialogAction =
-    daoCreationData == null ? handlePublishDao : handleExecuteCreation;
+    daoCreationData == null && creationProcessState !== TransactionState.SUCCESS
+      ? handlePublishDao
+      : handleExecuteCreation;
 
   return (
     <CreateDaoContext.Provider value={{handlePublishDao}}>

--- a/src/context/createProposal.tsx
+++ b/src/context/createProposal.tsx
@@ -103,7 +103,6 @@ import {useCreateGaslessProposal} from './createGaslessProposal';
 import {useGlobalModalContext} from './globalModals';
 import {useNetwork} from './network';
 import {useProviders} from './providers';
-import {retry} from 'utils/retry';
 
 type Props = {
   showTxModal: boolean;
@@ -167,6 +166,9 @@ const CreateProposalWrapper: React.FC<Props> = ({
       proposalCreationData !== undefined,
     [creationProcessState, proposalCreationData]
   );
+
+  const disableActionButton =
+    !proposalCreationData && creationProcessState !== TransactionState.SUCCESS;
 
   const {
     steps: gaslessProposalSteps,
@@ -389,10 +391,10 @@ const CreateProposalWrapper: React.FC<Props> = ({
                 preparedAction.inputs.avatar as unknown as Blob
               );
 
-              const logoCID = await retry(() =>
-                client.ipfs.add(new Uint8Array(daoLogoBuffer))
+              const logoCID = await client.ipfs.add(
+                new Uint8Array(daoLogoBuffer)
               );
-              await retry(() => client.ipfs.pin(logoCID));
+              await client.ipfs.pin(logoCID);
               preparedAction.inputs.avatar = `ipfs://${logoCID}`;
             } catch (e) {
               preparedAction.inputs.avatar = undefined;
@@ -400,8 +402,8 @@ const CreateProposalWrapper: React.FC<Props> = ({
           }
 
           try {
-            const ipfsUri = await retry(() =>
-              client.methods.pinMetadata(preparedAction.inputs)
+            const ipfsUri = await client.methods.pinMetadata(
+              preparedAction.inputs
             );
 
             actions.push(
@@ -503,8 +505,8 @@ const CreateProposalWrapper: React.FC<Props> = ({
     let ipfsUri;
     // Gasless voting store metadata using Vocdoni support
     if (!gasless) {
-      ipfsUri = await retry(
-        () => (pluginClient as TokenVotingClient)?.methods.pinMetadata(metadata)
+      ipfsUri = await (pluginClient as TokenVotingClient)?.methods.pinMetadata(
+        metadata
       );
     }
 
@@ -1092,6 +1094,7 @@ const CreateProposalWrapper: React.FC<Props> = ({
           tokenPrice={tokenPrice}
           title={t('TransactionModal.createProposal')}
           buttonStateLabels={buttonLabels}
+          disabledCallback={disableActionButton}
         />
       )}
     </>

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -11,6 +11,9 @@ export interface IRetryOptions {
   timeout: number;
 }
 
+/**
+ * Note: functionality introduced as a quick fix to retry the IPFS actions, to be removed with APP-2919
+ */
 export const retry = async <TReturn>(
   request: () => TReturn,
   options?: IRetryOptions

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -25,7 +25,7 @@ export const retry = async <TReturn>(
 
   const wait = (millis: number) =>
     new Promise(resolve => {
-      setTimeout(() => resolve(true), millis);
+      setTimeout(resolve, millis);
     });
 
   while (attempts < times) {
@@ -35,9 +35,9 @@ export const retry = async <TReturn>(
       const result = await request();
 
       return result;
-    } catch (error: unknown) {
+    } catch (error) {
       lastError = error;
-      attempts = attempts + 1;
+      attempts++;
     }
   }
 


### PR DESCRIPTION
## Description

- Add retry utility to retry IPFS pin/add actions on the create-dao process (to be removed and properly implemented with `react-query` with APP-2919)
- Improve loading and retry state handling on create-dao process

Task: [APP-2918](https://aragonassociation.atlassian.net/browse/APP-2918)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2918]: https://aragonassociation.atlassian.net/browse/APP-2918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ