### PR TITLE
fix(APP-3261): Truncate long link descriptions dashboard

### DIFF
--- a/src/@aragon/ods-old/components/headers/headerDao.tsx
+++ b/src/@aragon/ods-old/components/headers/headerDao.tsx
@@ -8,7 +8,7 @@ import {Link} from '../link';
 import {ListItemLink} from '../listItem';
 
 const DEFAULT_LINES_SHOWN = 2;
-const DEFAULT_LINKS_SHOWN = 3;
+const DEFAULT_LINKS_SHOWN = 2;
 const DEFAULT_TRANSLATIONS = {
   follow: 'Follow',
   following: 'Following',

--- a/src/@aragon/ods-old/components/headers/headerDao.tsx
+++ b/src/@aragon/ods-old/components/headers/headerDao.tsx
@@ -218,7 +218,8 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
                 <Button
                   iconRight={IconType.CHEVRON_DOWN}
                   variant="tertiary"
-                  size="lg"
+                  size="sm"
+                  responsiveSize={{md: 'md'}}
                   className="text-nowrap"
                 >
                   All Links
@@ -235,7 +236,8 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
           <Button
             onClick={onFollowClick}
             variant="tertiary"
-            size="lg"
+            size="sm"
+            responsiveSize={{md: 'md'}}
             iconLeft={following ? IconType.CHECKMARK : undefined}
           >
             {following ? labels.following : labels.follow}
@@ -283,7 +285,8 @@ const Description = styled.p.attrs({
 `;
 
 const DetailsWrapper = styled.div.attrs({
-  className: 'flex items-center justify-between flex gap-x-6',
+  className:
+    'flex sm:items-center justify-start items-start sm:justify-between flex-col gap-y-4 sm:flex-row sm:gap-x-6',
 })``;
 
 const NetworkDetailsContainer = styled.div.attrs({

--- a/src/@aragon/ods-old/components/headers/headerDao.tsx
+++ b/src/@aragon/ods-old/components/headers/headerDao.tsx
@@ -202,45 +202,45 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
             <DetailsText>{daoType}</DetailsText>
           </NetworkDetails>
         </NetworkDetailsContainer>
-        <ActionWrapper>
-          <LinksWrapper>
-            {links
-              ?.slice(0, DEFAULT_LINKS_SHOWN)
-              ?.map(({label, href}, index: number) => (
-                <StyledLink {...{label, href}} external key={index} />
-              ))}
-          </LinksWrapper>
-          <ActionContainer>
-            {showDropdown && (
-              <Dropdown.Container
-                align="start"
-                customTrigger={
-                  <Button
-                    iconRight={IconType.CHEVRON_DOWN}
-                    variant="tertiary"
-                    size="lg"
-                  >
-                    All Links
-                  </Button>
-                }
-              >
-                {links?.map(({label, href}, index: number) => (
-                  <div className="mb-3 p-2" key={index}>
-                    <ListItemLink {...{label, href}} external />
-                  </div>
-                ))}
-              </Dropdown.Container>
-            )}
-            <Button
-              onClick={onFollowClick}
-              variant="tertiary"
-              size="lg"
-              iconLeft={following ? IconType.CHECKMARK : undefined}
+
+        <LinksWrapper>
+          {links
+            ?.slice(0, DEFAULT_LINKS_SHOWN)
+            ?.map(({label, href}, index: number) => (
+              <StyledLink {...{label, href}} external key={index} />
+            ))}
+        </LinksWrapper>
+        <ActionContainer>
+          {showDropdown && (
+            <Dropdown.Container
+              align="start"
+              customTrigger={
+                <Button
+                  iconRight={IconType.CHEVRON_DOWN}
+                  variant="tertiary"
+                  size="lg"
+                  className="text-nowrap"
+                >
+                  All Links
+                </Button>
+              }
             >
-              {following ? labels.following : labels.follow}
-            </Button>
-          </ActionContainer>
-        </ActionWrapper>
+              {links?.map(({label, href}, index: number) => (
+                <div className="mb-3 p-2" key={index}>
+                  <ListItemLink {...{label, href}} external />
+                </div>
+              ))}
+            </Dropdown.Container>
+          )}
+          <Button
+            onClick={onFollowClick}
+            variant="tertiary"
+            size="lg"
+            iconLeft={following ? IconType.CHECKMARK : undefined}
+          >
+            {following ? labels.following : labels.follow}
+          </Button>
+        </ActionContainer>
       </DetailsWrapper>
     </Card>
   );
@@ -283,15 +283,15 @@ const Description = styled.p.attrs({
 `;
 
 const DetailsWrapper = styled.div.attrs({
-  className: 'flex items-center justify-between flex-col md:flex-row',
+  className: 'flex items-center justify-between flex gap-x-6',
 })``;
 
 const NetworkDetailsContainer = styled.div.attrs({
-  className: 'flex space-x-6 w-full md:w-auto',
+  className: 'flex space-x-6 w-max-content wrap-none',
 })``;
 
 const NetworkDetails = styled.div.attrs({
-  className: 'flex space-x-2 items-center justify-center',
+  className: 'flex space-x-2 items-center justify-center text-nowrap',
 })``;
 
 const DetailsText = styled.span.attrs({
@@ -299,20 +299,15 @@ const DetailsText = styled.span.attrs({
 })``;
 
 const LinksWrapper = styled.div.attrs({
-  className: 'space-x-3 ml-3 hidden xl:flex',
+  className: 'gap-x-3 hidden xl:grid xl:grid-cols-2 w-full',
 })``;
 
 const StyledLink = styled(Link).attrs({
-  className: 'max-w-xs',
+  className: 'w-full',
 })``;
 
 const ActionContainer = styled.div.attrs({
-  className: 'flex space-x-3 w-full justify-between',
-})``;
-
-const ActionWrapper = styled.div.attrs({
-  className:
-    'flex items-center md:space-x-6 justify-between md:justify-start w-full md:w-max space-y-6 md:space-y-0',
+  className: 'flex space-x-3 w-max-content justify-end',
 })``;
 
 const CredentialsDropdownTrigger = styled(Link).attrs({

--- a/src/@aragon/ods-old/components/headers/headerDao.tsx
+++ b/src/@aragon/ods-old/components/headers/headerDao.tsx
@@ -8,7 +8,7 @@ import {Link} from '../link';
 import {ListItemLink} from '../listItem';
 
 const DEFAULT_LINES_SHOWN = 2;
-const DEFAULT_LINKS_SHOWN = 2;
+const DEFAULT_LINKS_SHOWN = 3;
 const DEFAULT_TRANSLATIONS = {
   follow: 'Follow',
   following: 'Following',

--- a/src/@aragon/ods-old/components/headers/headerDao.tsx
+++ b/src/@aragon/ods-old/components/headers/headerDao.tsx
@@ -207,7 +207,7 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
             {links
               ?.slice(0, DEFAULT_LINKS_SHOWN)
               ?.map(({label, href}, index: number) => (
-                <Link {...{label, href}} external key={index} />
+                <StyledLink {...{label, href}} external key={index} />
               ))}
           </LinksWrapper>
           <ActionContainer>
@@ -299,7 +299,11 @@ const DetailsText = styled.span.attrs({
 })``;
 
 const LinksWrapper = styled.div.attrs({
-  className: 'space-x-6 hidden xl:flex',
+  className: 'space-x-3 ml-3 hidden xl:flex',
+})``;
+
+const StyledLink = styled(Link).attrs({
+  className: 'max-w-xs',
 })``;
 
 const ActionContainer = styled.div.attrs({

--- a/src/@aragon/ods-old/components/link/link.tsx
+++ b/src/@aragon/ods-old/components/link/link.tsx
@@ -49,7 +49,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
         {...props}
         data-testid="link"
       >
-        <div className="mr-1 flex items-center gap-x-2">
+        <div className="flex items-center">
           <Label>{label}</Label>
           {iconRight && <Icon icon={iconRight} size="sm" />}
         </div>

--- a/src/@aragon/ods-old/components/link/link.tsx
+++ b/src/@aragon/ods-old/components/link/link.tsx
@@ -49,7 +49,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
         {...props}
         data-testid="link"
       >
-        <div className="flex items-center">
+        <div className="flex items-center gap-x-2">
           <Label>{label}</Label>
           {iconRight && <Icon icon={iconRight} size="sm" />}
         </div>

--- a/src/@aragon/ods-old/components/listItem/link.tsx
+++ b/src/@aragon/ods-old/components/listItem/link.tsx
@@ -36,11 +36,12 @@ export const ListItemLink: React.FC<ListItemLinkProps> = ({
 };
 
 const Container = styled.div.attrs({
-  className: 'w-full overflow-hidden',
+  className: 'w-1/3 overflow-hidden border-[1px] border-critical-200 ',
 })``;
 
 const Link = styled.a.attrs({
-  className: 'flex items-center min-w-0 text-primary-500' as string,
+  className:
+    'flex items-center min-w-0 text-primary-500 border-[1px] border-critical-200' as string,
 })``;
 
 const Title = styled.p.attrs({

--- a/src/@aragon/ods-old/components/listItem/link.tsx
+++ b/src/@aragon/ods-old/components/listItem/link.tsx
@@ -36,12 +36,11 @@ export const ListItemLink: React.FC<ListItemLinkProps> = ({
 };
 
 const Container = styled.div.attrs({
-  className: 'w-1/3 overflow-hidden border-[1px] border-critical-200 ',
+  className: 'overflow-hidden',
 })``;
 
 const Link = styled.a.attrs({
-  className:
-    'flex items-center min-w-0 text-primary-500 border-[1px] border-critical-200' as string,
+  className: 'flex items-center min-w-0 text-primary-500',
 })``;
 
 const Title = styled.p.attrs({


### PR DESCRIPTION
## Description

Dashboard UI fix, bringing default displayed shown back from 3 to 2, see BEFORE and AFTER in the images below:

BEFORE
<img width="1620" alt="image" src="https://github.com/aragon/app/assets/16764792/70476e53-6d89-4f0d-9456-c1c6fcde96e4">

AFTER
<img width="1625" alt="image" src="https://github.com/aragon/app/assets/16764792/f6a54532-2dee-4f38-88a3-fde3546e41a0">



Task: [APP-3261](https://aragonassociation.atlassian.net/browse/APP-3261)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.


[APP-3261]: https://aragonassociation.atlassian.net/browse/APP-3261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ