### PR TITLE
hotfix: APP-3485 - Arbitrum logo disappeared from App

### DIFF
--- a/src/utils/constants/chains.ts
+++ b/src/utils/constants/chains.ts
@@ -164,7 +164,7 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
     id: 42161,
     name: i18n.t('explore.modal.filterDAOs.label.arbitrum'),
     domain: 'L2 Blockchain',
-    logo: 'https://bridge.arbitrum.io/logo.png',
+    logo: 'https://docs.arbitrum.io/img/logo.svg',
     explorer: 'https://arbiscan.io/',
     explorerName: 'Arbiscan',
     isTestnet: false,


### PR DESCRIPTION
## Description

Replaced the broken logo URL:

Before
<img width="1545" alt="image" src="https://github.com/user-attachments/assets/ede945df-9b11-4d20-a7f1-027f0909f6c2">


After
<img width="1550" alt="image" src="https://github.com/user-attachments/assets/72b1cfdd-1824-4fb8-b69d-4fe299f97471">


Task: [APP-3485](https://aragonassociation.atlassian.net/browse/APP-3485)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.


[APP-3485]: https://aragonassociation.atlassian.net/browse/APP-3485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ