### PR TITLE
fix(APP-3261): Truncate long link descriptions dashboard

### DIFF
--- a/src/@aragon/ods-old/components/headers/headerDao.tsx
+++ b/src/@aragon/ods-old/components/headers/headerDao.tsx
@@ -8,7 +8,7 @@ import {Link} from '../link';
 import {ListItemLink} from '../listItem';
 
 const DEFAULT_LINES_SHOWN = 2;
-const DEFAULT_LINKS_SHOWN = 3;
+const DEFAULT_LINKS_SHOWN = 2;
 const DEFAULT_TRANSLATIONS = {
   follow: 'Follow',
   following: 'Following',

--- a/src/@aragon/ods-old/components/headers/headerDao.tsx
+++ b/src/@aragon/ods-old/components/headers/headerDao.tsx
@@ -207,7 +207,12 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
             {links
               ?.slice(0, DEFAULT_LINKS_SHOWN)
               ?.map(({label, href}, index: number) => (
-                <Link {...{label, href}} external key={index} />
+                <Link
+                  className="max-w-44"
+                  {...{label, href}}
+                  external
+                  key={index}
+                />
               ))}
           </LinksWrapper>
           <ActionContainer>

--- a/src/@aragon/ods-old/components/link/link.tsx
+++ b/src/@aragon/ods-old/components/link/link.tsx
@@ -77,7 +77,7 @@ const StyledLink = styled.a.attrs<StyledLinkProps>(({disabled, type}) => {
 `;
 
 const Label = styled.span.attrs({
-  className: 'ft-text-base font-semibold truncate max-w-xs',
+  className: 'ft-text-base font-semibold truncate',
 })``;
 
 const Description = styled.p.attrs({

--- a/src/@aragon/ods-old/components/link/link.tsx
+++ b/src/@aragon/ods-old/components/link/link.tsx
@@ -77,7 +77,7 @@ const StyledLink = styled.a.attrs<StyledLinkProps>(({disabled, type}) => {
 `;
 
 const Label = styled.span.attrs({
-  className: 'ft-text-base font-semibold truncate',
+  className: 'ft-text-base font-semibold truncate max-w-xs',
 })``;
 
 const Description = styled.p.attrs({


### PR DESCRIPTION
Dashboard UI fix, bringing default displayed shown back from 3 to 2, see BEFORE and AFTER in the images below:

BEFORE
![image](https://github.com/aragon/app/assets/16764792/e8bc7152-4bcf-4f1e-a51f-5152ab8284fd)

AFTER
![image](https://github.com/aragon/app/assets/16764792/1b3fdfb1-6475-422c-a4f2-220a6f9c72c0)

Task: [APP-3261](https://aragonassociation.atlassian.net/browse/APP-3261)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.


[APP-3261]: https://aragonassociation.atlassian.net/browse/APP-3261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ