### PR TITLE
fix: Ensure useDelegatee is disabled for non-wrapped tokens

### DIFF
--- a/src/components/membersList/index.tsx
+++ b/src/components/membersList/index.tsx
@@ -13,8 +13,6 @@ import {useScreen} from '@aragon/ods-old';
 import {useTranslation} from 'react-i18next';
 import {featureFlags} from 'utils/featureFlags';
 import {useGaslessGovernanceEnabled} from '../../hooks/useGaslessGovernanceEnabled';
-import {useDaoDetailsQuery} from '../../hooks/useDaoDetails';
-import {PluginTypes} from '../../hooks/usePluginClient';
 
 type MembersListProps = {
   members: DaoMember[];
@@ -37,11 +35,7 @@ export const MembersList: React.FC<MembersListProps> = ({
 
   // Gasless voting plugin support non wrapped tokens
   // Used to hide delegation column in case of gasless voting plugin
-  const {data: daoDetails} = useDaoDetailsQuery();
-  const {isGovernanceEnabled} = useGaslessGovernanceEnabled({
-    pluginAddress: daoDetails?.plugins[0].instanceAddress as string,
-    pluginType: daoDetails?.plugins[0].id as PluginTypes,
-  });
+  const {isGovernanceEnabled} = useGaslessGovernanceEnabled();
 
   const isTokenBasedDao = token != null;
   const useCompactMode = isCompactMode ?? !isDesktop;

--- a/src/containers/delegateVotingMenu/delegateVotingForm.tsx
+++ b/src/containers/delegateVotingMenu/delegateVotingForm.tsx
@@ -17,7 +17,6 @@ import {
   DelegateVotingFormField,
   IDelegateVotingFormValues,
 } from './delegateVotingUtils';
-import {useGaslessGovernanceEnabled} from '../../hooks/useGaslessGovernanceEnabled';
 import {PluginTypes} from '../../hooks/usePluginClient';
 
 export interface IDelegateVotingFormProps {
@@ -62,15 +61,11 @@ export const DelegateVotingForm: React.FC<IDelegateVotingFormProps> = props => {
   );
 
   const pluginType = daoDetails?.plugins[0].id as PluginTypes;
-  const {isGovernanceEnabled} = useGaslessGovernanceEnabled({
-    pluginType: daoDetails?.plugins[0].id as PluginTypes,
-    pluginAddress: daoDetails?.plugins[0].instanceAddress as string,
-  });
 
   const {data: delegateData} = useDelegatee(
     {tokenAddress: daoToken?.address as string},
     pluginType,
-    {enabled: daoToken != null && !isOnWrongNetwork && isGovernanceEnabled}
+    {enabled: daoToken != null && !isOnWrongNetwork}
   );
   const currentDelegate = delegateData === null ? address : delegateData;
 

--- a/src/containers/delegateVotingMenu/delegateVotingMenu.tsx
+++ b/src/containers/delegateVotingMenu/delegateVotingMenu.tsx
@@ -22,7 +22,6 @@ import {
 } from './delegateVotingUtils';
 import {aragonBackendQueryKeys} from 'services/aragon-backend/query-keys';
 import {PluginTypes} from '../../hooks/usePluginClient';
-import {useGaslessGovernanceEnabled} from '../../hooks/useGaslessGovernanceEnabled';
 
 const buildFormSettings = (
   delegateAddress = ''
@@ -84,15 +83,11 @@ export const DelegateVotingMenu: React.FC = () => {
   });
 
   const pluginType = daoDetails?.plugins[0].id as PluginTypes;
-  const {isGovernanceEnabled} = useGaslessGovernanceEnabled({
-    pluginType: daoDetails?.plugins[0].id as PluginTypes,
-    pluginAddress: daoDetails?.plugins[0].instanceAddress as string,
-  });
 
   const {data: delegateData} = useDelegatee(
     {tokenAddress: daoToken?.address as string},
     pluginType,
-    {enabled: daoToken != null && !isOnWrongNetwork && isGovernanceEnabled}
+    {enabled: daoToken != null && !isOnWrongNetwork}
   );
 
   // The useDelegatee hook returns null when current delegate is connected address

--- a/src/containers/delegationGatingMenu/delegationGatingMenu.tsx
+++ b/src/containers/delegationGatingMenu/delegationGatingMenu.tsx
@@ -16,7 +16,6 @@ import {useMember} from 'services/aragon-sdk/queries/use-member';
 import ModalBottomSheetSwitcher from 'components/modalBottomSheetSwitcher';
 import {useGlobalModalContext} from 'context/globalModals';
 import {PluginTypes} from '../../hooks/usePluginClient';
-import {useGaslessGovernanceEnabled} from '../../hooks/useGaslessGovernanceEnabled';
 
 export interface IDelegationGatingMenuState {
   proposal?: TokenVotingProposal;
@@ -74,15 +73,11 @@ export const DelegationGatingMenu: React.FC = () => {
   const parsedPastBalance = abbreviateTokenAmount(pastBalance.toString());
 
   const pluginType = daoDetails?.plugins[0].id as PluginTypes;
-  const {isGovernanceEnabled} = useGaslessGovernanceEnabled({
-    pluginType: daoDetails?.plugins[0].id as PluginTypes,
-    pluginAddress: daoDetails?.plugins[0].instanceAddress as string,
-  });
 
   const {data: delegateData} = useDelegatee(
     {tokenAddress: daoToken?.address as string},
     pluginType,
-    {enabled: daoToken != null && isGovernanceEnabled}
+    {enabled: daoToken != null}
   );
 
   // The useDelegatee hook returns null when current delegate is connected address

--- a/src/hooks/useExistingToken.tsx
+++ b/src/hooks/useExistingToken.tsx
@@ -26,10 +26,7 @@ export const useExistingToken = ({
 } = {}) => {
   const {api: provider} = useProviders();
   const {data: daoDetailsFetched} = useDaoDetailsQuery();
-  const {isGovernanceEnabled} = useGaslessGovernanceEnabled({
-    pluginAddress: daoDetails?.plugins[0].instanceAddress as string,
-    pluginType: daoDetails?.plugins[0].id as PluginTypes,
-  });
+  const {isGovernanceEnabled} = useGaslessGovernanceEnabled();
 
   const dao = useMemo(
     () => daoDetails || daoDetailsFetched,

--- a/src/hooks/useGaslessGovernanceEnabled.tsx
+++ b/src/hooks/useGaslessGovernanceEnabled.tsx
@@ -1,26 +1,27 @@
 import {GaslessPluginName, PluginTypes} from './usePluginClient';
 import {useVotingSettings} from '../services/aragon-sdk/queries/use-voting-settings';
 import {GaslessPluginVotingSettings} from '@vocdoni/gasless-voting';
+import {useDaoDetailsQuery} from './useDaoDetails';
 
-export const useGaslessGovernanceEnabled = ({
-  pluginType,
-  pluginAddress,
-}: {
-  pluginType?: PluginTypes;
-  pluginAddress?: string;
-}) => {
+export const useGaslessGovernanceEnabled = () => {
+  const {data: daoDetails} = useDaoDetailsQuery();
+
+  const pluginAddress = daoDetails?.plugins[0].instanceAddress;
+  const pluginType = daoDetails?.plugins[0].id as PluginTypes;
+
   const {data: votingSettings} = useVotingSettings({
-    pluginAddress: pluginAddress,
-    pluginType: pluginType,
+    pluginAddress,
+    pluginType,
   });
 
   const isGasless = pluginType === GaslessPluginName;
+
   let isGovernanceEnabled = true;
 
   if (isGasless) {
     isGovernanceEnabled =
       (votingSettings as GaslessPluginVotingSettings)?.hasGovernanceEnabled ??
-      true;
+      false; // Await until loading is finished to ensure that governance is enabled
   }
 
   return {isGovernanceEnabled};

--- a/src/hooks/useGaslessGovernanceEnabled.tsx
+++ b/src/hooks/useGaslessGovernanceEnabled.tsx
@@ -14,15 +14,12 @@ export const useGaslessGovernanceEnabled = () => {
     pluginType,
   });
 
-  const isGasless = pluginType === GaslessPluginName;
-
-  let isGovernanceEnabled = true;
-
-  if (isGasless) {
-    isGovernanceEnabled =
-      (votingSettings as GaslessPluginVotingSettings)?.hasGovernanceEnabled ??
-      false; // Await until loading is finished to ensure that governance is enabled
-  }
-
+  // If is not gasless, return true
+  // If is loading should return false, to avoid to "wrapped tokens" workflows before know if the token is wrapped or not
+  // Then, return the value of hasGovernanceEnabled
+  const isGovernanceEnabled =
+    pluginType === GaslessPluginName
+      ? !!(votingSettings as GaslessPluginVotingSettings)?.hasGovernanceEnabled
+      : true;
   return {isGovernanceEnabled};
 };

--- a/src/pages/mintTokens.tsx
+++ b/src/pages/mintTokens.tsx
@@ -44,10 +44,7 @@ export const MintToken: React.FC = () => {
     pluginAddress,
     pluginType,
   });
-  const {isGovernanceEnabled} = useGaslessGovernanceEnabled({
-    pluginAddress,
-    pluginType,
-  });
+  const {isGovernanceEnabled} = useGaslessGovernanceEnabled();
 
   const {t} = useTranslation();
   const {network} = useNetwork();

--- a/src/services/aragon-sdk/queries/use-delegatee.ts
+++ b/src/services/aragon-sdk/queries/use-delegatee.ts
@@ -11,6 +11,7 @@ import {SupportedNetworks} from 'utils/constants';
 import {TokenVotingClient} from '@aragon/sdk-client';
 import {invariant} from 'utils/invariant';
 import {GaslessVotingClient} from '@vocdoni/gasless-voting';
+import {useGaslessGovernanceEnabled} from '../../../hooks/useGaslessGovernanceEnabled';
 
 const fetchDelegatee = async (
   params: IFetchDelegateeParams,
@@ -27,6 +28,8 @@ export const useDelegatee = (
   pluginType: PluginTypes,
   options: UseQueryOptions<string | null> = {}
 ) => {
+  const {isGovernanceEnabled} = useGaslessGovernanceEnabled();
+
   const client = usePluginClient(
     pluginType === GaslessPluginName
       ? GaslessPluginName
@@ -39,7 +42,12 @@ export const useDelegatee = (
     network: network as SupportedNetworks,
   };
 
-  if (client == null || address == null || network == null) {
+  if (
+    client == null ||
+    address == null ||
+    network == null ||
+    !isGovernanceEnabled
+  ) {
     options.enabled = false;
   }
 


### PR DESCRIPTION
## Description

Now there is a moment where the `useDelegattee` hook is enabled when the token is not wrapped. This happen when the DAO details are not loaded yet, and the `useGaslessGovernanceEnabled` hook have is `true` by default. 

This PR changes the default value from `true` to `false` avoiding to enter into the `useDelegatee` query if is gasless plugin and the settings are not fully loaded yet. 

It also refactors the `useGaslessGovernanceEnabled` to use the react query cache to access to the Dao information, avoiding to pass down the plugin address, so now is easier to  be called: 

https://github.com/aragon/app/pull/1267/files#diff-81eebd27e361315ca8a90bd3f581c0b162f34580b468fd601430044c906dede5L40-R38

```diff
-  const {data: daoDetails} = useDaoDetailsQuery();
-  const {isGovernanceEnabled} = useGaslessGovernanceEnabled({
-    pluginAddress: daoDetails?.plugins[0].instanceAddress as string,
-    pluginType: daoDetails?.plugins[0].id as PluginTypes,
-  });
+  const {isGovernanceEnabled} = useGaslessGovernanceEnabled();
```


## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the test network.
