### PR TITLE
fix: APP-3126 - Only initialise gasless plugin for supported gasless DAOs

### DIFF
--- a/src/hooks/useGaslessGovernanceEnabled.tsx
+++ b/src/hooks/useGaslessGovernanceEnabled.tsx
@@ -16,6 +16,7 @@ export const useGaslessGovernanceEnabled = () => {
   });
 
   const {data: isMintable} = useIsMintable({
+    pluginType,
     daoAddress: daoDetails?.address || '',
   });
 

--- a/src/services/aragon-sdk/aragon-sdk-service.api.ts
+++ b/src/services/aragon-sdk/aragon-sdk-service.api.ts
@@ -37,6 +37,7 @@ export interface IFetchVotingSettingsParams {
 
 export interface IFetchIsmintableParams {
   daoAddress: string;
+  pluginType?: PluginTypes;
 }
 
 export interface IFetchProposalsParams extends ProposalQueryParams {

--- a/src/services/aragon-sdk/queries/use-is-mintable.ts
+++ b/src/services/aragon-sdk/queries/use-is-mintable.ts
@@ -50,10 +50,14 @@ export function useIsMintable(
   params: IFetchIsmintableParams,
   options: Omit<UseQueryOptions<Boolean | null>, 'queryKey'> = {}
 ) {
-  const client = usePluginClient(GaslessPluginName);
+  const client = usePluginClient(params.pluginType);
   const {network} = useNetwork();
 
-  if (!client || !params.daoAddress) {
+  if (
+    !client ||
+    !params.daoAddress ||
+    params.pluginType !== GaslessPluginName
+  ) {
     options.enabled = false;
   }
 


### PR DESCRIPTION
## Description

- Only initialise gasless plugin for supported gasless DAOs

Task: [APP-3126](https://aragonassociation.atlassian.net/browse/APP-3126)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.


[APP-3126]: https://aragonassociation.atlassian.net/browse/APP-3126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ