### PR TITLE
fix: APP-2956 - Refine session detection for terminated sessions on dAppConnect Actions flow 

### DIFF
--- a/src/containers/walletConnect/dAppValidationModal/index.tsx
+++ b/src/containers/walletConnect/dAppValidationModal/index.tsx
@@ -41,7 +41,6 @@ const DAppValidationModal: React.FC<Props> = props => {
   const [connectionStatus, setConnectionStatus] = useState<ConnectionState>(
     ConnectionState.WAITING
   );
-
   const {wcConnect, validateURI, sessions} = useWalletConnectContext();
 
   const {control} = useFormContext();
@@ -76,8 +75,9 @@ const DAppValidationModal: React.FC<Props> = props => {
     return t('labels.paste');
   }, [connectionStatus, t, uri]);
 
-  const currentSession = sessions.find(
-    ({pairingTopic}) => pairingTopic === sessionTopic
+  const currentSession = useMemo(
+    () => sessions.find(({pairingTopic}) => pairingTopic === sessionTopic),
+    [sessions, sessionTopic]
   );
 
   /*************************************************
@@ -131,14 +131,17 @@ const DAppValidationModal: React.FC<Props> = props => {
     }
   }, [uri, wcConnect]);
 
-  // Reset the connection state if the session has been terminated on the dApp
+  // Reset the connection state if the session has been terminated on the dApp before `Adding actions` view is closed
   useEffect(() => {
     const isSuccess = connectionStatus === ConnectionState.SUCCESS;
 
-    if (isSuccess && currentSession == null) {
+    if (
+      !sessions.includes(currentSession as SessionTypes.Struct) &&
+      isSuccess
+    ) {
       resetConnectionState();
     }
-  }, [connectionStatus, currentSession, resetConnectionState]);
+  }, [connectionStatus, currentSession, sessions, resetConnectionState]);
 
   const disableCta = uri == null || Boolean(errors[WC_URI_INPUT_NAME]);
 

--- a/src/containers/walletConnect/dAppValidationModal/index.tsx
+++ b/src/containers/walletConnect/dAppValidationModal/index.tsx
@@ -1,7 +1,7 @@
 import {AlertInline, Button, IconType} from '@aragon/ods';
 import {WalletInputLegacy} from '@aragon/ods-old';
 import {SessionTypes} from '@walletconnect/types';
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {
   Controller,
   useFormContext,

--- a/src/containers/walletConnect/dAppValidationModal/index.tsx
+++ b/src/containers/walletConnect/dAppValidationModal/index.tsx
@@ -83,9 +83,7 @@ const DAppValidationModal: React.FC<Props> = props => {
 
   // Helps await `Adding actions` view correctly, while also resetting the flow if the session is terminated prematurely
   useEffect(() => {
-    if (currentSession != null) {
-      setDidConnect(true); // Update ref to the latest known session
-    }
+    setDidConnect(currentSession != null);
   }, [currentSession]);
 
   /*************************************************
@@ -111,7 +109,6 @@ const DAppValidationModal: React.FC<Props> = props => {
   const resetConnectionState = useCallback(() => {
     setConnectionStatus(ConnectionState.WAITING);
     setSessionTopic(undefined);
-    setDidConnect(false);
   }, []);
 
   const handleBackClick = useCallback(() => {

--- a/src/containers/walletConnect/selectdAppModal/index.tsx
+++ b/src/containers/walletConnect/selectdAppModal/index.tsx
@@ -53,7 +53,7 @@ const SelectdAppModal: React.FC<Props> = props => {
           <div className="flex flex-col gap-y-2">
             {sessions.map(session => (
               <ListItemAction
-                key={session.peer.metadata.name}
+                key={session.topic}
                 title={session.peer.metadata.name}
                 iconLeft={parseWCIconUrl(
                   session.peer.metadata.url,


### PR DESCRIPTION
## Description

Fixes race conditions that prevented connected dApps from correctly triggering 'Start adding actions' view

Task: [APP-2956](https://aragonassociation.atlassian.net/browse/APP-2956)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.


[APP-2956]: https://aragonassociation.atlassian.net/browse/APP-2956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ