### PR TITLE
fix(APP-3285): Fix block explorer links for zkSync chains, align zkSync mainnet chain name with backend

### DIFF
--- a/src/components/executionWidget/actions/mintTokenCard.tsx
+++ b/src/components/executionWidget/actions/mintTokenCard.tsx
@@ -167,12 +167,13 @@ export const MintTokenCard: React.FC<{
               </p>
             </HStack>
           )}
-          {/* TODO add total amount of token holders here. */}
-          <Link
-            label={t('labels.seeAllHolders')}
-            href={`${CHAIN_METADATA[network].explorer}/token/tokenholderchart/${action.summary.daoTokenAddress}`}
-            iconRight={IconType.LINK_EXTERNAL}
-          />
+          {network !== 'zksync' && network !== 'zksyncSepolia' && (
+            <Link
+              label={t('labels.seeAllHolders')}
+              href={`${CHAIN_METADATA[network].explorer}/token/tokenholderchart/${action.summary.daoTokenAddress}`}
+              iconRight={IconType.LINK_EXTERNAL}
+            />
+          )}
         </SummaryContainer>
       </Container>
     </AccordionMethod>

--- a/src/components/executionWidget/actions/mintTokenCard.tsx
+++ b/src/components/executionWidget/actions/mintTokenCard.tsx
@@ -90,7 +90,9 @@ export const MintTokenCard: React.FC<{
   );
 
   const explorerTokenPath =
-    network === 'zksync' || network === 'zksyncSepolia' ? 'address/' : 'token/';
+    network === 'zksyncMainnet' || network === 'zksyncSepolia'
+      ? 'address/'
+      : 'token/';
 
   /*************************************************
    *                     Render                    *
@@ -170,7 +172,7 @@ export const MintTokenCard: React.FC<{
               </p>
             </HStack>
           )}
-          {network !== 'zksync' && network !== 'zksyncSepolia' && (
+          {network !== 'zksyncMainnet' && network !== 'zksyncSepolia' && (
             <Link
               label={t('labels.seeAllHolders')}
               href={`${CHAIN_METADATA[network].explorer}/token/tokenholderchart/${action.summary.daoTokenAddress}`}

--- a/src/components/executionWidget/actions/mintTokenCard.tsx
+++ b/src/components/executionWidget/actions/mintTokenCard.tsx
@@ -89,6 +89,9 @@ export const MintTokenCard: React.FC<{
     [network]
   );
 
+  const explorerTokenPath =
+    network === 'zksync' || network === 'zksyncSepolia' ? 'address/' : 'token/';
+
   /*************************************************
    *                     Render                    *
    *************************************************/
@@ -100,7 +103,7 @@ export const MintTokenCard: React.FC<{
       smartContractAddress={daoToken?.address}
       blockExplorerLink={
         daoToken?.address
-          ? `${CHAIN_METADATA[network].explorer}token/${daoToken?.address}`
+          ? `${CHAIN_METADATA[network].explorer}${explorerTokenPath}${daoToken?.address}`
           : undefined
       }
       verified

--- a/src/components/executionWidget/actions/withdrawCard.tsx
+++ b/src/components/executionWidget/actions/withdrawCard.tsx
@@ -45,7 +45,9 @@ export const WithdrawCard: React.FC<{
   const recipientURL = `${explorerURL}address/${recipient}`;
 
   const explorerTokenPath =
-    network === 'zksync' || network === 'zksyncSepolia' ? 'address/' : 'token/';
+    network === 'zksyncMainnet' || network === 'zksyncSepolia'
+      ? 'address/'
+      : 'token/';
 
   return (
     <AccordionMethod

--- a/src/components/executionWidget/actions/withdrawCard.tsx
+++ b/src/components/executionWidget/actions/withdrawCard.tsx
@@ -44,6 +44,9 @@ export const WithdrawCard: React.FC<{
   const recipient = (action.to.ensName || action.to.address) as string;
   const recipientURL = `${explorerURL}address/${recipient}`;
 
+  const explorerTokenPath =
+    network === 'zksync' || network === 'zksyncSepolia' ? 'address/' : 'token/';
+
   return (
     <AccordionMethod
       type="execution-widget"
@@ -52,7 +55,7 @@ export const WithdrawCard: React.FC<{
       smartContractAddress={action.tokenAddress}
       blockExplorerLink={
         action.tokenAddress
-          ? `${CHAIN_METADATA[network].explorer}token/${action.tokenAddress}`
+          ? `${CHAIN_METADATA[network].explorer}${explorerTokenPath}${action.tokenAddress}`
           : undefined
       }
       verified

--- a/src/containers/actionBuilder/mintTokens/index.tsx
+++ b/src/containers/actionBuilder/mintTokens/index.tsx
@@ -89,7 +89,9 @@ const MintTokens: React.FC<MintTokensProps> = ({
   })();
 
   const explorerPath =
-    network === 'zksync' || network === 'zksyncSepolia' ? 'address/' : 'token/';
+    network === 'zksyncMainnet' || network === 'zksyncSepolia'
+      ? 'address/'
+      : 'token/';
 
   return (
     <AccordionMethod

--- a/src/containers/actionBuilder/mintTokens/index.tsx
+++ b/src/containers/actionBuilder/mintTokens/index.tsx
@@ -88,6 +88,9 @@ const MintTokens: React.FC<MintTokensProps> = ({
     return result;
   })();
 
+  const explorerPath =
+    network === 'zksync' || network === 'zksyncSepolia' ? 'address/' : 'token/';
+
   return (
     <AccordionMethod
       type="action-builder"
@@ -96,7 +99,7 @@ const MintTokens: React.FC<MintTokensProps> = ({
       smartContractAddress={daoToken?.address}
       blockExplorerLink={
         daoToken?.address
-          ? `${CHAIN_METADATA[network].explorer}token/${daoToken?.address}`
+          ? `${CHAIN_METADATA[network].explorer}${explorerPath}${daoToken?.address}`
           : undefined
       }
       verified

--- a/src/containers/actionBuilder/withdraw/withdrawAction.tsx
+++ b/src/containers/actionBuilder/withdraw/withdrawAction.tsx
@@ -80,6 +80,9 @@ const WithdrawAction: React.FC<WithdrawActionProps> = ({
     return result;
   })();
 
+  const explorerPath =
+    network === 'zksync' || network === 'zksyncSepolia' ? 'address/' : 'token/';
+
   return (
     <AccordionMethod
       verified
@@ -90,7 +93,7 @@ const WithdrawAction: React.FC<WithdrawActionProps> = ({
       smartContractAddress={tokenAddress}
       blockExplorerLink={
         tokenAddress
-          ? `${CHAIN_METADATA[network].explorer}token/${tokenAddress}`
+          ? `${CHAIN_METADATA[network].explorer}${explorerPath}${tokenAddress}`
           : undefined
       }
       methodDescription={t('AddActionModal.withdrawAssetsActionSubtitle')}

--- a/src/containers/actionBuilder/withdraw/withdrawAction.tsx
+++ b/src/containers/actionBuilder/withdraw/withdrawAction.tsx
@@ -81,7 +81,9 @@ const WithdrawAction: React.FC<WithdrawActionProps> = ({
   })();
 
   const explorerPath =
-    network === 'zksync' || network === 'zksyncSepolia' ? 'address/' : 'token/';
+    network === 'zksyncMainnet' || network === 'zksyncSepolia'
+      ? 'address/'
+      : 'token/';
 
   return (
     <AccordionMethod

--- a/src/containers/goLive/community.tsx
+++ b/src/containers/goLive/community.tsx
@@ -190,30 +190,33 @@ const Community: React.FC = () => {
                   </Dd>
                 </Dl>
               )}
-              <Dl>
-                <Dt>{t('labels.review.distribution')}</Dt>
-                <Dd>
-                  {isCustomToken ? (
-                    <Link
-                      label={t('createDAO.review.distributionLink', {
-                        count: wallets?.length,
-                      })}
-                      onClick={() => open('addresses')}
-                    />
-                  ) : (
-                    <Link
-                      label={t('labels.review.distributionLinkLabel')}
-                      href={
-                        CHAIN_METADATA[network].explorer +
-                          '/token/tokenholderchart/' +
-                          tokenAddress?.address || tokenAddress
-                      }
-                      iconRight={IconType.LINK_EXTERNAL}
-                      external
-                    />
-                  )}
-                </Dd>
-              </Dl>
+              {(isCustomToken ||
+                (network !== 'zksync' && network !== 'zksyncSepolia')) && (
+                <Dl>
+                  <Dt>{t('labels.review.distribution')}</Dt>
+                  <Dd>
+                    {isCustomToken ? (
+                      <Link
+                        label={t('createDAO.review.distributionLink', {
+                          count: wallets?.length,
+                        })}
+                        onClick={() => open('addresses')}
+                      />
+                    ) : (
+                      <Link
+                        label={t('labels.review.distributionLinkLabel')}
+                        href={
+                          CHAIN_METADATA[network].explorer +
+                            '/token/tokenholderchart/' +
+                            tokenAddress?.address || tokenAddress
+                        }
+                        iconRight={IconType.LINK_EXTERNAL}
+                        external
+                      />
+                    )}
+                  </Dd>
+                </Dl>
+              )}
               <Dl>
                 <Dt>{t('labels.proposalCreation')}</Dt>
                 <Dd>

--- a/src/containers/goLive/community.tsx
+++ b/src/containers/goLive/community.tsx
@@ -191,7 +191,8 @@ const Community: React.FC = () => {
                 </Dl>
               )}
               {(isCustomToken ||
-                (network !== 'zksync' && network !== 'zksyncSepolia')) && (
+                (network !== 'zksyncMainnet' &&
+                  network !== 'zksyncSepolia')) && (
                 <Dl>
                   <Dt>{t('labels.review.distribution')}</Dt>
                   <Dd>

--- a/src/containers/selectChainForm/index.tsx
+++ b/src/containers/selectChainForm/index.tsx
@@ -106,7 +106,7 @@ type SelectableNetworks = Record<
 const networks: SelectableNetworks = {
   main: {
     cost: ['polygon', 'base', 'arbitrum', 'ethereum', 'zksyncMainnet'],
-    popularity: ['ethereum', 'arbitrum', 'base', 'zksyncMainnet'],
+    popularity: ['ethereum', 'polygon', 'arbitrum', 'base', 'zksyncMainnet'],
     security: ['ethereum', 'base', 'arbitrum', 'polygon', 'zksyncMainnet'],
   },
   test: {

--- a/src/containers/selectChainForm/index.tsx
+++ b/src/containers/selectChainForm/index.tsx
@@ -105,9 +105,9 @@ type SelectableNetworks = Record<
 
 const networks: SelectableNetworks = {
   main: {
-    cost: ['polygon', 'base', 'arbitrum', 'ethereum', 'zksync'],
-    popularity: ['ethereum', 'arbitrum', 'base', 'zksync'],
-    security: ['ethereum', 'base', 'arbitrum', 'polygon', 'zksync'],
+    cost: ['polygon', 'base', 'arbitrum', 'ethereum', 'zksyncMainnet'],
+    popularity: ['ethereum', 'arbitrum', 'base', 'zksyncMainnet'],
+    security: ['ethereum', 'base', 'arbitrum', 'polygon', 'zksyncMainnet'],
   },
   test: {
     cost: ['sepolia', 'zksyncSepolia'],

--- a/src/containers/settings/majorityVoting/index.tsx
+++ b/src/containers/settings/majorityVoting/index.tsx
@@ -94,7 +94,9 @@ const MajorityVotingSettings: React.FC<IPluginSettings> = ({daoDetails}) => {
   };
 
   const explorerPath =
-    network === 'zksync' || network === 'zksyncSepolia' ? 'address/' : 'token/';
+    network === 'zksyncMainnet' || network === 'zksyncSepolia'
+      ? 'address/'
+      : 'token/';
   const daoTokenBlockUrl = `${CHAIN_METADATA[network].explorer}${explorerPath}${daoToken?.address}`;
 
   return (

--- a/src/containers/settings/majorityVoting/index.tsx
+++ b/src/containers/settings/majorityVoting/index.tsx
@@ -93,8 +93,9 @@ const MajorityVotingSettings: React.FC<IPluginSettings> = ({daoDetails}) => {
         : t('labels.no'),
   };
 
-  const daoTokenBlockUrl =
-    CHAIN_METADATA[network].explorer + 'token/' + daoToken?.address;
+  const explorerPath =
+    network === 'zksync' || network === 'zksyncSepolia' ? 'address/' : 'token/';
+  const daoTokenBlockUrl = `${CHAIN_METADATA[network].explorer}${explorerPath}${daoToken?.address}`;
 
   return (
     <>

--- a/src/containers/setupCommunity/addExistingToken.tsx
+++ b/src/containers/setupCommunity/addExistingToken.tsx
@@ -29,8 +29,9 @@ const AddExistingToken: React.FC = () => {
 
   const provider = aragonGateway.getRpcProvider(blockchain.id);
   const nativeCurrency = CHAIN_METADATA[network].nativeCurrency;
-  const tokenAddressBlockExplorerURL =
-    CHAIN_METADATA[network].explorer + 'token/';
+  const explorerPath =
+    network === 'zksync' || network === 'zksyncSepolia' ? 'address/' : 'token/';
+  const tokenAddressBlockExplorerURL = `${CHAIN_METADATA[network].explorer}${explorerPath}`;
 
   // get plugin Client
   const pluginClient = usePluginClient('token-voting.plugin.dao.eth');

--- a/src/containers/setupCommunity/addExistingToken.tsx
+++ b/src/containers/setupCommunity/addExistingToken.tsx
@@ -30,7 +30,9 @@ const AddExistingToken: React.FC = () => {
   const provider = aragonGateway.getRpcProvider(blockchain.id);
   const nativeCurrency = CHAIN_METADATA[network].nativeCurrency;
   const explorerPath =
-    network === 'zksync' || network === 'zksyncSepolia' ? 'address/' : 'token/';
+    network === 'zksyncMainnet' || network === 'zksyncSepolia'
+      ? 'address/'
+      : 'token/';
   const tokenAddressBlockExplorerURL = `${CHAIN_METADATA[network].explorer}${explorerPath}`;
 
   // get plugin Client

--- a/src/hooks/useDaoMembers.tsx
+++ b/src/hooks/useDaoMembers.tsx
@@ -141,7 +141,7 @@ export const useDaoMembers = (
     network === 'arbitrum' ||
     network === 'base' ||
     network === 'zksyncSepolia' ||
-    network === 'zksync'
+    network === 'zksyncMainnet'
   );
 
   const useGraphql =

--- a/src/hooks/useTokenMetadata.tsx
+++ b/src/hooks/useTokenMetadata.tsx
@@ -17,9 +17,13 @@ export const useTokenMetadata = (
 ): HookData<TokenWithMetadata[]> => {
   const {network} = useNetwork();
 
+  const addressZero =
+    network === 'zksyncMainnet' || network === 'zksyncSepolia'
+      ? '0x000000000000000000000000000000000000800a'
+      : constants.AddressZero;
+
   const tokenListParams = assets.map(asset => ({
-    address:
-      asset.type !== TokenType.NATIVE ? asset.address : constants.AddressZero,
+    address: asset.type !== TokenType.NATIVE ? asset.address : addressZero,
     network,
     symbol:
       asset.type !== TokenType.NATIVE

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -168,13 +168,14 @@ export const Community: React.FC = () => {
   )}`;
 
   // Await to load daoToken address to prevent null see all holders button
-  const seeAllHoldersBtn = daoToken?.address
-    ? {
-        label: t('labels.seeAllHolders'),
-        iconLeft: <Icon icon={IconType.LINK_EXTERNAL} />,
-        onClick: navigateToTokenHoldersChart,
-      }
-    : undefined;
+  const seeAllHoldersBtn =
+    daoToken?.address && network !== 'zksync' && network !== 'zksyncSepolia'
+      ? {
+          label: t('labels.seeAllHolders'),
+          iconLeft: <Icon icon={IconType.LINK_EXTERNAL} />,
+          onClick: navigateToTokenHoldersChart,
+        }
+      : undefined;
 
   return (
     <PageWrapper

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -169,7 +169,9 @@ export const Community: React.FC = () => {
 
   // Await to load daoToken address to prevent null see all holders button
   const seeAllHoldersBtn =
-    daoToken?.address && network !== 'zksync' && network !== 'zksyncSepolia'
+    daoToken?.address &&
+    network !== 'zksyncMainnet' &&
+    network !== 'zksyncSepolia'
       ? {
           label: t('labels.seeAllHolders'),
           iconLeft: <Icon icon={IconType.LINK_EXTERNAL} />,

--- a/src/utils/aragonGateway.ts
+++ b/src/utils/aragonGateway.ts
@@ -55,12 +55,12 @@ class AragonGateway {
 
     const {gatewayNetwork} = CHAIN_METADATA[network];
     const gatewayKey =
-      network === 'zksyncSepolia' || network === 'zksync'
+      network === 'zksyncSepolia' || network === 'zksyncMainnet'
         ? import.meta.env.VITE_GATEWAY_RPC_API_KEY_ALCHEMY
         : import.meta.env.VITE_GATEWAY_RPC_API_KEY;
 
     const baseUrl =
-      network === 'zksyncSepolia' || network === 'zksync'
+      network === 'zksyncSepolia' || network === 'zksyncMainnet'
         ? this.baseUrl.replace('app', 'alchemy')
         : this.baseUrl;
 

--- a/src/utils/constants/api.ts
+++ b/src/utils/constants/api.ts
@@ -33,7 +33,7 @@ export const SUBGRAPH_API_URL: SubgraphNetworkUrl = {
     'https://subgraph.satsuma-prod.com/qHR2wGfc5RLi6/aragon/osx-polygon/version/1.4.2/api',
   sepolia:
     'https://subgraph.satsuma-prod.com/qHR2wGfc5RLi6/aragon/osx-sepolia/version/1.4.2/api',
-  zksync:
+  zksyncMainnet:
     'https://subgraph.satsuma-prod.com/qHR2wGfc5RLi6/aragon/osx-zksync-era/version/1.4.3/api',
   zksyncSepolia:
     'https://subgraph.satsuma-prod.com/qHR2wGfc5RLi6/aragon/osx-zksync-era-sepolia/version/1.4.2/api',

--- a/src/utils/constants/chains.ts
+++ b/src/utils/constants/chains.ts
@@ -253,7 +253,7 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
     etherscanApiKey: '',
     covalent: {
       networkId: 'zksync-mainnet',
-      nativeTokenId: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      nativeTokenId: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee800A',
     },
     supportsEns: false,
   },

--- a/src/utils/constants/chains.ts
+++ b/src/utils/constants/chains.ts
@@ -23,7 +23,7 @@ export const NETWORKS_WITH_CUSTOM_REGISTRY: SupportedNetworks[] = [
   'base',
   'polygon',
   'sepolia',
-  'zksync',
+  'zksyncMainnet',
   'zksyncSepolia',
 ];
 
@@ -35,7 +35,7 @@ const SUPPORTED_NETWORKS = [
   'ethereum',
   'polygon',
   'sepolia',
-  'zksync',
+  'zksyncMainnet',
   'zksyncSepolia',
 ] as const;
 
@@ -234,7 +234,7 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
     },
     supportsEns: false,
   },
-  zksync: {
+  zksyncMainnet: {
     id: 324,
     name: i18n.t('explore.modal.filterDAOs.label.zksync'),
     domain: 'L2 Blockchain',
@@ -264,7 +264,7 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
     logo: 'https://static.debank.com/image/chain/logo_url/era/2cfcd0c8436b05d811b03935f6c1d7da.png',
     explorer: 'https://sepolia.explorer.zksync.io/',
     isTestnet: true,
-    mainnet: 'zksync',
+    mainnet: 'zksyncMainnet',
     explorerName: 'zkSync Sepolia Explorer',
     publicRpc: 'https://endpoints.omniatech.io/v1/zksync-era/sepolia/public',
     gatewayNetwork: 'zksync/sepolia',

--- a/src/utils/library.ts
+++ b/src/utils/library.ts
@@ -864,7 +864,7 @@ export const translateToAppNetwork = (
     case SdkSupportedNetworks.ZKSYNC_SEPOLIA:
       return 'zksyncSepolia';
     case SdkSupportedNetworks.ZKSYNC_MAINNET:
-      return 'zksync';
+      return 'zksyncMainnet';
     default:
       return 'unsupported';
   }
@@ -903,7 +903,7 @@ export function translateToNetworkishName(
       return SdkSupportedNetworks.SEPOLIA;
     case 'zksyncSepolia':
       return SdkSupportedNetworks.ZKSYNC_SEPOLIA;
-    case 'zksync':
+    case 'zksyncMainnet':
       return SdkSupportedNetworks.ZKSYNC_MAINNET;
   }
 


### PR DESCRIPTION
## Description

- Fix token links for zksync and zksync sepolia
- Rename zksync to zksyncMainnet to keep it in sync with backend

Task: [APP-3285](https://aragonassociation.atlassian.net/browse/APP-3285)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.


[APP-3285]: https://aragonassociation.atlassian.net/browse/APP-3285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ