### PR TITLE
fix: APP-2997 - Allow proxy contract to be removed in Smart Contract Composer

### DIFF
--- a/src/containers/smartContractComposer/components/inputForm.tsx
+++ b/src/containers/smartContractComposer/components/inputForm.tsx
@@ -63,17 +63,16 @@ const InputForm: React.FC<InputFormProps> = ({
 }) => {
   const {t} = useTranslation();
   const {network} = useNetwork();
-  const [selectedAction, selectedSC, sccActions, writeAsProxy]: [
+  const [selectedAction, selectedSC, sccActions]: [
     SmartContractAction,
     SmartContract,
     Record<string, Record<string, Record<string, unknown>>>,
-    boolean,
   ] = useWatch({
-    name: ['selectedAction', 'selectedSC', 'sccActions', 'writeAsProxy'],
+    name: ['selectedAction', 'selectedSC', 'sccActions'],
   });
   const {dao: daoAddressOrEns} = useParams();
   const {addAction, removeAction} = useActionsContext();
-  const {setValue, resetField, getValues} = useFormContext();
+  const {setValue, resetField} = useFormContext();
   const [another, setAnother] = useState(false);
 
   // add payable input to the selected action if it is a payable method
@@ -92,27 +91,10 @@ const InputForm: React.FC<InputFormProps> = ({
       name: 'external_contract_action',
     });
 
-    // check if the action is being written as a proxy
-    let contractAddress = selectedSC.address;
-    let contractName = selectedSC.name;
-
-    if (writeAsProxy) {
-      // get proxy contract
-      const contracts: SmartContract[] = getValues('contracts');
-      const contract = contracts.filter(
-        c => c.address === selectedSC.proxyAddress
-      )[0];
-
-      if (contract.proxy) {
-        contractName = contract.name;
-        contractAddress = contract.address;
-      }
-    }
-
     resetField(`actions.${actionIndex}`);
     setValue(`actions.${actionIndex}.name`, 'external_contract_action');
-    setValue(`actions.${actionIndex}.contractAddress`, contractAddress);
-    setValue(`actions.${actionIndex}.contractName`, contractName);
+    setValue(`actions.${actionIndex}.contractAddress`, selectedSC.address);
+    setValue(`actions.${actionIndex}.contractName`, selectedSC.name);
     setValue(`actions.${actionIndex}.functionName`, selectedAction.name);
     setValue(`actions.${actionIndex}.notice`, selectedAction.notice);
 
@@ -160,24 +142,21 @@ const InputForm: React.FC<InputFormProps> = ({
       method_name: selectedAction.name,
     });
   }, [
-    removeAction,
     actionIndex,
-    addAction,
-    selectedSC.address,
-    selectedSC.name,
-    selectedSC?.proxyAddress,
-    writeAsProxy,
-    resetField,
-    setValue,
-    selectedAction.name,
-    selectedAction.notice,
     actionInputs,
-    onComposeButtonClicked,
+    addAction,
     another,
     daoAddressOrEns,
-    getValues,
-    t,
+    onComposeButtonClicked,
+    removeAction,
+    resetField,
     sccActions,
+    selectedAction.name,
+    selectedAction.notice,
+    selectedSC.address,
+    selectedSC.name,
+    setValue,
+    t,
   ]);
 
   return (

--- a/src/containers/smartContractComposer/components/listHeaderContract.tsx
+++ b/src/containers/smartContractComposer/components/listHeaderContract.tsx
@@ -43,31 +43,41 @@ export const ListHeaderContract: React.FC<Props> = ({
     }
   };
 
-  const handleWriteAsProxy = () => {
+  const handleWriteModeClick = () => {
     if (sc.implementationData) {
-      const selectedAction = sc.implementationData.actions.filter(
-        a =>
-          a.type === 'function' &&
-          (a.stateMutability === 'payable' ||
-            a.stateMutability === 'nonpayable')
-      )?.[0];
-
-      setValue('writeAsProxy', true);
-      setValue('selectedSC', sc.implementationData);
-      setValue('selectedAction', selectedAction);
+      writeAsProxy({
+        ...sc.implementationData,
+        name: sc.name,
+        address: sc.address,
+      });
     } else {
-      const contract = contracts.filter(c => c.address === sc.proxyAddress)[0];
-      const selectedAction = contract.actions.filter(
-        a =>
-          a.type === 'function' &&
-          (a.stateMutability === 'payable' ||
-            a.stateMutability === 'nonpayable')
-      )?.[0];
-
-      setValue('writeAsProxy', false);
-      setValue('selectedSC', contract);
-      setValue('selectedAction', selectedAction);
+      writeAsImplementation();
     }
+  };
+
+  const writeAsProxy = (
+    implementationData: NonNullable<SmartContract['implementationData']>
+  ) => {
+    const selectedAction = implementationData.actions.filter(
+      a =>
+        a.type === 'function' &&
+        (a.stateMutability === 'payable' || a.stateMutability === 'nonpayable')
+    )?.[0];
+
+    setValue('selectedSC', implementationData);
+    setValue('selectedAction', selectedAction);
+  };
+
+  const writeAsImplementation = () => {
+    const contract = contracts.filter(c => c.address === sc.proxyAddress)[0];
+    const selectedAction = contract.actions.filter(
+      a =>
+        a.type === 'function' &&
+        (a.stateMutability === 'payable' || a.stateMutability === 'nonpayable')
+    )?.[0];
+
+    setValue('selectedSC', contract);
+    setValue('selectedAction', selectedAction);
   };
 
   const listItems = [
@@ -117,7 +127,7 @@ export const ListHeaderContract: React.FC<Props> = ({
         }
         iconRight={IconType.BLOCKCHAIN_SMARTCONTRACT}
         className="my-2 w-full justify-between px-4"
-        onClick={handleWriteAsProxy}
+        onClick={handleWriteModeClick}
       />
     );
   }

--- a/src/containers/smartContractComposer/components/listHeaderContract.tsx
+++ b/src/containers/smartContractComposer/components/listHeaderContract.tsx
@@ -35,6 +35,41 @@ export const ListHeaderContract: React.FC<Props> = ({
   // @ts-ignore
   const contracts = getValues('contracts');
 
+  const handleDeleteContract = () => {
+    if (sc.implementationData) {
+      onRemoveContract(sc.address);
+    } else {
+      onRemoveContract(sc.proxyAddress ?? sc.address);
+    }
+  };
+
+  const handleWriteAsProxy = () => {
+    if (sc.implementationData) {
+      const selectedAction = sc.implementationData.actions.filter(
+        a =>
+          a.type === 'function' &&
+          (a.stateMutability === 'payable' ||
+            a.stateMutability === 'nonpayable')
+      )?.[0];
+
+      setValue('writeAsProxy', true);
+      setValue('selectedSC', sc.implementationData);
+      setValue('selectedAction', selectedAction);
+    } else {
+      const contract = contracts.filter(c => c.address === sc.proxyAddress)[0];
+      const selectedAction = contract.actions.filter(
+        a =>
+          a.type === 'function' &&
+          (a.stateMutability === 'payable' ||
+            a.stateMutability === 'nonpayable')
+      )?.[0];
+
+      setValue('writeAsProxy', false);
+      setValue('selectedSC', contract);
+      setValue('selectedAction', selectedAction);
+    }
+  };
+
   const listItems = [
     <Link
       key={0}
@@ -65,13 +100,7 @@ export const ListHeaderContract: React.FC<Props> = ({
       iconRight={IconType.CLOSE}
       label={t('scc.detailContract.dropdownRemoveLabel')}
       className="my-2 w-full justify-between px-4"
-      onClick={() => {
-        if (sc.implementationData) {
-          onRemoveContract(sc.proxyAddress as string);
-        } else {
-          onRemoveContract(sc.address);
-        }
-      }}
+      onClick={handleDeleteContract}
     />,
   ];
 
@@ -88,36 +117,7 @@ export const ListHeaderContract: React.FC<Props> = ({
         }
         iconRight={IconType.BLOCKCHAIN_SMARTCONTRACT}
         className="my-2 w-full justify-between px-4"
-        onClick={() => {
-          if (sc.implementationData) {
-            setValue('writeAsProxy', true);
-            setValue('selectedSC', sc.implementationData as SmartContract);
-            setValue(
-              'selectedAction',
-              (sc.implementationData as SmartContract).actions.filter(
-                a =>
-                  a.type === 'function' &&
-                  (a.stateMutability === 'payable' ||
-                    a.stateMutability === 'nonpayable')
-              )?.[0]
-            );
-          } else {
-            const contract = contracts.filter(
-              c => c.address === sc.proxyAddress
-            )[0];
-            setValue('writeAsProxy', false);
-            setValue('selectedSC', contract);
-            setValue(
-              'selectedAction',
-              contract.actions.filter(
-                a =>
-                  a.type === 'function' &&
-                  (a.stateMutability === 'payable' ||
-                    a.stateMutability === 'nonpayable')
-              )?.[0]
-            );
-          }
-        }}
+        onClick={handleWriteAsProxy}
       />
     );
   }
@@ -135,13 +135,15 @@ export const ListHeaderContract: React.FC<Props> = ({
     </Dropdown.Container>
   );
 
+  const listItemSubtitle = sc.proxyAddress
+    ? `${t('scc.listContracts.proxyContractAddressLabel', {
+        contractAddress: shortenAddress(sc.address),
+      })}`
+    : shortenAddress(sc.address);
+
   const liaProps = {
     title: sc.name,
-    subtitle: sc.proxyAddress
-      ? `${t('scc.listContracts.proxyContractAddressLabel', {
-          contractAddress: shortenAddress(sc.address),
-        })}`
-      : shortenAddress(sc.address),
+    subtitle: listItemSubtitle,
     bgWhite: true,
     logo: sc.logo,
     iconRight,

--- a/src/containers/smartContractComposer/desktopModal/index.tsx
+++ b/src/containers/smartContractComposer/desktopModal/index.tsx
@@ -123,17 +123,15 @@ const DesktopModal: React.FC<DesktopModalProps> = props => {
         </Aside>
 
         <Main>
-          {selectedSC ? (
-            selectedAction ? (
-              <InputForm
-                actionIndex={props.actionIndex}
-                onComposeButtonClicked={props.onComposeButtonClicked}
-              />
-            ) : (
-              <EmptyActionsState selectedSC={selectedSC} />
-            )
-          ) : (
-            <DesktopModalEmptyState />
+          {!selectedSC && <DesktopModalEmptyState />}
+          {selectedSC && selectedAction && (
+            <InputForm
+              actionIndex={props.actionIndex}
+              onComposeButtonClicked={props.onComposeButtonClicked}
+            />
+          )}
+          {selectedSC && !selectedAction && (
+            <EmptyActionsState selectedSC={selectedSC} />
           )}
         </Main>
       </Wrapper>
@@ -149,6 +147,26 @@ const EmptyActionsState: React.FC<{selectedSC: SmartContract}> = ({
   const {t} = useTranslation();
   const {setValue} = useFormContext<SccFormData>();
 
+  const handleWriteAsProxy = () => {
+    const contract: SmartContract = {
+      actions: [],
+      ...selectedSC.implementationData,
+      name: selectedSC.name,
+      address: selectedSC.address,
+    };
+
+    const selectedAction = (
+      selectedSC.implementationData?.actions ?? []
+    ).filter(
+      a =>
+        a.type === 'function' &&
+        (a.stateMutability === 'payable' || a.stateMutability === 'nonpayable')
+    )?.[0];
+
+    setValue('selectedSC', contract);
+    setValue('selectedAction', selectedAction);
+  };
+
   return (
     <Container>
       <div>
@@ -163,22 +181,7 @@ const EmptyActionsState: React.FC<{selectedSC: SmartContract}> = ({
             size="md"
             variant="primary"
             iconLeft={IconType.BLOCKCHAIN_SMARTCONTRACT}
-            onClick={() => {
-              setValue('writeAsProxy', true);
-              setValue(
-                'selectedSC',
-                selectedSC.implementationData as SmartContract
-              );
-              setValue(
-                'selectedAction',
-                (selectedSC.implementationData as SmartContract).actions.filter(
-                  a =>
-                    a.type === 'function' &&
-                    (a.stateMutability === 'payable' ||
-                      a.stateMutability === 'nonpayable')
-                )?.[0]
-              );
-            }}
+            onClick={handleWriteAsProxy}
           >
             {t('scc.writeContractEmptyState.ctaLabel')}
           </Button>

--- a/src/containers/smartContractComposer/index.tsx
+++ b/src/containers/smartContractComposer/index.tsx
@@ -22,7 +22,6 @@ export type SccFormData = {
   selectedSC: SmartContract | null;
   selectedAction: SmartContractAction;
   ABIInput: string;
-  writeAsProxy: boolean;
 };
 
 type SCC = {

--- a/src/utils/library.ts
+++ b/src/utils/library.ts
@@ -419,16 +419,6 @@ export async function decodeMetadataToAction(
 }
 
 /**
- * Decodes the provided DAO action into an external action
- * (SCC or Wallet Connect).
- *
- * @param action - A DAO action to decode.
- * @param network - The network on which the action is to be performed.
- *
- * @returns A promise that resolves to the decoded action
- * or undefined if the action could not be decoded.
- */
-/**
  * Decodes a DAO action to an external contract action (SCC or Wallet Connect).
  * @param action - DAO action to decode.
  * @param daoAddress - The address of the DAO.


### PR DESCRIPTION
## Description

- Fixes the issue of not being able to remove a proxy contract from the SCC
- Shows the proxy contract name & address when decoding an external action

Task: [APP-2997](https://aragonassociation.atlassian.net/browse/APP-2997)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-2997]: https://aragonassociation.atlassian.net/browse/APP-2997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ