### PR TITLE
fix: APP-3195 - An empty link is unnecessarily added to Proposal "resources"

### DIFF
--- a/src/containers/createProposalDialog/utils/createProposalUtils.ts
+++ b/src/containers/createProposalDialog/utils/createProposalUtils.ts
@@ -49,9 +49,7 @@ class CreateProposalUtils {
     title: values.proposalTitle,
     summary: values.proposalSummary,
     description: values.proposal,
-    resources: values.links.filter(
-      ({name, url}) => url != null && name != null
-    ),
+    resources: values.links.filter(({name, url}) => name && url),
   });
 
   getProposalIdFromReceipt = (


### PR DESCRIPTION
## Description

Found that issue was introduced with new `createProposalUtil` which would add an object to the resources array even when no link added. This prevented showing empty state since `links.length > 0`

Proposals before the new util did not have the issue, see here e.g.: [proposal link](http://localhost:5173/#/daos/polygon/0x48e12572f4a01a538b1162d39694dbfe910832b8/governance/proposals/0x3e3c5b75ef8c9f3b0e245395a4e64987b92bef81_0x2)

For these proposals no links object was added to the array. So for the new `createProposalUtil` added truthy logic preventing an object added to the array when no link present. Compare before and after in the images below:

Before ([proposal link](http://localhost:5173/#/daos/polygon/0x82af78f41521cb9165b0d8488f52b0d3f7d29d63/governance/proposals/0x2350517e2c3481ff5367ef956ad0f2241a1aedaf_0x9))
<img width="1575" alt="image" src="https://github.com/aragon/app/assets/16764792/613b18d8-f8f5-4ecf-8d11-81918398c1a9">


After ([proposal link](http://localhost:5173/#/daos/polygon/0x82af78f41521cb9165b0d8488f52b0d3f7d29d63/governance/proposals/0x2350517e2c3481ff5367ef956ad0f2241a1aedaf_0xc))
<img width="1578" alt="image" src="https://github.com/aragon/app/assets/16764792/a53c62e2-1875-4f19-86fa-be90451e7d4f">





Task: [APP-3195](https://aragonassociation.atlassian.net/browse/APP-3195)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.


[APP-3195]: https://aragonassociation.atlassian.net/browse/APP-3195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ