### PR TITLE
chore(APP-4262): Migrate to Etherscan API to v2

### DIFF
--- a/src/hooks/useValidateContract.tsx
+++ b/src/hooks/useValidateContract.tsx
@@ -16,8 +16,10 @@ const useValidateContractEtherscan = (
   network: SupportedNetworks,
   verificationState: TransactionState
 ) => {
+  const api = CHAIN_METADATA[network]?.etherscanApi;
+  const apiKey = CHAIN_METADATA[network]?.etherscanApiKey;
   const chainId = CHAIN_METADATA[network]?.id;
-  const url = `${CHAIN_METADATA[network].etherscanApi}?chainid=${chainId}&module=contract&action=getsourcecode&address=${contractAddress}&apikey=${CHAIN_METADATA[network].etherscanApiKey}`;
+  const url = `${api}?chainid=${chainId}&module=contract&action=getsourcecode&address=${contractAddress}&apikey=${apiKey}`;
 
   return useQuery({
     queryKey: ['verifyContractEtherscan', contractAddress, network],
@@ -27,7 +29,7 @@ const useValidateContractEtherscan = (
         return res.json().then(data => {
           if (data.result[0].Proxy === '1') {
             return fetch(
-              `${CHAIN_METADATA[network].etherscanApi}?chainid=${chainId}&module=contract&action=getsourcecode&address=${data.result[0].Implementation}&apikey=${CHAIN_METADATA[network].etherscanApiKey}`
+              `${api}?chainid=${chainId}&module=contract&action=getsourcecode&address=${data.result[0].Implementation}&apikey=${apiKey}`
             ).then(async r => {
               data.result[0].proxyImplementation = await r.json();
               return data;
@@ -56,13 +58,14 @@ const useValidateContractSourcify = (
   network: SupportedNetworks,
   verificationState: TransactionState
 ) => {
+  const chainId = CHAIN_METADATA[network]?.id;
   return useQueries({
     queries: ['full_match', 'partial_match'].map(type => {
       return {
         queryKey: [`verifycontract${type}Sourcify`, contractAddress, network],
         queryFn: () => {
           return fetch(
-            `https://repo.sourcify.dev/contracts/${type}/${CHAIN_METADATA[network].id}/${contractAddress}/metadata.json`
+            `https://repo.sourcify.dev/contracts/${type}/${chainId}/${contractAddress}/metadata.json`
           ).then(res => res.json());
         },
         enabled: verificationState === TransactionState.LOADING && !!network,

--- a/src/hooks/useValidateContract.tsx
+++ b/src/hooks/useValidateContract.tsx
@@ -16,7 +16,8 @@ const useValidateContractEtherscan = (
   network: SupportedNetworks,
   verificationState: TransactionState
 ) => {
-  const url = `${CHAIN_METADATA[network].etherscanApi}?module=contract&action=getsourcecode&address=${contractAddress}&apikey=${CHAIN_METADATA[network].etherscanApiKey}`;
+  const chainId = CHAIN_METADATA[network]?.id;
+  const url = `${CHAIN_METADATA[network].etherscanApi}?chainid=${chainId}&module=contract&action=getsourcecode&address=${contractAddress}&apikey=${CHAIN_METADATA[network].etherscanApiKey}`;
 
   return useQuery({
     queryKey: ['verifyContractEtherscan', contractAddress, network],
@@ -26,7 +27,7 @@ const useValidateContractEtherscan = (
         return res.json().then(data => {
           if (data.result[0].Proxy === '1') {
             return fetch(
-              `${CHAIN_METADATA[network].etherscanApi}?module=contract&action=getsourcecode&address=${data.result[0].Implementation}&apikey=${CHAIN_METADATA[network].etherscanApiKey}`
+              `${CHAIN_METADATA[network].etherscanApi}?chainid=${chainId}&module=contract&action=getsourcecode&address=${data.result[0].Implementation}&apikey=${CHAIN_METADATA[network].etherscanApiKey}`
             ).then(async r => {
               data.result[0].proxyImplementation = await r.json();
               return data;

--- a/src/services/etherscanAPI.ts
+++ b/src/services/etherscanAPI.ts
@@ -14,7 +14,8 @@ export const getEtherscanVerifiedContract = (
       fetchVerifiedContract(
         etherscanApi,
         etherscanApiKey ?? '',
-        contractAddress
+        contractAddress,
+        network
       ),
   });
 };
@@ -22,9 +23,10 @@ export const getEtherscanVerifiedContract = (
 const fetchVerifiedContract = async (
   blockApi: string,
   blockApiKey: string,
-  contractAddress: string
+  contractAddress: string,
+  network: SupportedNetworks
 ) => {
-  const url = getSourceCodeURL(blockApi, blockApiKey, contractAddress);
+  const url = getSourceCodeURL(blockApi, blockApiKey, contractAddress, network);
 
   let response = await fetch(url);
   const data = await response.json();
@@ -36,7 +38,8 @@ const fetchVerifiedContract = async (
     const implementationContractURl = getSourceCodeURL(
       blockApi,
       blockApiKey,
-      implementationContractAddress
+      implementationContractAddress,
+      network
     );
 
     response = await fetch(implementationContractURl);
@@ -50,6 +53,12 @@ const fetchVerifiedContract = async (
   }
 };
 
-function getSourceCodeURL(blockApi: string, apiKey: string, contract: string) {
-  return `${blockApi}?module=contract&action=getsourcecode&address=${contract}&apikey=${apiKey}`;
+function getSourceCodeURL(
+  blockApi: string,
+  apiKey: string,
+  contract: string,
+  network: SupportedNetworks
+) {
+  const chainId = CHAIN_METADATA[network]?.id;
+  return `${blockApi}?chainid=${chainId}&module=contract&action=getsourcecode&address=${contract}&apikey=${apiKey}`;
 }

--- a/src/utils/constants/chains.ts
+++ b/src/utils/constants/chains.ts
@@ -117,7 +117,7 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
       symbol: 'ETH',
       decimals: 18,
     },
-    etherscanApi: 'https://api.etherscan.io/v2/api?chainid=1',
+    etherscanApi: 'https://api.etherscan.io/v2/api',
     etherscanApiKey: etherscanApiKey,
     coingecko: {
       networkId: 'ethereum',
@@ -144,7 +144,7 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
       symbol: 'MATIC',
       decimals: 18,
     },
-    etherscanApi: 'https://api.etherscan.io/v2/api?chainid=137',
+    etherscanApi: 'https://api.etherscan.io/v2/api',
     etherscanApiKey: etherscanApiKey,
     coingecko: {
       networkId: 'polygon-pos',
@@ -172,7 +172,7 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
       symbol: 'ETH',
       decimals: 18,
     },
-    etherscanApi: 'https://api.etherscan.io/v2/api?chainid=42161',
+    etherscanApi: 'https://api.etherscan.io/v2/api',
     etherscanApiKey: etherscanApiKey,
     coingecko: {
       networkId: 'arbitrum-one',
@@ -199,7 +199,7 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
       symbol: 'ETH',
       decimals: 18,
     },
-    etherscanApi: 'https://api.etherscan.io/v2/api?chainid=8453',
+    etherscanApi: 'https://api.etherscan.io/v2/api',
     etherscanApiKey: etherscanApiKey,
     covalent: {
       networkId: 'base-mainnet',
@@ -223,7 +223,7 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
       symbol: 'ETH',
       decimals: 18,
     },
-    etherscanApi: 'https://api.etherscan.io/v2/api?chainid=11155111',
+    etherscanApi: 'https://api.etherscan.io/v2/api',
     etherscanApiKey: etherscanApiKey,
     covalent: {
       networkId: 'eth-sepolia',
@@ -246,7 +246,7 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
       symbol: 'ETH',
       decimals: 18,
     },
-    etherscanApi: 'https://api.etherscan.io/v2/api?chainid=324',
+    etherscanApi: 'https://api.etherscan.io/v2/api',
     etherscanApiKey: etherscanApiKey,
     covalent: {
       networkId: 'zksync-mainnet',
@@ -270,7 +270,7 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
       symbol: 'ETH',
       decimals: 18,
     },
-    etherscanApi: 'https://api.etherscan.io/v2/api?chainid=300',
+    etherscanApi: 'https://api.etherscan.io/v2/api',
     etherscanApiKey: etherscanApiKey,
     covalent: {
       networkId: 'zksync-sepolia-testnet',

--- a/src/utils/constants/chains.ts
+++ b/src/utils/constants/chains.ts
@@ -100,9 +100,6 @@ export type ChainData = {
 };
 
 const etherscanApiKey = import.meta.env.VITE_ETHERSCAN_API_KEY;
-const polygonscanApiKey = import.meta.env.VITE_POLYGONSCAN_API_KEY;
-const arbiscanApiKey = import.meta.env.VITE_ARBISCAN_API_KEY;
-const basecanApiKey = import.meta.env.VITE_BASESCAN_API_KEY;
 
 export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
   ethereum: {
@@ -120,7 +117,7 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
       symbol: 'ETH',
       decimals: 18,
     },
-    etherscanApi: 'https://api.etherscan.io/api',
+    etherscanApi: 'https://api.etherscan.io/v2/api?chainid=1',
     etherscanApiKey: etherscanApiKey,
     coingecko: {
       networkId: 'ethereum',
@@ -147,8 +144,8 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
       symbol: 'MATIC',
       decimals: 18,
     },
-    etherscanApi: 'https://api.polygonscan.com/api',
-    etherscanApiKey: polygonscanApiKey,
+    etherscanApi: 'https://api.etherscan.io/v2/api?chainid=137',
+    etherscanApiKey: etherscanApiKey,
     coingecko: {
       networkId: 'polygon-pos',
       nativeTokenId: 'matic-network',
@@ -175,8 +172,8 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
       symbol: 'ETH',
       decimals: 18,
     },
-    etherscanApi: 'https://api.arbiscan.io/api',
-    etherscanApiKey: arbiscanApiKey,
+    etherscanApi: 'https://api.etherscan.io/v2/api?chainid=42161',
+    etherscanApiKey: etherscanApiKey,
     coingecko: {
       networkId: 'arbitrum-one',
       nativeTokenId: 'ethereum',
@@ -202,8 +199,8 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
       symbol: 'ETH',
       decimals: 18,
     },
-    etherscanApi: 'https://api.basescan.org/api',
-    etherscanApiKey: basecanApiKey,
+    etherscanApi: 'https://api.etherscan.io/v2/api?chainid=8453',
+    etherscanApiKey: etherscanApiKey,
     covalent: {
       networkId: 'base-mainnet',
       nativeTokenId: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
@@ -226,7 +223,7 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
       symbol: 'ETH',
       decimals: 18,
     },
-    etherscanApi: 'https://api-sepolia.etherscan.io/api',
+    etherscanApi: 'https://api.etherscan.io/v2/api?chainid=11155111',
     etherscanApiKey: etherscanApiKey,
     covalent: {
       networkId: 'eth-sepolia',
@@ -249,8 +246,8 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
       symbol: 'ETH',
       decimals: 18,
     },
-    etherscanApi: 'https://block-explorer-api.mainnet.zksync.io/api',
-    etherscanApiKey: '',
+    etherscanApi: 'https://api.etherscan.io/v2/api?chainid=324',
+    etherscanApiKey: etherscanApiKey,
     covalent: {
       networkId: 'zksync-mainnet',
       nativeTokenId: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee800A',
@@ -273,8 +270,8 @@ export const CHAIN_METADATA: Record<SupportedNetworks, ChainData> = {
       symbol: 'ETH',
       decimals: 18,
     },
-    etherscanApi: 'https://block-explorer-api.sepolia.zksync.dev/api',
-    etherscanApiKey: '',
+    etherscanApi: 'https://api.etherscan.io/v2/api?chainid=300',
+    etherscanApiKey: etherscanApiKey,
     covalent: {
       networkId: 'zksync-sepolia-testnet',
       nativeTokenId: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee800A',


### PR DESCRIPTION
## Description

Migrate to Etherscan API to v2

Task: [APP-4262](https://aragonassociation.atlassian.net/browse/APP-4262)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have tested my code on the test network.


[APP-4262]: https://aragonassociation.atlassian.net/browse/APP-4262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ