### PR TITLE
fix: APP-2952 - Show offchain voting option only on supported networks

### DIFF
--- a/src/utils/constants/chains.ts
+++ b/src/utils/constants/chains.ts
@@ -14,6 +14,9 @@ export function isSupportedChainId(
   return SUPPORTED_CHAIN_ID.some(id => id === chainId);
 }
 
+// Networks supported by the Gasless voting plugin
+export const GASLESS_SUPPORTED_NETWORKS: SupportedNetworks[] = ['sepolia'];
+
 // TODO: Remove this Goerli based network conditions
 export const ENS_SUPPORTED_NETWORKS: SupportedNetworks[] = [
   'ethereum',


### PR DESCRIPTION
## Description

- shows offchain voting only on supported networks
- fixes issue of execution committee multisig configuration step showing up when the multisig plugin is selected after having selected offchain voting with the Vocdoni plugin

Task: [APP-0000](https://aragonassociation.atlassian.net/browse/APP-0000)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.
