### PR TITLE
fix(APP-3595): Fix error thrown on DAO creation when removing empty link

### DIFF
--- a/src/containers/goLive/daoMetadata.tsx
+++ b/src/containers/goLive/daoMetadata.tsx
@@ -58,7 +58,7 @@ const DaoMetadata: React.FC = () => {
             <Dt>{t('labels.summary')}</Dt>
             <Dd>{daoSummary}</Dd>
           </Dl>
-          {links[0].url !== '' && (
+          {links && links.length > 0 && links[0].url && (
             <Dl>
               <Dt>{t('labels.links')}</Dt>
               <Dd>


### PR DESCRIPTION
## Description

Added checks whether `link` is truthy and whether link array is not empty. Now able to create DAO's when removing link from DAO creation, see for example[ this one](http://localhost:5173/#/daos/sepolia/0x6045bb5761c3c91ccabf67bb408c058f4266d252/dashboard
).

Also tested whether can add a DAO link with Edit Settings proposal, this is (still) possible, see [here](http://localhost:5173/#/daos/sepolia/0x6045bb5761c3c91ccabf67bb408c058f4266d252/governance/proposals/0xd28f949bd972d0449437133a2b5248378ed9b013_0x0).

Last tested whether there is a bug when removing empty link from proposals: the same bug does not appear here.



Task: [APP-3595](https://aragonassociation.atlassian.net/browse/APP-3595)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.


[APP-3595]: https://aragonassociation.atlassian.net/browse/APP-3595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ