### PR TITLE
fix: APP-3263 - zkSync Sepolia uses title case on the DAO list and DAO header and displays as "ZkSync Sepolia"

### DIFF
--- a/src/@aragon/ods-old/components/headers/headerDao.tsx
+++ b/src/@aragon/ods-old/components/headers/headerDao.tsx
@@ -195,7 +195,7 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
               icon={IconType.BLOCKCHAIN_BLOCK}
               className="text-primary-400"
             />
-            <DetailsText className="capitalize">{daoChain}</DetailsText>
+            <DetailsText>{daoChain}</DetailsText>
           </NetworkDetails>
           <NetworkDetails>
             <Icon icon={IconType.APP_MEMBERS} className="text-primary-400" />

--- a/src/components/daoCard/index.tsx
+++ b/src/components/daoCard/index.tsx
@@ -112,7 +112,7 @@ const DaoMetadataWrapper = styled.div.attrs({
   className: 'flex flex-row space-x-6',
 })``;
 const IconLabel = styled.p.attrs({
-  className: 'text-neutral-600 ft-text-sm capitalize',
+  className: 'text-neutral-600 ft-text-sm',
 })``;
 const IconWrapper = styled.div.attrs({
   className: 'flex flex-row space-x-2',


### PR DESCRIPTION
## Description

Lower cased zkSync (both Era and Sepolia) on DAO header and DAO cards while keeping other networks upper cased. Found 7 app instances where `CHAIN_METADATA[network].name` is rendered. In 5 of them zkSync is already lower cased, fixed the 2 instances where it was upper cased (DAO header and DAO cards).

Dashboard before
<img width="1558" alt="image" src="https://github.com/aragon/app/assets/16764792/0afdf8c4-f541-458f-b46a-74be52cebfc6">

Dashboard after
<img width="1566" alt="image" src="https://github.com/aragon/app/assets/16764792/ec0d654b-7bed-46cc-bb9c-3103e6116390">

DAO cards before
<img width="1562" alt="image" src="https://github.com/aragon/app/assets/16764792/ff013295-66d7-44f8-9442-e2d80fafe798">

DAO cards after
<img width="1563" alt="image" src="https://github.com/aragon/app/assets/16764792/072386a5-439b-468a-a975-35560a2aa6ab">


Task: [APP-3263](https://aragonassociation.atlassian.net/browse/APP-3263)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.


[APP-3263]: https://aragonassociation.atlassian.net/browse/APP-3263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ