### PR TITLE
feat: APP-2933 - Check token allowance on wrap tokens flow

### DIFF
--- a/src/context/govTokensWrapping.tsx
+++ b/src/context/govTokensWrapping.tsx
@@ -60,7 +60,7 @@ const GovTokensWrappingProvider: FC<{children: ReactNode}> = ({children}) => {
   const {data: daoTokenData, isLoading: isTokenDataLoading} = useDaoToken(
     daoDetails?.plugins?.[0]?.instanceAddress || ''
   );
-  const underlyingToken = (daoTokenData as Erc20WrapperTokenDetails)
+  const underlyingToken = (daoTokenData as Erc20WrapperTokenDetails | undefined)
     ?.underlyingToken;
   const [daoTokenBalance, setDaoTokenBalance] = useState('');
 
@@ -80,7 +80,7 @@ const GovTokensWrappingProvider: FC<{children: ReactNode}> = ({children}) => {
 
   const {data: tokenAllowance} = useTokenAllowance(
     {
-      token: underlyingToken?.address,
+      token: underlyingToken?.address as string,
       owner: userAddress as string,
       spender: wrappedDaoToken?.address as string,
     },

--- a/src/context/govTokensWrapping.tsx
+++ b/src/context/govTokensWrapping.tsx
@@ -368,8 +368,6 @@ const GovTokensWrappingProvider: FC<{children: ReactNode}> = ({children}) => {
           ethers.utils.parseUnits(amount, wrappedDaoToken.decimals).toString()
         );
 
-        console.log({underlyingToken, userAddress, wrappedDaoToken});
-
         const currentAllowance = await getAllowance(
           underlyingToken?.address,
           userAddress,

--- a/src/context/govTokensWrapping.tsx
+++ b/src/context/govTokensWrapping.tsx
@@ -378,10 +378,10 @@ const GovTokensWrappingProvider: FC<{children: ReactNode}> = ({children}) => {
     }
 
     const wrapAmount = BigInt(
-      ethers.utils.parseUnits(amount, wrappedDaoToken?.decimals).toString()
+      ethers.utils.parseUnits(amount, wrappedDaoToken.decimals).toString()
     );
 
-    if (tokenAllowance?.gte(wrapAmount)) {
+    if (tokenAllowance.gte(wrapAmount)) {
       setCurrentStep(2);
     } else {
       setCurrentStep(1);

--- a/src/services/aragon-sdk/aragon-sdk-service.api.ts
+++ b/src/services/aragon-sdk/aragon-sdk-service.api.ts
@@ -80,3 +80,9 @@ export interface IFetchIsDAOListParams {
   address: string | null;
   pluginType?: PluginTypes;
 }
+
+export interface IFetchTokenAllowanceParams {
+  token: string;
+  owner: string;
+  spender: string;
+}

--- a/src/services/aragon-sdk/queries/use-token-allowance.ts
+++ b/src/services/aragon-sdk/queries/use-token-allowance.ts
@@ -1,0 +1,19 @@
+import {UseQueryOptions, useQuery} from '@tanstack/react-query';
+import {aragonSdkQueryKeys} from '../query-keys';
+import type {IFetchTokenAllowanceParams} from '../aragon-sdk-service.api';
+import {getAllowance} from 'utils/tokens';
+import {useProviders} from 'context/providers';
+import {BigNumber} from 'ethers';
+
+export const useTokenAllowance = (
+  params: IFetchTokenAllowanceParams,
+  options?: UseQueryOptions<BigNumber>
+) => {
+  const {api: provider} = useProviders();
+
+  return useQuery(
+    aragonSdkQueryKeys.tokenAllowance(params),
+    () => getAllowance(params.token, params.owner, params.spender, provider),
+    options
+  );
+};

--- a/src/services/aragon-sdk/query-keys.ts
+++ b/src/services/aragon-sdk/query-keys.ts
@@ -14,6 +14,7 @@ import type {
   IFetchVotingPowerParams,
   IFetchVotingSettingsParams,
   IFetchCreatorProposalsParams,
+  IFetchTokenAllowanceParams,
 } from './aragon-sdk-service.api';
 import {SupportedNetworks} from 'utils/constants';
 
@@ -34,6 +35,7 @@ export enum AragonSdkQueryItem {
   GET_CREATOR_PROPOSALS = 'GET_CREATOR_PROPOSALS',
   RELEASE_NOTES = 'RELEASE_NOTES',
   GET_DAOS = 'GET_DAOS',
+  TOKEN_ALLOWANCE = 'TOKEN_ALLOWANCE',
 }
 
 // Add address and network parameters to all query keys to use the most updated DAO plugin client
@@ -102,6 +104,10 @@ export const aragonSdkQueryKeys = {
   releaseNotes: (): QueryKey => [AragonSdkQueryItem.RELEASE_NOTES],
   getMemberDAOs: (params: IAragonSdkBaseParams): QueryKey => [
     AragonSdkQueryItem.GET_DAOS,
+    params,
+  ],
+  tokenAllowance: (params: IFetchTokenAllowanceParams): QueryKey => [
+    AragonSdkQueryItem.TOKEN_ALLOWANCE,
     params,
   ],
 };

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -220,6 +220,21 @@ export async function isERC721(
   }
 }
 
+export async function getAllowance(
+  address: string,
+  owner: string,
+  spender: string,
+  provider: EthersProviders.Provider
+): Promise<BigNumber> {
+  const contract = new ethers.Contract(address, erc20TokenABI, provider);
+  try {
+    const allowance = await contract.allowance(owner, spender);
+    return allowance;
+  } catch (err) {
+    return BigNumber.from(0);
+  }
+}
+
 /**
  * This Validation function checks if the existing token contract
  * is ERC1155 or not


### PR DESCRIPTION
## Description

- Check token allowance during the wrap tokens flow

Note:
For such direct calls to smart contracts we should be using the [useReadContract](https://wagmi.sh/react/api/hooks/useReadContract) hook from Wagmi that is not available on the current installed version. I created a ticket ([APP-2949](https://aragonassociation.atlassian.net/browse/APP-2949)) to update Wagmi and Viem to v2.

Task: [APP-2933](https://aragonassociation.atlassian.net/browse/APP-2933)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2933]: https://aragonassociation.atlassian.net/browse/APP-2933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APP-2949]: https://aragonassociation.atlassian.net/browse/APP-2949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ