### PR TITLE
fix(APP-2655): Version info in settings for the App is poorly displayed

### DIFF
--- a/src/containers/settings/majorityVoting/index.tsx
+++ b/src/containers/settings/majorityVoting/index.tsx
@@ -112,7 +112,7 @@ const MajorityVotingSettings: React.FC<IPluginSettings> = ({daoDetails}) => {
           <Definition>
             <div className="flex flex-1 flex-wrap items-start justify-between gap-y-2">
               <Link
-                label={`${daoToken.name} ${daoToken.symbol}`}
+                label={`${daoToken.name} (${daoToken.symbol})`}
                 iconRight={IconType.LINK_EXTERNAL}
                 href={daoTokenBlockUrl}
                 description={shortenAddress(daoToken.address)}

--- a/src/containers/settings/versionInfoCard/index.tsx
+++ b/src/containers/settings/versionInfoCard/index.tsx
@@ -71,7 +71,7 @@ export const VersionInfoCard: React.FC<{
       <SettingsCard title={t('setting.versionInfo.title')}>
         <DescriptionPair>
           <Term>{t('setting.versionInfo.labelApp')}</Term>
-          <FlexibleDefinition className="truncate">
+          <FlexibleDefinition className="truncate max-w-60">
             <Link
               label={`Aragon App v${AppVersion}`}
               type="primary"
@@ -82,7 +82,7 @@ export const VersionInfoCard: React.FC<{
         </DescriptionPair>
         <DescriptionPair>
           <Term>{t('setting.versionInfo.labelOs')}</Term>
-          <FlexibleDefinition className="truncate">
+          <FlexibleDefinition className="truncate max-w-60">
             <Link
               label={
                 !isLoading ? `Aragon OSx v${versions?.join('.')}` : 'Loading...'
@@ -97,7 +97,7 @@ export const VersionInfoCard: React.FC<{
 
         <DescriptionPair className="border-none">
           <Term>{t('setting.versionInfo.labelGovernance')}</Term>
-          <FlexibleDefinition className="truncate">
+          <FlexibleDefinition className="truncate max-w-60">
             <Link
               label={`${pluginName} v${pluginVersion}`}
               description={shortenAddress(pluginAddress)}

--- a/src/containers/settings/versionInfoCard/index.tsx
+++ b/src/containers/settings/versionInfoCard/index.tsx
@@ -71,7 +71,7 @@ export const VersionInfoCard: React.FC<{
       <SettingsCard title={t('setting.versionInfo.title')}>
         <DescriptionPair>
           <Term>{t('setting.versionInfo.labelApp')}</Term>
-          <FlexibleDefinition className="truncate max-w-60">
+          <FlexibleDefinition className="max-w-60 truncate">
             <Link
               label={`Aragon App v${AppVersion}`}
               type="primary"
@@ -82,7 +82,7 @@ export const VersionInfoCard: React.FC<{
         </DescriptionPair>
         <DescriptionPair>
           <Term>{t('setting.versionInfo.labelOs')}</Term>
-          <FlexibleDefinition className="truncate max-w-60">
+          <FlexibleDefinition className="max-w-60 truncate">
             <Link
               label={
                 !isLoading ? `Aragon OSx v${versions?.join('.')}` : 'Loading...'
@@ -97,7 +97,7 @@ export const VersionInfoCard: React.FC<{
 
         <DescriptionPair className="border-none">
           <Term>{t('setting.versionInfo.labelGovernance')}</Term>
-          <FlexibleDefinition className="truncate max-w-60">
+          <FlexibleDefinition className="max-w-60 truncate">
             <Link
               label={`${pluginName} v${pluginVersion}`}
               description={shortenAddress(pluginAddress)}

--- a/src/containers/settings/versionInfoCard/index.tsx
+++ b/src/containers/settings/versionInfoCard/index.tsx
@@ -71,7 +71,7 @@ export const VersionInfoCard: React.FC<{
       <SettingsCard title={t('setting.versionInfo.title')}>
         <DescriptionPair>
           <Term>{t('setting.versionInfo.labelApp')}</Term>
-          <FlexibleDefinition className="max-w-60 truncate">
+          <FlexibleDefinition className="xl:max-w-60 truncate">
             <Link
               label={`Aragon App v${AppVersion}`}
               type="primary"
@@ -82,7 +82,7 @@ export const VersionInfoCard: React.FC<{
         </DescriptionPair>
         <DescriptionPair>
           <Term>{t('setting.versionInfo.labelOs')}</Term>
-          <FlexibleDefinition className="max-w-60 truncate">
+          <FlexibleDefinition className="xl:max-w-60 truncate">
             <Link
               label={
                 !isLoading ? `Aragon OSx v${versions?.join('.')}` : 'Loading...'
@@ -97,7 +97,7 @@ export const VersionInfoCard: React.FC<{
 
         <DescriptionPair className="border-none">
           <Term>{t('setting.versionInfo.labelGovernance')}</Term>
-          <FlexibleDefinition className="max-w-60 truncate">
+          <FlexibleDefinition className="xl:max-w-60 truncate">
             <Link
               label={`${pluginName} v${pluginVersion}`}
               description={shortenAddress(pluginAddress)}

--- a/src/containers/settings/versionInfoCard/index.tsx
+++ b/src/containers/settings/versionInfoCard/index.tsx
@@ -71,7 +71,7 @@ export const VersionInfoCard: React.FC<{
       <SettingsCard title={t('setting.versionInfo.title')}>
         <DescriptionPair>
           <Term>{t('setting.versionInfo.labelApp')}</Term>
-          <FlexibleDefinition className="xl:max-w-60 truncate">
+          <FlexibleDefinition className="truncate xl:max-w-60">
             <Link
               label={`Aragon App v${AppVersion}`}
               type="primary"
@@ -82,7 +82,7 @@ export const VersionInfoCard: React.FC<{
         </DescriptionPair>
         <DescriptionPair>
           <Term>{t('setting.versionInfo.labelOs')}</Term>
-          <FlexibleDefinition className="xl:max-w-60 truncate">
+          <FlexibleDefinition className="truncate xl:max-w-60">
             <Link
               label={
                 !isLoading ? `Aragon OSx v${versions?.join('.')}` : 'Loading...'
@@ -97,7 +97,7 @@ export const VersionInfoCard: React.FC<{
 
         <DescriptionPair className="border-none">
           <Term>{t('setting.versionInfo.labelGovernance')}</Term>
-          <FlexibleDefinition className="xl:max-w-60 truncate">
+          <FlexibleDefinition className="truncate xl:max-w-60">
             <Link
               label={`${pluginName} v${pluginVersion}`}
               description={shortenAddress(pluginAddress)}


### PR DESCRIPTION
## Description

Fix for poorly displayed App name (see Before and After)
Also added fix for tiny UI issue (which has annoyed me for some time 😄 ), no brackets around the DAO Token Symbol (see Image below).

Before
<img width="452" alt="image" src="https://github.com/aragon/app/assets/16764792/edc3d542-754e-4926-bb00-cf17853f9b97">

After
<img width="452" alt="image" src="https://github.com/aragon/app/assets/16764792/b5cef7f6-65b5-4044-b3fa-c9ec135ac6df">

Image
<img width="802" alt="image" src="https://github.com/aragon/app/assets/16764792/da39b14b-ddb4-4c50-a8ba-1144614419e0">


Task: [APP-2655](https://aragonassociation.atlassian.net/browse/APP-2655)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.


[APP-2655]: https://aragonassociation.atlassian.net/browse/APP-2655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ