### PR TITLE
fix: zksyncSepolia token deposits and treasury

### DIFF
--- a/src/utils/constants/chains.ts
+++ b/src/utils/constants/chains.ts
@@ -261,11 +261,11 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
     id: 300,
     name: i18n.t('explore.modal.filterDAOs.label.zksyncSepolia'),
     domain: 'L2 Blockchain',
-    logo: 'https://assets.coingecko.com/asset_platforms/images/121/large/zksync.jpeg',
+    logo: 'https://static.debank.com/image/chain/logo_url/era/2cfcd0c8436b05d811b03935f6c1d7da.png',
     explorer: 'https://sepolia.explorer.zksync.io/',
     isTestnet: true,
     mainnet: 'ethereum', // temporary price lookup while zksyncSepolia native token is not supported with default values by API services
-    explorerName: 'ZkSync Sepolia Explorer',
+    explorerName: 'zkSync Sepolia Explorer',
     publicRpc: 'https://endpoints.omniatech.io/v1/zksync-era/sepolia/public',
     gatewayNetwork: 'zksync/sepolia',
     nativeCurrency: {

--- a/src/utils/constants/chains.ts
+++ b/src/utils/constants/chains.ts
@@ -261,11 +261,11 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
     id: 300,
     name: i18n.t('explore.modal.filterDAOs.label.zksyncSepolia'),
     domain: 'L2 Blockchain',
-    logo: 'https://static.debank.com/image/chain/logo_url/era/2cfcd0c8436b05d811b03935f6c1d7da.png',
+    logo: 'https://assets.coingecko.com/asset_platforms/images/121/large/zksync.jpeg',
     explorer: 'https://sepolia.explorer.zksync.io/',
     isTestnet: true,
-    // mainnet: 'zksync',
-    explorerName: 'zkSync Sepolia Explorer',
+    mainnet: 'ethereum', // temporary price lookup while zksyncSepolia native token is not supported with default values by API services
+    explorerName: 'ZkSync Sepolia Explorer',
     publicRpc: 'https://endpoints.omniatech.io/v1/zksync-era/sepolia/public',
     gatewayNetwork: 'zksync/sepolia',
     nativeCurrency: {
@@ -277,7 +277,7 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
     etherscanApiKey: '',
     covalent: {
       networkId: 'zksync-sepolia-testnet',
-      nativeTokenId: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      nativeTokenId: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee800A',
     },
     supportsEns: false,
   },


### PR DESCRIPTION
## Description

Adjusts chain metadata config for 'ethereum' as mainnet pair in conjunction with backend updates to grab tokens with correct prices and logos. zkSync is not supported yet as mainnet and sepolia testnet doesn't contain proper metadata for native token. 

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.
