### PR TITLE
fix: minor fixes on stepper and empty-snapshots components

### DIFF
--- a/src/@aragon/ods-old/components/wizard/wizard.tsx
+++ b/src/@aragon/ods-old/components/wizard/wizard.tsx
@@ -50,18 +50,20 @@ export const Wizard: React.FC<WizardProps> = ({
         <StepTitle>{title}</StepTitle>
 
         <StepSubTitle>{description}</StepSubTitle>
-        <div className="max-w-fit">
-          <Button
-            className="mt-4"
-            size="md"
-            iconRight={IconType.LINK_EXTERNAL}
-            variant="secondary"
-            href={descriptionLink}
-            target="_blank"
-          >
-            {t('navLinks.guide')}
-          </Button>
-        </div>
+        {!!descriptionLink && (
+          <div className="max-w-fit">
+            <Button
+              className="mt-4"
+              size="md"
+              iconRight={IconType.LINK_EXTERNAL}
+              variant="secondary"
+              href={descriptionLink}
+              target="_blank"
+            >
+              {t('navLinks.guide')}
+            </Button>
+          </div>
+        )}
       </Wrapper>
     </StepCard>
   );

--- a/src/containers/proposalSnapshot/index.tsx
+++ b/src/containers/proposalSnapshot/index.tsx
@@ -102,7 +102,7 @@ const ProposalSnapshot: React.FC<Props> = ({
 
   if (proposalCountIsFetched && (proposalCount === 0 || proposalCountError)) {
     return (
-      // needs ODS adjustment & release long term
+      // TODO: remove this when fixed on ODS (APP-2994)
       <CardEmptyState
         className="!w-fit"
         humanIllustration={{

--- a/src/containers/proposalSnapshot/index.tsx
+++ b/src/containers/proposalSnapshot/index.tsx
@@ -102,7 +102,9 @@ const ProposalSnapshot: React.FC<Props> = ({
 
   if (proposalCountIsFetched && (proposalCount === 0 || proposalCountError)) {
     return (
+      // needs ODS adjustment & release long term
       <CardEmptyState
+        className="!w-fit"
         humanIllustration={{
           body: 'VOTING',
           expression: 'SMILE',

--- a/src/containers/treasurySnapshot/index.tsx
+++ b/src/containers/treasurySnapshot/index.tsx
@@ -31,7 +31,9 @@ const TreasurySnapshot: React.FC<Props> = ({
 
   if (transfers.length === 0) {
     return (
+      // needs ODS adjustment & release long term
       <CardEmptyState
+        className="!w-fit"
         humanIllustration={{
           body: 'CHART',
           expression: 'EXCITED',


### PR DESCRIPTION
## Description

Quick fixes:
- Proposal creation stepper was rendering 'Learn More' button without link out.
- ProposalSnapshot and TreasurySnapshot using CardEmptyStates were overflowing the page layout grid due to fixed width sizing of underlying EmptyState component (temporary fix, needs ODS update)
 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the test network.
