### PR TITLE
fix: APP-3004 - REPORT - ; in the Proposal DataItem Succeeded 

### DIFF
--- a/src/@aragon/ods-old/components/cards/cardProposal.tsx
+++ b/src/@aragon/ods-old/components/cards/cardProposal.tsx
@@ -223,7 +223,7 @@ const HeaderOptions: React.VFC<HeaderOptionProps> = ({
     case 'succeeded':
       return (
         <>
-          <Tag label={stateLabel[4]} colorScheme="success" />;
+          <Tag label={stateLabel[4]} colorScheme="success" />
           {alertMessage && (
             <AlertInline
               label={alertMessage}


### PR DESCRIPTION
## Description

Each proposal dataItem which is succeeded, has an ; in the upper right (see screenshots below).

BEFORE
<img width="1605" alt="image" src="https://github.com/aragon/app/assets/16764792/f3608151-59f3-4c92-b5c9-d9c056876717">

AFTER
<img width="1604" alt="image" src="https://github.com/aragon/app/assets/16764792/f3a89c5c-b8f9-489e-b27a-b265b7ea3883">


Task: [APP-3004](https://aragonassociation.atlassian.net/browse/APP-3004)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.


[APP-3004]: https://aragonassociation.atlassian.net/browse/APP-3004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ