### PR TITLE
fix: APP-3119 - Cannot Edit DAO Settings of New DAOs

### DIFF
--- a/e2e/basic.setup.ts
+++ b/e2e/basic.setup.ts
@@ -5,7 +5,7 @@ import {
 } from '@synthetixio/synpress';
 import 'dotenv/config';
 
-export const LOCALHOST_URL = 'http://localhost:5173/';
+export const LOCALHOST_URL = 'http://localhost:5173';
 
 const SEED_PHRASE = process.env.METAMASK_SEED_PHRASE!;
 const PASSWORD = process.env.METAMASK_PASSWORD!;

--- a/e2e/basic.setup.ts
+++ b/e2e/basic.setup.ts
@@ -5,7 +5,7 @@ import {
 } from '@synthetixio/synpress';
 import 'dotenv/config';
 
-export const LOCALHOST_URL = 'http://localhost:5173';
+export const LOCALHOST_URL = 'http://localhost:5173/';
 
 const SEED_PHRASE = process.env.METAMASK_SEED_PHRASE!;
 const PASSWORD = process.env.METAMASK_PASSWORD!;

--- a/src/@aragon/ods-old/components/input/inputImageSingle.tsx
+++ b/src/@aragon/ods-old/components/input/inputImageSingle.tsx
@@ -8,7 +8,7 @@ export type InputImageSingleProps = {
   /**
    * onChange Event will fires after uploading a valid image
    */
-  onChange: (file: File | null) => void;
+  onChange: (file: File | undefined) => void;
   /**
    * All error messages will pass as onError function inputs
    */
@@ -126,7 +126,7 @@ export const InputImageSingle: React.FC<InputImageSingleProps> = ({
         variant="tertiary"
         onClick={() => {
           setPreview('');
-          onChange(null);
+          onChange(undefined);
         }}
       />
     </ImageContainer>

--- a/src/containers/createDaoDialog/utils/createDaoUtils.ts
+++ b/src/containers/createDaoDialog/utils/createDaoUtils.ts
@@ -68,7 +68,7 @@ class CreateDaoUtils {
     links: values.links.filter(
       ({name, url}) => name != null && name !== '' && url != null && url !== ''
     ),
-    avatar: `ipfs://${logoCid}`,
+    avatar: logoCid ? `ipfs://${logoCid}` : undefined,
   });
 
   buildCreateDaoParams = (


### PR DESCRIPTION
## Description

Found that the edit settings proposal flow, and after debugging that, the edit settings transaction would crash because at DAO creation the value `ipfs://undefined` for avatar is given in case no logo is added (this is the case since we have the new transaction flow).

Before that, the value was for avatar was `undefined`, which I again added in case no logo is added at DAO creation.

Edit settings proposals succeed again when changing metadata such as the DAO name, and not editing the DAO logo, see e.g. the proposal [here](http://localhost:5173/#/daos/sepolia/0x3593a8099a96b7caa7b8163962b537ebc3dde786/governance/proposals/0x75de0acf44e2c36e247f13eb2b27bc4135214b61_0x0).

Update: also added a fix for the edge case when a DAO is removing its logo which resulted in a failed create edit proposal transaction before.

Task: [APP-3119](https://aragonassociation.atlassian.net/browse/APP-3119)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.


[APP-3119]: https://aragonassociation.atlassian.net/browse/APP-3119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ