### PR TITLE
fix: Update @aragon/sdk to 1.26.0 to remove dependency to old IPFS infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,7 @@ VITE_BASESCAN_API_KEY=YOUR_VALUE_HERE
 
 # # Aragon gateway API key used for the RPC service
 VITE_GATEWAY_RPC_API_KEY=YOUR_VALUE_HERE
-
-# Aragon gateway API key used for the IPFS service
-VITE_GATEWAY_IPFS_API_KEY=YOUR_VALUE_HERE
+VITE_GATEWAY_RPC_API_KEY_ALCHEMY=YOUR_VALUE_HERE
 
 # WalletConnect - connection layer between DApp and user crypto wallet https://cloud.walletconnect.com/sign-in
 VITE_WALLET_CONNECT_PROJECT_ID=YOUR_VALUE_HERE
@@ -24,3 +22,12 @@ VITE_COVALENT_API_KEY=YOUR_VALUE_HERE
 
 # Sentry - Error & Performance Monitoring https://sentry.io/issues/
 VITE_SENTRY_DNS=YOUR_VALUE_HERE
+
+# Synpress - Keys needed ro run Playwright E2E tests
+METAMASK_SEED_PHRASE=YOUR_VALUE_HERE
+METAMASK_PASSWORD=YOUR_VALUE_HERE
+
+# IPFS
+VITE_PINATA_CID_VERSION=YOUR_VALUE_HERE
+VITE_PINATA_GATEWAY=YOUR_VALUE_HERE
+VITE_PINATA_JWT_API_KEY=YOUR_VALUE_HERE

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@apollo/client": "^3.5.8",
     "@aragon/ods": "^1.0.20",
     "@aragon/osx-commons-configs": "^0.6.0",
-    "@aragon/sdk-client": "^1.25.1",
+    "@aragon/sdk-client": "^1.26.0",
     "@aragon/sdk-client-common": "^1.17.0",
     "@playwright/test": "^1.42.1",
     "@radix-ui/react-accordion": "^1.1.2",

--- a/src/hooks/useClient.tsx
+++ b/src/hooks/useClient.tsx
@@ -59,12 +59,6 @@ export const UseClientProvider: React.FC<{children: ReactNode}> = ({
       return;
     }
 
-    const ipfsNodes = [
-      {
-        url: aragonGateway.buildIpfsUrl(network)!,
-        headers: {'X-API-KEY': import.meta.env.VITE_GATEWAY_IPFS_API_KEY},
-      },
-    ];
     const daoFactoryAddress =
       getLatestNetworkDeployment(translatedNetwork)?.DAOFactory.address ?? '';
 
@@ -73,7 +67,7 @@ export const UseClientProvider: React.FC<{children: ReactNode}> = ({
       network: translatedNetwork,
       signer: signer ?? undefined,
       web3Providers: aragonGateway.buildRpcUrl(network)!,
-      ipfsNodes,
+      ipfsNodes: [],
       graphqlNodes: [{url: SUBGRAPH_API_URL[network]!}],
     };
 

--- a/src/services/aragon-sdk/queries/use-plugin-versions.ts
+++ b/src/services/aragon-sdk/queries/use-plugin-versions.ts
@@ -37,7 +37,7 @@ async function fetchPluginVersions(
     'fetchAvailablePlugins: client is not defined'
   );
 
-  const data = await client.methods.getPlugin(pluginRepoAddress);
+  const data = await client.methods.getPlugin(pluginRepoAddress, false);
   return data;
 }
 

--- a/src/utils/aragonGateway.ts
+++ b/src/utils/aragonGateway.ts
@@ -68,22 +68,6 @@ class AragonGateway {
     return rpcUrl;
   };
 
-  buildIpfsUrl = (
-    chainIdOrNetwork: number | SupportedNetworks
-  ): string | null => {
-    const network = this.parseNetwork(chainIdOrNetwork);
-
-    if (network == null || network === 'unsupported') {
-      return null;
-    }
-
-    const {isTestnet} = CHAIN_METADATA[network];
-    const ipfsEnv = isTestnet ? 'test' : 'prod';
-    const ipfsUrl = `${this.baseUrl}/v${this.ipfsVersion}/ipfs/${ipfsEnv}/api/v0`;
-
-    return ipfsUrl;
-  };
-
   private parseNetwork = (
     chainIdOrNetwork: number | SupportedNetworks
   ): SupportedNetworks | undefined => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -171,10 +171,10 @@
     graphql-request "^4.3.0"
     yup "^1.2.0"
 
-"@aragon/sdk-client@^1.25.1":
-  version "1.25.1"
-  resolved "https://registry.yarnpkg.com/@aragon/sdk-client/-/sdk-client-1.25.1.tgz#d026124a90719ef0b356856c5983d455660406fe"
-  integrity sha512-3JcMZZaJwdhfovYvD8BEt44aNAksCcqnpMJEDg3T8WTcsv2wrzS94JmgUd+JH6YzT4ARz0YX88kLctPCwAL+vA==
+"@aragon/sdk-client@^1.26.0":
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/@aragon/sdk-client/-/sdk-client-1.26.0.tgz#db80f1b82a5ac974a0c0c4d9c4e218dc60a4600e"
+  integrity sha512-yGxPKC2xmT3WeGAf3ryoEm1Mq457Mk/FxfjjTN8bkNgJjIND1H3zaqLexmCnW1ldbo05SvOyNUztnOvUdhYv7A==
   dependencies:
     "@aragon/osx-commons-configs" "^0.6.0"
     "@aragon/osx-ethers" "1.3.0"
@@ -10911,16 +10911,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10991,14 +10982,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11910,7 +11894,7 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11923,15 +11907,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -11975,19 +11950,14 @@ ws@8.13.0:
   integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
 
 ws@^7.5.1:
-  version "7.5.9"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
-  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+  version "7.5.10"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
+  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
-ws@^8.11.0:
-  version "8.14.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.2.tgz#6c249a806eb2db7a20d26d51e7709eab7b2e6c7f"
-  integrity sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==
-
-ws@^8.13.0:
-  version "8.16.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
-  integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
+ws@^8.11.0, ws@^8.13.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 ws@~8.11.0:
   version "8.11.0"


### PR DESCRIPTION
## Description

- Update @aragon/sdk dependency to 1.26.0 to remove dependency to old IPFS infrastructure

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.
