### PR TITLE
fix(APP-3092): Truncate DAO links on settings page

### DIFF
--- a/src/@aragon/ods-old/components/link/link.tsx
+++ b/src/@aragon/ods-old/components/link/link.tsx
@@ -81,7 +81,7 @@ const Label = styled.span.attrs({
 })``;
 
 const Description = styled.p.attrs({
-  className: 'ft-text-sm text-neutral-600 truncate',
+  className: 'ft-text-sm text-neutral-600 truncate max-w-md',
 })``;
 
 const variants = {

--- a/src/@aragon/ods-old/components/link/link.tsx
+++ b/src/@aragon/ods-old/components/link/link.tsx
@@ -81,7 +81,7 @@ const Label = styled.span.attrs({
 })``;
 
 const Description = styled.p.attrs({
-  className: 'ft-text-sm text-neutral-600 truncate max-w-md',
+  className: 'ft-text-sm text-neutral-600 truncate',
 })``;
 
 const variants = {

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -249,7 +249,7 @@ const SettingsCardDao: React.FC<{daoDetails: DaoDetails}> = ({daoDetails}) => {
         <DescriptionPair className="border-none">
           <Term>{t('labels.links')}</Term>
           <Definition>
-            <div className="relative flex xl:max-w-sm flex-col space-y-3">
+            <div className="relative flex flex-col space-y-3 xl:max-w-sm">
               {daoDetails.metadata.links.slice(0, 3).map(({name, url}) => (
                 <Link
                   key={url}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -249,7 +249,7 @@ const SettingsCardDao: React.FC<{daoDetails: DaoDetails}> = ({daoDetails}) => {
         <DescriptionPair className="border-none">
           <Term>{t('labels.links')}</Term>
           <Definition>
-            <div className="relative flex max-w-md flex-col space-y-3">
+            <div className="relative flex xl:max-w-sm flex-col space-y-3">
               {daoDetails.metadata.links.slice(0, 3).map(({name, url}) => (
                 <Link
                   key={url}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -249,7 +249,7 @@ const SettingsCardDao: React.FC<{daoDetails: DaoDetails}> = ({daoDetails}) => {
         <DescriptionPair className="border-none">
           <Term>{t('labels.links')}</Term>
           <Definition>
-            <div className="relative flex flex-col space-y-3">
+            <div className="relative flex max-w-md flex-col space-y-3">
               {daoDetails.metadata.links.slice(0, 3).map(({name, url}) => (
                 <Link
                   key={url}


### PR DESCRIPTION
## Description

Before (find DAO [here](http://localhost:5173/#/daos/polygon/0xbf3460589097676656343a9e44d5a83e54e081ad/settings))
<img width="1604" alt="image" src="https://github.com/aragon/app/assets/16764792/0966d2e0-3608-4eea-a918-9b392d2deee5">

After
<img width="1598" alt="image" src="https://github.com/aragon/app/assets/16764792/eb9a4489-1f0e-4158-acab-a79d3575436e">





Task: [APP-3092](https://aragonassociation.atlassian.net/browse/APP-3092)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.


[APP-3092]: https://aragonassociation.atlassian.net/browse/APP-3092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ