### PR TITLE
fix: APP-3113 - dApp Connect - Our metadata points to aragon.org instead off app.aragon.org

### DIFF
--- a/src/utils/constants/api.ts
+++ b/src/utils/constants/api.ts
@@ -8,7 +8,7 @@ export const AppVersion =
 export const AppMetadata = {
   name: 'Aragon DAO',
   description: 'Aragon DAO',
-  url: 'https://aragon.org',
+  url: 'https://app.aragon.org/',
   icons: [
     'https://assets.website-files.com/5e997428d0f2eb13a90aec8c/635283b535e03c60d5aafe64_logo_aragon_isotype.png',
   ],


### PR DESCRIPTION
## Description

Tested this locally, and now 'Open Aragon DAO' button (see image below) opens Aragon App instead of the general Aragon website.

Image 
<img width="1557" alt="image" src="https://github.com/aragon/app/assets/16764792/1a960ae4-100b-4580-888b-f143f70e284e">


Task: [APP-3113](https://aragonassociation.atlassian.net/browse/APP-3113)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.


[APP-3113]: https://aragonassociation.atlassian.net/browse/APP-3113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ